### PR TITLE
fix(insights): correct chart component import path

### DIFF
--- a/apps/insights/app/blog/cloudflare.tsx
+++ b/apps/insights/app/blog/cloudflare.tsx
@@ -1,6 +1,6 @@
 import { request } from 'graphql-request'
 
-import { AreaChart, Flex, Metric, Text } from '@duyet/components/Tremor'
+import { AreaChart, Flex, Metric, Text } from '@duyet/components'
 import type { CloudflareAnalyticsByDate } from '@duyet/interfaces'
 import { TextDataSource } from '../../components/text-data-source'
 


### PR DESCRIPTION
## Summary
- Fix AreaChart, Flex, Metric, Text imports from incorrect `@duyet/components/Tremor` to correct `@duyet/components`
- Resolves charts not displaying issue in Cloudflare analytics page
- Aligns with other chart components using consistent import pattern

## Issue
Charts were not showing in the insights app due to incorrect import path in the Cloudflare component.

## Root Cause
The `apps/insights/app/blog/cloudflare.tsx` was importing chart components from `@duyet/components/Tremor` instead of the correct `@duyet/components` path.

## Solution
Updated import statement to use the consistent pattern used by other chart components:
```diff
- import { AreaChart, Flex, Metric, Text } from '@duyet/components/Tremor'
+ import { AreaChart, Flex, Metric, Text } from '@duyet/components'
```

## Verification
- ✅ Build passes successfully
- ✅ No TypeScript errors
- ✅ Consistent with wakatime.tsx and posthog.tsx import patterns
- ✅ All static pages generate correctly (8/8)

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Fix incorrect import path for chart components causing charts not to display on the Cloudflare analytics page.