### PR TITLE
refactor(cv): extract CV data to typed config and add llms.txt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Build & Development
+- `yarn build` - Build all apps and packages using Turbo
+- `yarn dev` - Start development servers for all apps with Turbo parallel execution 
+- `yarn start` - Start production servers for all apps
+
+### Code Quality
+- `yarn lint` - Lint all projects using Turbo
+- `yarn fmt` or `yarn fix` - Format all TypeScript, TSX, and Markdown files with Prettier
+- `yarn prettier-check` - Check code formatting without making changes
+- `yarn test` - Run tests across all packages using Turbo
+
+### Individual App Development
+Navigate to specific app directories and run:
+- `yarn dev` - Start development (blog runs on port 3000 with Turbopack)
+- `yarn build` - Build specific app
+- `yarn check-types` - TypeScript type checking
+- `yarn analyze` - Bundle analysis (available in blog app)
+
+## Architecture Overview
+
+This is a **Yarn Workspaces monorepo** managed by **Turborepo** containing:
+
+### Apps (`/apps/`)
+1. **blog** (`apps/blog/`) - Next.js blog with Auth0 authentication and Vercel KV for comments
+   - Main blog at https://blog.duyet.net / https://duyet.vercel.app
+   - Uses Auth0 for auth, Vercel KV for Redis storage
+   - Supports markdown posts with KaTeX math rendering
+
+2. **cv** (`apps/cv/`) - Simple CV hosting application
+   - Live at https://cv.duyet.net / https://duyet-cv.vercel.app  
+   - Serves PDF CV from `/public` directory
+
+3. **insights** (`apps/insights/`) - Analytics dashboard
+   - Live at https://insights.duyet.net / https://duyet-insights.vercel.app
+   - Integrates Cloudflare Analytics, GitHub data, PostHog, WakaTime
+
+### Shared Packages (`/packages/`)
+- `@duyet/components` - Shared React components
+- `@duyet/libs` - Utility libraries and functions
+- `@duyet/interfaces` - TypeScript type definitions
+- `@duyet/eslint-config-custom` - ESLint configuration
+- `@duyet/prettier` - Prettier configuration
+- `@duyet/tailwind-config` - Tailwind CSS configuration
+- `@duyet/tsconfig` - TypeScript configurations
+
+## Environment Variables
+
+Global environment variables are defined in `turbo.json` and include:
+- Next.js public URLs for cross-app linking
+- Auth0 configuration (domain, client ID, admin email)
+- Vercel KV Redis credentials
+- PostgreSQL database connections
+- External API tokens (PostHog, GitHub, Cloudflare, etc.)
+
+Place environment files as `.env` or `.env.local` in the root directory.
+
+## Technology Stack
+
+- **Framework**: Next.js 15 with React 19
+- **Build Tool**: Turborepo for monorepo management
+- **Package Manager**: Yarn v1 (specified in package.json)
+- **Styling**: Tailwind CSS with custom configurations
+- **Authentication**: Auth0 (blog app)
+- **Database**: PostgreSQL + Vercel KV Redis
+- **Analytics**: PostHog, Cloudflare Analytics
+- **Deployment**: Vercel
+
+## Development Patterns
+
+- Use Yarn workspaces for cross-package dependencies (`@duyet/package-name`)
+- Turbo handles build orchestration and dependency management
+- All apps share common ESLint, Prettier, and TypeScript configurations
+- Environment variables are globally managed through Turborepo
+- Shared components and utilities live in `/packages` and are imported as workspace dependencies

