### PR TITLE
docs: update deployment URLs to Cloudflare Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 This monorepo contains the Nextjs version of the blog, cv, photo, etc.
 
-- **Blog: https://blog.duyet.net or https://duyet.vercel.app**
-- **Insights: https://insights.duyet.net or https://duyet-insights.vercel.app**
-- **CV: https://cv.duyet.net or https://duyet-cv.vercel.app**
-- **Photos: https://photos.duyet.net**
+- **Home: https://duyet.net or https://duyet-home.pages.dev**
+- **Blog: https://blog.duyet.net or https://duyet-blog.pages.dev**
+- **Insights: https://insights.duyet.net or https://duyet-insights.pages.dev**
+- **CV: https://cv.duyet.net or https://duyet-cv.pages.dev**
+- **Photos: https://photos.duyet.net or https://duyet-photos.pages.dev**
 
 ## 1. Blog
 


### PR DESCRIPTION
## Summary
- Update README.md with new Cloudflare Pages deployment URLs
- Add Home URL entry (duyet.net / duyet-home.pages.dev)
- Update Blog, CV, and Photos URLs from Vercel to Cloudflare Pages

## Changes
- ✅ Added Home section with duyet.net and duyet-home.pages.dev
- ✅ Updated Blog URL to duyet-blog.pages.dev
- ✅ Updated CV URL to duyet-cv.pages.dev  
- ✅ Updated Photos URL to include duyet-photos.pages.dev

## Test plan
- [ ] Verify all URLs are accessible
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update README with new Cloudflare Pages deployment URLs and add a Home link

Documentation:
- Add Home URL entry pointing to duyet.net and duyet-home.pages.dev
- Update Blog, CV, and Photos URLs to use Cloudflare Pages domains