### PR TITLE
fix: set dynamic rendering to force-static for multiple pages

### DIFF
--- a/apps/blog/app/category/[category]/page.tsx
+++ b/apps/blog/app/category/[category]/page.tsx
@@ -2,6 +2,8 @@ import Feed from '@duyet/components/Feed'
 import { getAllCategories, getPostsByCategory } from '@duyet/libs/getPost'
 import { getSlug } from '@duyet/libs/getSlug'
 
+export const dynamic = 'force-static'
+
 interface Params {
   category: string
 }

--- a/apps/blog/app/rss.xml/route.ts
+++ b/apps/blog/app/rss.xml/route.ts
@@ -3,6 +3,7 @@ import { getAllPosts } from '@duyet/libs/getPost'
 import RSS from 'rss'
 
 const siteUrl = 'https://blog.duyet.net'
+export const dynamic = 'force-static'
 
 export async function GET() {
   const posts = getAllPosts(['slug', 'title', 'excerpt', 'date'], 100000)

--- a/apps/blog/app/series/[slug]/page.tsx
+++ b/apps/blog/app/series/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { getSeries } from '@duyet/libs/getSeries'
 import { notFound } from 'next/navigation'
 import { SeriesBox } from '../../../components/series'
 
+export const dynamic = 'force-static'
+
 interface PageProps {
   params: Promise<{
     slug: string

--- a/apps/blog/app/tag/[tag]/page.tsx
+++ b/apps/blog/app/tag/[tag]/page.tsx
@@ -1,7 +1,10 @@
+import Link from 'next/link'
+
 import Feed from '@duyet/components/Feed'
 import { getAllTags, getPostsByTag } from '@duyet/libs/getPost'
 import { getSlug } from '@duyet/libs/getSlug'
-import Link from 'next/link'
+
+export const dynamic = 'force-static'
 
 interface Params {
   tag: string


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Improve SEO by forcing Next.js to pre-render these pages.