### PR TITLE
fix(ui): remove all padding and gaps from photo grid for seamless fit

### DIFF
--- a/apps/photo/app/[year]/page.tsx
+++ b/apps/photo/app/[year]/page.tsx
@@ -145,9 +145,7 @@ export default async function YearPage({ params }: YearPageProps) {
 
       {/* Photo grid - full width */}
       <div className="w-full">
-        <div className="px-4 sm:px-6 lg:px-8">
-          <PhotoGrid photos={yearPhotos} />
-        </div>
+        <PhotoGrid photos={yearPhotos} />
       </div>
     </>
   )

--- a/apps/photo/app/page.tsx
+++ b/apps/photo/app/page.tsx
@@ -79,9 +79,7 @@ export default async function PhotosPage() {
       {/* Photo grid - full width */}
       <div className="w-full">
         {photos.length > 0 ? (
-          <div className="px-4 sm:px-6 lg:px-8">
-            <PhotoGrid photos={photos} />
-          </div>
+          <PhotoGrid photos={photos} />
         ) : (
           <Container>
             <div className="flex min-h-[400px] items-center justify-center">

--- a/apps/photo/components/PhotoCard.tsx
+++ b/apps/photo/components/PhotoCard.tsx
@@ -42,7 +42,7 @@ export default function PhotoCard({
       className={cn(
         'group relative cursor-pointer overflow-hidden bg-gray-100 dark:bg-gray-800',
         'transition-opacity duration-200 hover:opacity-95',
-        'break-inside-avoid mb-4', // Prevents breaking in masonry layout
+        'break-inside-avoid', // Prevents breaking in masonry layout
         className,
       )}
       onClick={() => {

--- a/apps/photo/components/PhotoGrid.tsx
+++ b/apps/photo/components/PhotoGrid.tsx
@@ -69,8 +69,8 @@ export default function PhotoGrid({ photos, className }: PhotoGridProps) {
     <>
       <Masonry
         breakpointCols={breakpointColumns}
-        className={cn('flex w-full -ml-4', className)}
-        columnClassName="pl-4 bg-clip-padding"
+        className={cn('flex w-full', className)}
+        columnClassName="bg-clip-padding"
       >
         {photos.map((photo, index) => (
           <PhotoCard


### PR DESCRIPTION
## Summary

This PR removes all padding and gaps from the photo grid to make images fit together seamlessly as requested.

### Key Changes

✅ **Seamless Photo Grid**
- Removed masonry column padding (`-ml-4` and `pl-4` classes)
- Removed bottom margin (`mb-4`) from PhotoCard components
- Removed page-level padding containers (`px-4 sm:px-6 lg:px-8`)
- Photos now fit together perfectly with no spacing

✅ **Layout Improvements**
- Maintained masonry layout functionality
- Preserved responsive breakpoints
- Images now touch each other seamlessly
- Full-width photo grid implementation

### Technical Changes

- **PhotoGrid.tsx**: Removed negative margin and column padding
- **PhotoCard.tsx**: Removed bottom margin for seamless fitting
- **page.tsx**: Removed padding wrapper around grid
- **[year]/page.tsx**: Removed padding wrapper around grid

### Visual Impact

- **Before**: Photos had gaps and padding between them
- **After**: Photos fit seamlessly together like a true masonry layout
- No white space between images
- Wall-to-wall photo display

### Testing

✅ Photo app builds successfully
✅ Masonry layout still works correctly
✅ Responsive design maintained
✅ All breakpoints function properly

The photo grid now displays images in a seamless, gap-free layout as requested.

🤖 Generated with [Claude Code](https://claude.ai/code)