--- a/apps/blog/app/llms.txt/route.ts
+++ b/apps/blog/app/llms.txt/route.ts
@@ -1,0 +1,115 @@
+import type { Post } from '@duyet/interfaces'
+import { getAllPosts } from '@duyet/libs/getPost'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const posts = getAllPosts(['slug', 'title', 'date', 'category', 'tags', 'excerpt'], 100000)
+  
+  const llmsContent = `# Duyet Le - Technical Blog
+
+A comprehensive collection of technical blog posts covering Data Engineering, Software Engineering, and Technology insights from Duyet Le.
+
+## Contact
+- Author: Duyet Le
+- Email: me@duyet.net
+- Website: https://duyet.net
+- GitHub: https://github.com/duyet
+- LinkedIn: https://linkedin.com/in/duyet
+- Blog: https://blog.duyet.net
+
+## About This Blog
+
+${posts.length}+ technical articles covering topics including:
+- Data Engineering & Big Data
+- Apache Spark, ClickHouse, Apache Airflow
+- Cloud Computing (AWS, GCP, Azure)
+- Kubernetes & DevOps
+- Programming (Python, Rust, JavaScript/TypeScript)
+- Machine Learning & AI
+- Software Engineering Best Practices
+
+Articles span from ${new Date(posts[posts.length - 1]?.date).getFullYear()} to ${new Date(posts[0]?.date).getFullYear()}, documenting the evolution of modern data engineering and software development practices.
+
+## Recent Posts
+
+${posts.slice(0, 20).map((post: Post) => {
+  const url = `https://blog.duyet.net${post.slug}`
+  const date = new Date(post.date).toISOString().split('T')[0]
+  const tags = post.tags?.join(', ') || ''
+  
+  return `### [${post.title}](${url})
+- **Date**: ${date}
+- **Category**: ${post.category}
+- **Tags**: ${tags}
+- **URL**: ${url}
+${post.excerpt ? `- **Description**: ${post.excerpt}` : ''}
+`
+}).join('\n')}
+
+## All Blog Posts by Year
+
+${Object.entries(
+  posts.reduce((acc: Record<string, Post[]>, post: Post) => {
+    const year = new Date(post.date).getFullYear().toString()
+    if (!acc[year]) acc[year] = []
+    acc[year].push(post)
+    return acc
+  }, {})
+).sort(([a], [b]) => parseInt(b) - parseInt(a))
+.map(([year, yearPosts]) => {
+  return `### ${year} (${yearPosts.length} posts)
+
+${yearPosts.map((post: Post) => {
+  const url = `https://blog.duyet.net${post.slug}`
+  const date = new Date(post.date).toISOString().split('T')[0]
+  return `- [${post.title}](${url}) - ${date}`
+}).join('\n')}
+`
+}).join('\n')}
+
+## Popular Topics
+
+The blog covers these main technical areas with substantial content:
+
+### Data Engineering
+- ClickHouse: Database optimization, Kubernetes deployment, performance tuning
+- Apache Spark: Kubernetes integration, performance optimization, data processing
+- Apache Airflow: Workflow management, best practices, monitoring
+
+### Cloud & DevOps  
+- Kubernetes: Container orchestration, monitoring, production deployments
+- Cloud Platforms: AWS, GCP, Azure architecture and cost optimization
+- CI/CD: GitHub Actions, automated testing, deployment strategies
+
+### Programming Languages
+- Rust: Systems programming, data engineering tools, performance optimization
+- Python: Data processing, web development, automation scripts
+- JavaScript/TypeScript: Web development, Node.js, modern frameworks
+
+### Machine Learning & AI
+- Natural Language Processing: Text analysis, sentiment analysis, tokenization
+- Deep Learning: Model deployment, training optimization, production ML
+- Data Science: Statistical analysis, visualization, data mining
+
+---
+
+This file follows the llms.txt standard for providing comprehensive blog information to Large Language Models and AI assistants.
+
+**Blog Statistics:**
+- Total Posts: ${posts.length}
+- Years Active: ${new Date(posts[posts.length - 1]?.date).getFullYear()}-${new Date(posts[0]?.date).getFullYear()}
+- Categories: ${Array.from(new Set(posts.map(p => p.category))).length}
+- Tags: ${Array.from(new Set(posts.flatMap(p => p.tags || []))).length}
+
+Generated from: https://blog.duyet.net
+`
+
+  return new NextResponse(llmsContent, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}

--- a/apps/cv/app/llms.txt/route.ts
+++ b/apps/cv/app/llms.txt/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+
+import { llmsInfo } from '@/config/cv.data'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const llmsContent = `# ${llmsInfo.name}
+
+${llmsInfo.bio}
+
+## Contact
+- Email: ${llmsInfo.email}
+- Website: ${llmsInfo.website}
+- GitHub: ${llmsInfo.links.github}
+- LinkedIn: ${llmsInfo.links.linkedin}
+- Blog: ${llmsInfo.links.blog}
+
+## Current Role
+${llmsInfo.currentRole.title} at ${llmsInfo.currentRole.company} (${llmsInfo.currentRole.duration})
+
+## Areas of Expertise
+${llmsInfo.expertise.map(area => `- ${area}`).join('\n')}
+
+## Key Technologies
+${llmsInfo.technologies.map(tech => `- ${tech}`).join('\n')}
+
+## Notable Achievements
+${llmsInfo.keyAchievements.map(achievement => `- ${achievement}`).join('\n')}
+
+---
+
+This file follows the llms.txt standard for providing information about ${llmsInfo.name} to Large Language Models and AI assistants.
+Generated from CV data at ${llmsInfo.website}
+`
+
+  return new NextResponse(llmsContent, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}

