### PR TITLE
fix(lib): update getSlug

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -22,6 +22,8 @@ module.exports = {
         "rust",
         // Docs-related changes
         "docs",
+        // Library-related changes
+        "lib",
       ],
     ],
     "scope-empty": [1, "never"],

--- a/packages/libs/getSlug.ts
+++ b/packages/libs/getSlug.ts
@@ -1,4 +1,11 @@
-export const getSlug = (name?: string) => {
+/**
+ * Get slug from string
+ * Example: "Hello World!" => "hello-world", "Hello World 😊" => "hello-world"
+ *
+ * @param name
+ * @returns slug
+ */
+export const getSlug = (name?: string): string => {
   if (!name) {
     return "";
   }
@@ -12,6 +19,9 @@ export const getSlug = (name?: string) => {
         "",
       )
       .replace(/ /g, "-")
+      // Replace "-" at the beginning and end of the string, e.g. "-slug-" => "slug"
+      .replace(/^-+/, "")
+      .replace(/-+$/, "")
   );
 };
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a bug in the getSlug function by ensuring hyphens at the beginning and end of the string are removed. It also enhances the function with JSDoc comments for better documentation and updates the commit lint configuration to include 'lib' as a valid scope.

* **Bug Fixes**:
    - Fixed issue in getSlug function where hyphens at the beginning and end of the string were not removed.
* **Enhancements**:
    - Added JSDoc comments to the getSlug function for better documentation and clarity.
* **Build**:
    - Updated .commitlintrc.js to include 'lib' as a valid commit scope.

<!-- Generated by sourcery-ai[bot]: end summary -->