### PR TITLE
fix(blog): remove link from year display in YearPost component, mark Spark GitHub Actions post as featured

### DIFF
--- a/apps/blog/_posts/2023/05/spark-github-actions.md
+++ b/apps/blog/_posts/2023/05/spark-github-actions.md
@@ -1,6 +1,7 @@
 ---
 title: Running Spark in GitHub Actions
 date: '2023-05-07'
+featured: true
 author: Duyet
 category: Data
 tags:

--- a/apps/blog/components/year-post.tsx
+++ b/apps/blog/components/year-post.tsx
@@ -26,9 +26,7 @@ export function YearPost({ year, posts, className }: YearPostProps) {
           'md:mb-10 md:text-8xl md:font-black',
         )}
       >
-        <Link as={`/${year}`} href="/[year]">
-          {year}
-        </Link>
+        {year}
       </h1>
 
       <div className="flex flex-col gap-3">


### PR DESCRIPTION
## Summary by Sourcery

Fix the YearPost component by removing the link from the year display and enhance the blog by marking the Spark GitHub Actions post as featured.

Bug Fixes:
- Remove the link from the year display in the YearPost component to prevent incorrect navigation.

Enhancements:
- Mark the 'Running Spark in GitHub Actions' post as featured to highlight its importance.