### PR TITLE
feat: post snippet

### DIFF
--- a/apps/blog/_posts/2015/04/tim-hieu-ve-giay-phep-gnu.md
+++ b/apps/blog/_posts/2015/04/tim-hieu-ve-giay-phep-gnu.md
@@ -10,6 +10,18 @@ thumbnail: https://4.bp.blogspot.com/-LlEOmpqG7Dg/VSi4YDNEClI/AAAAAAAACPU/VZ-xgK
 slug: /2015/04/tim-hieu-ve-giay-phep-gnu.html
 category: News
 description: GNU (GNU General Public License) là giấy phép phần mềm tự do phổ biến nhất, ban đầu được thiết kê bới Richard Stallman, dành cho dự án GNU. Phiên bản 2 của giấy phép này được phát hành năm 1991, và phiên bản 3, phiên bản hiện tại, được phát hành năm 2007.
+snippet: |
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4044047400859099"
+     crossorigin="anonymous"></script>
+  <ins class="adsbygoogle"
+      style="display:block; text-align:center;"
+      data-ad-layout="in-article"
+      data-ad-format="fluid"
+      data-ad-client="ca-pub-4044047400859099"
+      data-ad-slot="4768236865"></ins>
+  <script>
+      (adsbygoogle = window.adsbygoogle || []).push({});
+  </script>
 ---
 
 GNU (GNU General Public License) là giấy phép phần mềm tự do phổ biến nhất, ban đầu được thiết kê bới Richard Stallman, dành cho dự án GNU. Phiên bản 2 của giấy phép này được phát hành năm 1991, và phiên bản 3, phiên bản hiện tại, được phát hành năm 2007.

--- a/apps/blog/app/[year]/[month]/[slug]/content/content.tsx
+++ b/apps/blog/app/[year]/[month]/[slug]/content/content.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment -- have no idea to fix the line 37 */
+
 import type { Post } from '@duyet/interfaces'
 import { getPostBySlug } from '@duyet/libs/getPost'
 import { markdownToHtml } from '@duyet/libs/markdownToHtml'
@@ -5,6 +7,7 @@ import { cn } from '@duyet/libs/utils'
 
 import 'katex/dist/contrib/mhchem.min.js'
 import 'katex/dist/katex.min.css'
+import { Snippet } from './snippet'
 
 export default function Content({ post }: { post: Post }) {
   return (
@@ -30,6 +33,8 @@ export default function Content({ post }: { post: Post }) {
         )}
         dangerouslySetInnerHTML={{ __html: post.content || 'No content' }}
       />
+
+      <Snippet html={post.snippet || ''} />
     </>
   )
 }
@@ -45,6 +50,7 @@ export async function getPost(slug: string[]) {
     'category_slug',
     'tags',
     'series',
+    'snippet',
   ])
   const content = await markdownToHtml(post.content || 'Error')
 

--- a/apps/blog/app/[year]/[month]/[slug]/content/snippet.tsx
+++ b/apps/blog/app/[year]/[month]/[slug]/content/snippet.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@duyet/libs'
+
+export function Snippet({
+  html,
+  className,
+}: {
+  html: string
+  className?: string
+}) {
+  if (!html) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(className)}
+      dangerouslySetInnerHTML={{ __html: html }}
+      suppressHydrationWarning
+    />
+  )
+}

--- a/apps/blog/next.redirects.js
+++ b/apps/blog/next.redirects.js
@@ -103,7 +103,6 @@ const redirects = async () => [
     destination: '/2015/04/mongo-web-query.html',
     permanent: true,
   },
-
 ]
 
 module.exports = redirects

--- a/packages/interfaces/src/post.ts
+++ b/packages/interfaces/src/post.ts
@@ -12,6 +12,7 @@ export type Post = {
   excerpt?: string;
   edit_url?: string;
   series?: string;
+  snippet?: string;
   [key: string]: any;
 };
 

--- a/packages/libs/getPost.ts
+++ b/packages/libs/getPost.ts
@@ -63,6 +63,7 @@ export function getPostByPath(fullPath: string, fields: string[] = []): Post {
     category_slug: 'unknown',
     tags: [],
     tags_slug: [],
+    snippet: '',
   }
 
   // Ensure only the minimal needed data is exposed
@@ -114,6 +115,10 @@ export function getPostByPath(fullPath: string, fields: string[] = []): Post {
     if (field === 'excerpt') {
       post[field] =
         data.description || content.split(' ').slice(0, 20).join(' ') + '...'
+    }
+
+    if (field === 'snippet') {
+      post['snippet'] = data.snippet || ''
     }
 
     if (typeof data[field] !== 'undefined') {


### PR DESCRIPTION
## Summary by Sourcery

Add support for HTML snippets in blog posts, enabling the integration of elements like ads. Update the content component to render these snippets using a new Snippet component.

New Features:
- Introduce a new 'snippet' feature in blog posts, allowing the inclusion of HTML snippets such as ads within the post content.

Enhancements:
- Enhance the blog post content component to render the new 'snippet' field using a dedicated Snippet component.