### PR TITLE
refactor: improve navigation UX and fix dark mode placement

### DIFF
--- a/packages/components/Menu.tsx
+++ b/packages/components/Menu.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 
 import { cn } from "@duyet/libs/utils";
-import ThemeToggle from "./ThemeToggle";
 
 const BLOG_URL =
   process.env.NEXT_PUBLIC_DUYET_BLOG_URL || "https://blog.duyet.net";
@@ -19,7 +18,7 @@ export const ABOUT = { name: "About", href: `${BLOG_URL}/about` };
 export const INSIGHTS = { name: "Insights", href: INSIGHTS_URL };
 export const PHOTOS = { name: "Photos", href: PHOTO_URL };
 export const ARCHIVES = { name: "Archives", href: `${BLOG_URL}/archives` };
-export const FEED = { name: "Feed", href: `${BLOG_URL}/feed` };
+export const FEED = { name: "Feed", href: `${BLOG_URL}` };
 export const BLOG = { name: "Blog", href: `${BLOG_URL}` };
 const defaultNavigation = [FEED, PHOTOS, INSIGHTS, ABOUT];
 
@@ -43,7 +42,6 @@ export default function Menu({
           {name}
         </Link>
       ))}
-      <ThemeToggle />
     </div>
   );
 }

--- a/packages/components/ThemeProvider.tsx
+++ b/packages/components/ThemeProvider.tsx
@@ -8,6 +8,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       defaultTheme="light" 
       attribute="class"
       enableSystem={true}
+      disableTransitionOnChange
     >
       {children}
     </ThemeProvider>


### PR DESCRIPTION
## Summary
- Remove dark mode toggle from menu, keep in footer only to reduce menu clutter
- Change Feed link to point to blog root instead of /feed page for better UX
- Verified ccusage tab is working correctly in insights app
- Verified dark mode still works on photos page (ThemeProvider properly configured)

## Changes Made
1. **Menu Simplification**: Removed `ThemeToggle` from navigation menu component
2. **Feed Link Fix**: Updated Feed navigation to point to blog root (`${BLOG_URL}`) instead of `/feed`
3. **Dark Mode**: Theme toggle remains available in footer as intended
4. **Routing**: Confirmed ccusage tab routing works correctly in insights app

## Test plan
- [x] Build all apps successfully with `yarn build`
- [x] Verify dark mode toggle still accessible in footer
- [x] Test Feed link points to correct destination
- [x] Confirm ccusage tab navigation works in insights app
- [x] Check that photos page dark mode styles are properly applied

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Simplify the navigation UX by removing the dark mode toggle from the main menu and updating the feed link to point to the blog root, while ensuring dark mode and insights routing remain functional.

Enhancements:
- Remove ThemeToggle from the navigation menu to reduce clutter
- Update the Feed menu link to use the blog root URL instead of the /feed path