### PR TITLE
refactor(insights): update navigation tab names and fix AI link

### DIFF
--- a/apps/insights/components/navigation/CompactNavigation.tsx
+++ b/apps/insights/components/navigation/CompactNavigation.tsx
@@ -31,28 +31,27 @@ const navItems: NavItem[] = [
     description: 'Dashboard overview with key metrics',
   },
   {
-    text: 'Website',
+    text: 'Blog',
     href: '/blog',
     icon: Globe,
     description: 'Traffic analytics from Cloudflare & PostHog',
   },
   {
-    text: 'Development',
+    text: 'Github',
     href: '/github',
     icon: Code,
     description: 'GitHub activity and repository insights',
   },
   {
-    text: 'Productivity',
+    text: 'Wakatime',
     href: '/wakatime',
     icon: Activity,
     description: 'Coding time and productivity tracking',
   },
   {
-    text: 'AI Usage',
-    href: '/ccusage',
+    text: 'AI',
+    href: '/ai',
     icon: BarChart3,
-    badge: 'New',
     description: 'Claude Code usage and cost analytics',
   },
 ]


### PR DESCRIPTION
## Summary
- Update navigation tab names for clarity and brevity
- Fix broken AI tab link

## Changes
- Rename navigation tabs:
  - "Website" → "Blog"
  - "Development" → "Github"  
  - "Productivity" → "Wakatime"
  - "AI Usage" → "AI"
- Remove "New" badge from AI tab
- Fix AI tab link from `/ccusage` to `/ai`

## Files Changed
- `apps/insights/components/navigation/CompactNavigation.tsx`

## Test Plan
- [ ] Navigate to insights app
- [ ] Verify all tab names are updated correctly
- [ ] Click on AI tab and verify it navigates to `/ai` page
- [ ] Ensure no visual regressions in navigation component

🤖 Generated with [Claude Code](https://claude.com/claude-code)