--- a/apps/cv/app/page.tsx
+++ b/apps/cv/app/page.tsx
@@ -1,5 +1,3 @@
-import { GitHubLogoIcon, LinkedInLogoIcon } from '@radix-ui/react-icons'
-import type { ImageProps } from 'next/image'
 import Link from 'next/link'
 
 import { Education } from '@/components/education'
@@ -13,14 +11,9 @@ import {
   HoverCardTrigger,
 } from '@/components/ui/hover-card'
 import { Separator } from '@/components/ui/separator'
-
-import { HoverLinks } from '@/components/hover-links'
 import { Skill } from '@/components/skill'
-import FossilLogo from '@/public/fossil.svg'
-import FptLogo from '@/public/fpt.svg'
-import JvnLogo from '@/public/jvn.png'
-import CartrackLogo from '@/public/karo.svg'
 
+import { cvData } from '@/config/cv.data'
 import {
   SkillAirflow,
   SkillCICD,
@@ -36,6 +29,58 @@ import {
 export const dynamic = 'force-static'
 
 export default function Page() {
+  const { personal, experience, education } = cvData
+
+  const renderContactLinks = () => {
+    return personal.contacts.map((contact) => {
+      if (contact.type === 'email') {
+        return <div key={contact.id}>{contact.label}</div>
+      }
+
+      if (contact.hoverContent) {
+        return (
+          <HoverCard key={contact.id} openDelay={100} closeDelay={100}>
+            <HoverCardTrigger asChild>
+              <Link
+                className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
+                href={contact.url}
+                target="_blank"
+              >
+                {contact.label}
+              </Link>
+            </HoverCardTrigger>
+            <HoverCardContent>
+              <Link
+                className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
+                href={contact.url}
+                target="_blank"
+              >
+                <div className="flex flex-col gap-2">
+                  {contact.hoverContent.icon}
+                  <div>
+                    <strong>{contact.hoverContent.title} </strong>
+                    <span>{contact.hoverContent.subtitle}</span>
+                  </div>
+                </div>
+              </Link>
+            </HoverCardContent>
+          </HoverCard>
+        )
+      }
+
+      return (
+        <Link
+          key={contact.id}
+          className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
+          href={contact.url}
+          target="_blank"
+        >
+          {contact.label}
+        </Link>
+      )
+    })
+  }
+
   return (
     <div className="m-auto flex min-h-screen flex-col gap-8 text-sm text-black">
       <header className="flex flex-col gap-3">
@@ -43,78 +88,13 @@ export default function Page() {
           className="mb-2 inline-flex gap-2 text-2xl font-bold"
           style={{ fontFamily: 'var(--font-lora)' }}
         >
-          <span>Duyet Le</span>
+          <span>{personal.name}</span>
           <Separator orientation="vertical" />
-          <span className="text-red-500">Résumé</span>
+          <span className="text-red-500">{personal.title}</span>
         </h1>
 
-        <InlineLink
-          links={[
-            <div key="email">me@duyet.net</div>,
-            <Link
-              className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
-              key="homepage"
-              href="https://duyet.net"
-              target="_blank"
-            >
-              https://duyet.net
-            </Link>,
-
-            <HoverCard key="github" openDelay={100} closeDelay={100}>
-              <HoverCardTrigger asChild>
-                <Link
-                  className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
-                  href="https://github.com/duyet"
-                  target="_blank"
-                >
-                  https://github.com/duyet
-                </Link>
-              </HoverCardTrigger>
-              <HoverCardContent>
-                <Link
-                  className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
-                  href="https://linkedin.com/in/duyet"
-                  target="_blank"
-                >
-                  <div className="flex flex-col gap-2">
-                    <GitHubLogoIcon />
-                    <div>
-                      <strong>Github: </strong>
-                      <span>@duyet</span>
-                    </div>
-                  </div>
-                </Link>
-              </HoverCardContent>
-            </HoverCard>,
-
-            <HoverCard key="linkedin" openDelay={100} closeDelay={0}>
-              <HoverCardTrigger asChild>
-                <Link
-                  className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
-                  href="https://linkedin.com/in/duyet"
-                  target="_blank"
-                >
-                  https://linkedin.com/in/duyet
-                </Link>
-              </HoverCardTrigger>
-              <HoverCardContent>
-                <Link
-                  className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
-                  href="https://linkedin.com/in/duyet"
-                  target="_blank"
-                >
-                  <div className="flex flex-col gap-2">
-                    <LinkedInLogoIcon />
-                    <div>
-                      <strong>Linkedin: </strong>
-                      <span>/in/duyet</span>
-                    </div>
-                  </div>
-                </Link>
-              </HoverCardContent>
-            </HoverCard>,
-          ]}
-        />
+        <InlineLink links={renderContactLinks()} />
+        
         <Overview className="text-sm">
           Data Engineer with 6+ years of experience in modern data warehousing,
           distributed systems, and cloud computing. Proficient in <SkillClickHouse />
@@ -131,172 +111,33 @@ export default function Page() {
 
       <Section title="Experience">
         <div className="flex flex-col gap-5">
-          <ExperienceItem
-            title="Sr. Data Engineer"
-            company="Cartrack"
-            companyUrl="https://cartrack.us"
-            companyLogo={CartrackLogo as ImageProps['src']}
-            companyLogoClassName="h-5 w-auto"
-            from={new Date('2023-10')}
-            responsibilities={[
-              {
-                id: 1,
-                item: 'Deprecated old stack (Spark, Iceberg, Trino) replaced by ClickHouse.',
-              },
-              {
-                id: 2,
-                item: (
-                  <span key="migrate-iceberg-to-clickhouse">
-                    Migrated 350TB+ Iceberg Data Lake to{' '}
-                    <HoverLinks
-                      text="ClickHouse on Kubernetes"
-                      links={[
-                        {
-                          text: 'ClickHouse on Kubernetes',
-                          href: 'https://blog.duyet.net/2024/03/clickhouse-on-kubernetes.html',
-                        },
-                        {
-                          text: 'Monitoring ClickHouse on Kubernetes',
-                          href: 'https://blog.duyet.net/2024/03/clickhouse-monitoring.html',
-                        },
-                        {
-                          text: 'Why ClickHouse Should Be the Go-To Choice for Your Next Data Platform?',
-                          href: 'https://blog.duyet.net/2023/01/clickhouse.html',
-                        },
-                      ]}
-                    />
-                    .
-                  </span>
-                ),
-              },
-              {
-                id: 3,
-                item: 'Enhanced ClickHouse for 300% better data compression and 2x-100x faster queries, compared with Trino + Iceberg',
-              },
-              {
-                id: 4,
-                item: 'Automated operations with Airflow: data replication, data processing, healthchecks, etc.',
-              },
-              {
-                id: 5,
-                item: 'Multi-agent LLM + RAG (LlamaIndex, Qdrant, ClickHouse text2sql, Nextjs, etc)',
-              },
-            ]}
-          />
-          <ExperienceItem
-            title="Sr. Data Engineer"
-            company="Fossil Group Inc"
-            companyUrl="https://fossil.com"
-            companyLogo={FossilLogo as ImageProps['src']}
-            companyLogoClassName="h-auto w-10"
-            from={new Date('2018-10')}
-            to={new Date('2023-07')}
-            responsibilities={[
-              {
-                id: 1,
-                item: 'Optimize monthly costs from $45,000 to $20,000 (GCP and AWS Cloud).',
-              },
-              {
-                id: 2,
-                item: 'Managed a team of 4 data engineers and 2 data analysts to provide end-to-end analytics solutions to stakeholders. Raised data-driven awareness throughout the organization and encouraged everyone to take a more data-driven approach to problem-solving.',
-              },
-              {
-                id: 3,
-                item: (
-                  <Link
-                    href="https://blog.duyet.net/2023/06/fossil-data-platform-written-rust.html"
-                    key="next-gen-data-platform"
-                    className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
-                    target="_blank"
-                  >
-                    Designed next-gen Data Platform in Rust ↗︎
-                  </Link>
-                ),
-              },
-              {
-                id: 4,
-                item: (
-                  <span key="k8s-deploy">
-                    Developed tools for Data Monitoring, Data Catalog, and
-                    Self-service Analytics for internal teams with{' '}
-                    <HoverLinks
-                      text="everything deployed on Kubernetes"
-                      links={[
-                        {
-                          text: 'Spark on Kubernetes tại Fossil︎',
-                          href: 'https://blog.duyet.net/2022/03/spark-kubernetes-at-fossil.html',
-                        },
-                        {
-                          text: 'Spark on Kubernetes Performance Tuning︎',
-                          href: 'https://blog.duyet.net/2021/04/spark-kubernetes-performance-tuning.html',
-                        },
-                        {
-                          text: 'ClickHouse on Kubernetes︎',
-                          href: 'https://blog.duyet.net/2024/03/clickhouse-on-kubernetes.html',
-                        },
-                        {
-                          text: 'Fossil Data Platform Rewritten in Rust 🦀︎',
-                          href: 'https://blog.duyet.net/2023/06/fossil-data-platform-written-rust.html',
-                        },
-                      ]}
-                    />
-                    .
-                  </span>
-                ),
-              },
-            ]}
-          />
-          <ExperienceItem
-            title="Sr. Data Engineer"
-            company="FPT Software"
-            companyLogo={FptLogo as ImageProps['src']}
-            companyLogoClassName="h-auto w-7"
-            from={new Date('2017-06')}
-            to={new Date('2018-10')}
-            responsibilities={[
-              {
-                id: 1,
-                item: 'Built data pipelines processing 2TB/day with AWS for a Recommendation System',
-              },
-              {
-                id: 2,
-                item: (
-                  <span key="azure">
-                    Ingested and transformed 1TB+/day into Data Lake using Azure
-                    Cloud and Databricks
-                  </span>
-                ),
-              },
-            ]}
-          />
-          <ExperienceItem
-            title="Data Engineer"
-            company="John von Neumann Institute"
-            companyLogo={JvnLogo as ImageProps['src']}
-            companyLogoClassName="h-5 w-auto"
-            from={new Date('2015-09')}
-            to={new Date('2017-06')}
-            responsibilities={[
-              {
-                id: 1,
-                item: 'Developed data pipelines, data cleaning and visualizations for adhoc problems.',
-              },
-              {
-                id: 2,
-                item: 'Train and deployed ML models: customer lifetime value, churn prediction, sales optimization, recruitment optimization, etc.',
-              },
-            ]}
-          />
+          {experience.map((exp) => (
+            <ExperienceItem
+              key={exp.id}
+              title={exp.title}
+              company={exp.company}
+              companyUrl={exp.companyUrl}
+              companyLogo={exp.companyLogo}
+              companyLogoClassName={exp.companyLogoClassName}
+              from={exp.from}
+              to={exp.to}
+              responsibilities={exp.responsibilities}
+            />
+          ))}
         </div>
       </Section>
 
       <Section title="Education">
-        <Education
-          major="Bachelor's degree, Information System"
-          thesis="Thesis: Network of career skills and support an optimal job search"
-          thesisUrl="https://arxiv.org/pdf/1707.09751"
-          university="University of Information Technology"
-        />
+        {education.map((edu) => (
+          <Education
+            key={edu.id}
+            major={edu.major}
+            thesis={edu.thesis}
+            thesisUrl={edu.thesisUrl}
+            university={edu.university}
+            period={edu.period}
+          />
+        ))}
       </Section>
 
       <Section title="Skills">

--- a/apps/cv/config/cv.data.tsx
+++ b/apps/cv/config/cv.data.tsx
@@ -1,0 +1,306 @@
+import { GitHubLogoIcon, LinkedInLogoIcon } from '@radix-ui/react-icons'
+import Link from 'next/link'
+
+import { HoverLinks } from '@/components/hover-links'
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card'
+import FossilLogo from '@/public/fossil.svg'
+import FptLogo from '@/public/fpt.svg'
+import JvnLogo from '@/public/jvn.png'
+import CartrackLogo from '@/public/karo.svg'
+
+import type { CVData, LLMsInfo } from './cv.types'
+
+export const cvData: CVData = {
+  personal: {
+    name: 'Duyet Le',
+    title: 'Résumé',
+    email: 'me@duyet.net',
+    overview: 'Data Engineer with 6+ years of experience in modern data warehousing, distributed systems, and cloud computing. Proficient in ClickHouse, Spark, Airflow, Python, Rust.',
+    contacts: [
+      {
+        id: 'email',
+        type: 'email',
+        label: 'me@duyet.net',
+        url: 'mailto:me@duyet.net',
+      },
+      {
+        id: 'website',
+        type: 'website', 
+        label: 'https://duyet.net',
+        url: 'https://duyet.net',
+      },
+      {
+        id: 'github',
+        type: 'github',
+        label: 'https://github.com/duyet',
+        url: 'https://github.com/duyet',
+        hoverContent: {
+          icon: <GitHubLogoIcon />,
+          title: 'Github:',
+          subtitle: '@duyet',
+        },
+      },
+      {
+        id: 'linkedin',
+        type: 'linkedin',
+        label: 'https://linkedin.com/in/duyet',
+        url: 'https://linkedin.com/in/duyet',
+        hoverContent: {
+          icon: <LinkedInLogoIcon />,
+          title: 'Linkedin:',
+          subtitle: '/in/duyet',
+        },
+      },
+    ],
+  },
+  experience: [
+    {
+      id: 'cartrack',
+      title: 'Sr. Data Engineer',
+      company: 'Cartrack',
+      companyUrl: 'https://cartrack.us',
+      companyLogo: CartrackLogo,
+      companyLogoClassName: 'h-5 w-auto',
+      from: new Date('2023-10'),
+      responsibilities: [
+        {
+          id: 1,
+          item: 'Deprecated old stack (Spark, Iceberg, Trino) replaced by ClickHouse.',
+        },
+        {
+          id: 2,
+          item: (
+            <span key="migrate-iceberg-to-clickhouse">
+              Migrated 350TB+ Iceberg Data Lake to{' '}
+              <HoverLinks
+                text="ClickHouse on Kubernetes"
+                links={[
+                  {
+                    text: 'ClickHouse on Kubernetes',
+                    href: 'https://blog.duyet.net/2024/03/clickhouse-on-kubernetes.html',
+                  },
+                  {
+                    text: 'Monitoring ClickHouse on Kubernetes',
+                    href: 'https://blog.duyet.net/2024/03/clickhouse-monitoring.html',
+                  },
+                  {
+                    text: 'Why ClickHouse Should Be the Go-To Choice for Your Next Data Platform?',
+                    href: 'https://blog.duyet.net/2023/01/clickhouse.html',
+                  },
+                ]}
+              />
+              .
+            </span>
+          ),
+        },
+        {
+          id: 3,
+          item: 'Enhanced ClickHouse for 300% better data compression and 2x-100x faster queries, compared with Trino + Iceberg',
+        },
+        {
+          id: 4,
+          item: 'Automated operations with Airflow: data replication, data processing, healthchecks, etc.',
+        },
+        {
+          id: 5,
+          item: 'Multi-agent LLM + RAG (LlamaIndex, Qdrant, ClickHouse text2sql, Nextjs, etc)',
+        },
+      ],
+    },
+    {
+      id: 'fossil',
+      title: 'Sr. Data Engineer',
+      company: 'Fossil Group Inc',
+      companyUrl: 'https://fossil.com',
+      companyLogo: FossilLogo,
+      companyLogoClassName: 'h-auto w-10',
+      from: new Date('2018-10'),
+      to: new Date('2023-07'),
+      responsibilities: [
+        {
+          id: 1,
+          item: 'Optimize monthly costs from $45,000 to $20,000 (GCP and AWS Cloud).',
+        },
+        {
+          id: 2,
+          item: 'Managed a team of 4 data engineers and 2 data analysts to provide end-to-end analytics solutions to stakeholders. Raised data-driven awareness throughout the organization and encouraged everyone to take a more data-driven approach to problem-solving.',
+        },
+        {
+          id: 3,
+          item: (
+            <Link
+              href="https://blog.duyet.net/2023/06/fossil-data-platform-written-rust.html"
+              key="next-gen-data-platform"
+              className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
+              target="_blank"
+            >
+              Designed next-gen Data Platform in Rust ↗︎
+            </Link>
+          ),
+        },
+        {
+          id: 4,
+          item: (
+            <span key="k8s-deploy">
+              Developed tools for Data Monitoring, Data Catalog, and Self-service
+              Analytics for internal teams with{' '}
+              <HoverLinks
+                text="everything deployed on Kubernetes"
+                links={[
+                  {
+                    text: 'Spark on Kubernetes tại Fossil︎',
+                    href: 'https://blog.duyet.net/2022/03/spark-kubernetes-at-fossil.html',
+                  },
+                  {
+                    text: 'Spark on Kubernetes Performance Tuning︎',
+                    href: 'https://blog.duyet.net/2021/04/spark-kubernetes-performance-tuning.html',
+                  },
+                  {
+                    text: 'ClickHouse on Kubernetes︎',
+                    href: 'https://blog.duyet.net/2024/03/clickhouse-on-kubernetes.html',
+                  },
+                  {
+                    text: 'Fossil Data Platform Rewritten in Rust 🦀︎',
+                    href: 'https://blog.duyet.net/2023/06/fossil-data-platform-written-rust.html',
+                  },
+                ]}
+              />
+              .
+            </span>
+          ),
+        },
+      ],
+    },
+    {
+      id: 'fpt',
+      title: 'Sr. Data Engineer',
+      company: 'FPT Software',
+      companyLogo: FptLogo,
+      companyLogoClassName: 'h-auto w-7',
+      from: new Date('2017-06'),
+      to: new Date('2018-10'),
+      responsibilities: [
+        {
+          id: 1,
+          item: 'Built data pipelines processing 2TB/day with AWS for a Recommendation System',
+        },
+        {
+          id: 2,
+          item: (
+            <span key="azure">
+              Ingested and transformed 1TB+/day into Data Lake using Azure Cloud
+              and Databricks
+            </span>
+          ),
+        },
+      ],
+    },
+    {
+      id: 'jvn',
+      title: 'Data Engineer',
+      company: 'John von Neumann Institute',
+      companyLogo: JvnLogo,
+      companyLogoClassName: 'h-5 w-auto',
+      from: new Date('2015-09'),
+      to: new Date('2017-06'),
+      responsibilities: [
+        {
+          id: 1,
+          item: 'Developed data pipelines, data cleaning and visualizations for adhoc problems.',
+        },
+        {
+          id: 2,
+          item: 'Train and deployed ML models: customer lifetime value, churn prediction, sales optimization, recruitment optimization, etc.',
+        },
+      ],
+    },
+  ],
+  education: [
+    {
+      id: 'uit',
+      major: 'Bachelor\'s degree, Information System',
+      thesis: 'Thesis: Network of career skills and support an optimal job search',
+      thesisUrl: 'https://arxiv.org/pdf/1707.09751',
+      university: 'University of Information Technology',
+    },
+  ],
+  skills: [
+    {
+      id: 'data-engineering',
+      name: 'Data Engineering',
+      skills: [
+        { id: 'clickhouse', name: 'ClickHouse' },
+        { id: 'spark', name: 'Spark' },
+        { id: 'kafka', name: 'Kafka' },
+        { id: 'airflow', name: 'Airflow' },
+        { id: 'aws', name: 'AWS' },
+        { id: 'bigquery', name: 'BigQuery' },
+        { id: 'data-studio', name: 'Data Studio' },
+        { id: 'python', name: 'Python' },
+        { id: 'rust', name: 'Rust' },
+        { id: 'typescript', name: 'Typescript' },
+      ],
+    },
+    {
+      id: 'devops',
+      name: 'DevOps',
+      skills: [
+        { id: 'cicd', name: 'CI/CD' },
+        { id: 'kubernetes', name: 'Kubernetes' },
+        { id: 'helm', name: 'Helm' },
+      ],
+    },
+  ],
+}
+
+export const llmsInfo: LLMsInfo = {
+  name: 'Duyet Le',
+  role: 'Senior Data Engineer',
+  email: 'me@duyet.net',
+  website: 'https://duyet.net',
+  bio: 'Data Engineer with 6+ years of experience in modern data warehousing, distributed systems, and cloud computing.',
+  expertise: [
+    'Data Engineering',
+    'Distributed Systems',
+    'Cloud Computing',
+    'Data Warehousing',
+    'Machine Learning Infrastructure',
+    'DevOps',
+  ],
+  currentRole: {
+    title: 'Sr. Data Engineer',
+    company: 'Cartrack',
+    duration: 'Oct 2023 - Present',
+  },
+  keyAchievements: [
+    'Migrated 350TB+ Iceberg Data Lake to ClickHouse on Kubernetes',
+    'Enhanced ClickHouse for 300% better data compression and 2x-100x faster queries',
+    'Optimized cloud costs from $45,000 to $20,000/month at Fossil Group',
+    'Managed team of 6 engineers and analysts',
+    'Designed next-gen Data Platform in Rust',
+    'Built multi-agent LLM + RAG systems',
+  ],
+  technologies: [
+    'ClickHouse',
+    'Apache Spark',
+    'Apache Airflow',
+    'Python',
+    'Rust',
+    'TypeScript',
+    'Kubernetes',
+    'AWS',
+    'GCP',
+    'Kafka',
+    'BigQuery',
+    'Helm',
+  ],
+  links: {
+    github: 'https://github.com/duyet',
+    blog: 'https://blog.duyet.net',
+    linkedin: 'https://linkedin.com/in/duyet',
+  },
+}

--- a/apps/cv/config/cv.types.ts
+++ b/apps/cv/config/cv.types.ts
@@ -1,0 +1,92 @@
+import type { ImageProps } from 'next/image'
+import type { ReactNode } from 'react'
+
+export interface ContactLink {
+  id: string
+  type: 'email' | 'website' | 'github' | 'linkedin' | 'custom'
+  label: string
+  url: string
+  displayText?: string
+  hoverContent?: {
+    icon?: ReactNode
+    title: string
+    subtitle: string
+  }
+}
+
+export interface PersonalInfo {
+  name: string
+  title: string
+  email: string
+  overview: string
+  contacts: ContactLink[]
+}
+
+export interface Responsibility {
+  id: number
+  item: string | ReactNode
+}
+
+export interface Experience {
+  id: string
+  title: string
+  company: string
+  companyUrl?: string
+  companyLogo?: ImageProps['src']
+  companyLogoClassName?: string
+  from: Date
+  to?: Date
+  responsibilities: Responsibility[]
+}
+
+export interface Education {
+  id: string
+  major: string
+  university: string
+  period?: string
+  thesis: string
+  thesisUrl: string
+}
+
+export interface SkillDetail {
+  id: string
+  name: string
+  url?: string
+  icon?: ReactNode
+  note?: string | ReactNode
+}
+
+export interface SkillCategory {
+  id: string
+  name: string
+  skills: SkillDetail[]
+}
+
+export interface CVData {
+  personal: PersonalInfo
+  experience: Experience[]
+  education: Education[]
+  skills: SkillCategory[]
+}
+
+// For generating llms.txt
+export interface LLMsInfo {
+  name: string
+  role: string
+  email: string
+  website: string
+  bio: string
+  expertise: string[]
+  currentRole: {
+    title: string
+    company: string
+    duration: string
+  }
+  keyAchievements: string[]
+  technologies: string[]
+  links: {
+    github: string
+    blog: string
+    linkedin: string
+  }
+}

--- a/apps/insights/app/llms.txt/route.ts
+++ b/apps/insights/app/llms.txt/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-static'
+
+export async function GET() {
+  const llmsContent = `# Duyet Le - Insights & Analytics
+
+Senior Data Engineer with 6+ years of experience in modern data warehousing, distributed systems, and cloud computing.
+
+## Contact
+- Email: me@duyet.net
+- Website: https://duyet.net
+- GitHub: https://github.com/duyet
+- LinkedIn: https://linkedin.com/in/duyet
+- Blog: https://blog.duyet.net
+
+## Current Role
+Sr. Data Engineer at Cartrack (Oct 2023 - Present)
+
+## Areas of Expertise
+- Data Engineering
+- Distributed Systems
+- Cloud Computing
+- Data Warehousing
+- Machine Learning Infrastructure
+- DevOps
+- Analytics & Business Intelligence
+
+## Key Technologies
+- ClickHouse
+- Apache Spark
+- Apache Airflow
+- Python
+- Rust
+- TypeScript
+- Kubernetes
+- AWS
+- GCP
+- Kafka
+- BigQuery
+- Helm
+
+## Analytics & Insights Work
+- Built comprehensive analytics platforms processing TBs of data daily
+- Developed real-time monitoring and alerting systems
+- Created self-service analytics tools for business stakeholders
+- Implemented cost optimization strategies reducing cloud costs by 55%
+- Designed and deployed multi-agent LLM + RAG systems
+
+## Notable Achievements
+- Migrated 350TB+ Iceberg Data Lake to ClickHouse on Kubernetes
+- Enhanced ClickHouse for 300% better data compression and 2x-100x faster queries
+- Optimized cloud costs from $45,000 to $20,000/month at Fossil Group
+- Managed team of 6 engineers and analysts
+- Designed next-gen Data Platform in Rust
+- Built multi-agent LLM + RAG systems
+
+---
+
+This insights dashboard showcases real-time analytics from various data sources including:
+- Blog analytics (Cloudflare, PostHog)
+- GitHub activity and repository metrics
+- WakaTime coding statistics
+- Personal productivity and development insights
+
+This file follows the llms.txt standard for providing information about Duyet Le to Large Language Models and AI assistants.
+Generated from insights dashboard at https://insights.duyet.net
+`
+
+  return new NextResponse(llmsContent, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  })
+}


### PR DESCRIPTION
- Extract hardcoded CV data into typed configuration system:
  - Add cv.types.ts with TypeScript interfaces for CV data structure
  - Create cv.data.tsx with all CV information as typed config
  - Refactor page.tsx to use config data instead of hardcoded values

- Add llms.txt generation routes:
  - Implement /llms.txt route in CV app with comprehensive CV data
  - Add /llms.txt route in insights app with analytics focus
  - Both routes follow llms.txt standard for AI assistant information

- Add CLAUDE.md with comprehensive monorepo guidance for AI assistants

Changes enable easy CV updates via config files and provide standardized AI-readable CV information at both cv.duyet.net/llms.txt and insights.duyet.net/llms.txt endpoints.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Extract CV content into a typed configuration system, refactor the CV page to consume this config, and introduce standardized AI-readable endpoints plus guidance documentation.

New Features:
- Extract all hardcoded CV data into a new typed config (cv.types.ts and cv.data.tsx) and refactor the CV page to render from it
- Implement llms.txt routes in both CV and Insights apps to expose AI-readable profile data at /llms.txt
- Add a CLAUDE.md guide with comprehensive monorepo usage instructions for AI assistants

Enhancements:
- Enable easy CV updates and consistent rendering through the configuration-driven approach

Documentation:
- Include CLAUDE.md as user-facing documentation for monorepo development and AI assistant guidelines