### PR TITLE
feat: add /ping health check endpoint to all apps

### DIFF
--- a/apps/blog/app/ping/route.ts
+++ b/apps/blog/app/ping/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-static'
+
+export function GET(): NextResponse {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+      },
+    },
+  )
+}

--- a/apps/blog/app/ping/route.ts
+++ b/apps/blog/app/ping/route.ts
@@ -6,12 +6,10 @@ export function GET(): NextResponse {
   return NextResponse.json(
     {
       status: 'ok',
-      timestamp: new Date().toISOString(),
     },
     {
       headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     },
   )

--- a/apps/cv/app/ping/route.ts
+++ b/apps/cv/app/ping/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-static'
+
+export function GET(): NextResponse {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+      },
+    },
+  )
+}

--- a/apps/cv/app/ping/route.ts
+++ b/apps/cv/app/ping/route.ts
@@ -6,12 +6,10 @@ export function GET(): NextResponse {
   return NextResponse.json(
     {
       status: 'ok',
-      timestamp: new Date().toISOString(),
     },
     {
       headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     },
   )

--- a/apps/home/app/ping/route.ts
+++ b/apps/home/app/ping/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-static'
+
+export function GET(): NextResponse {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+      },
+    },
+  )
+}

--- a/apps/home/app/ping/route.ts
+++ b/apps/home/app/ping/route.ts
@@ -10,6 +10,7 @@ export function GET(): NextResponse {
     },
     {
       headers: {
+        'Content-Type': 'application/json',
         'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
       },
     },

--- a/apps/home/app/ping/route.ts
+++ b/apps/home/app/ping/route.ts
@@ -6,12 +6,10 @@ export function GET(): NextResponse {
   return NextResponse.json(
     {
       status: 'ok',
-      timestamp: new Date().toISOString(),
     },
     {
       headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     },
   )

--- a/apps/insights/app/ping/route.ts
+++ b/apps/insights/app/ping/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-static'
+
+export function GET(): NextResponse {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+      },
+    },
+  )
+}

--- a/apps/insights/app/ping/route.ts
+++ b/apps/insights/app/ping/route.ts
@@ -6,12 +6,10 @@ export function GET(): NextResponse {
   return NextResponse.json(
     {
       status: 'ok',
-      timestamp: new Date().toISOString(),
     },
     {
       headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     },
   )

--- a/apps/photos/app/ping/route.ts
+++ b/apps/photos/app/ping/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-static'
+
+export function GET(): NextResponse {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+      },
+    },
+  )
+}

--- a/apps/photos/app/ping/route.ts
+++ b/apps/photos/app/ping/route.ts
@@ -6,12 +6,10 @@ export function GET(): NextResponse {
   return NextResponse.json(
     {
       status: 'ok',
-      timestamp: new Date().toISOString(),
     },
     {
       headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+        'Cache-Control': 'public, max-age=3600, s-maxage=3600',
       },
     },
   )


### PR DESCRIPTION
## Summary
- Add health check endpoint at `/ping` for all apps:
  - **home** (https://duyet.net/ping)
  - **blog** (https://blog.duyet.net/ping)
  - **cv** (https://cv.duyet.net/ping)
  - **insights** (https://insights.duyet.net/ping)
  - **photos** (https://photos.duyet.net/ping)
- Returns simple JSON response: `{"status":"ok"}`
- Configured with static generation (`force-static`)
- Cache headers for 1 hour (3600s)
- Verified builds to static files correctly

## Implementation
- Uses `NextResponse.json()` which automatically sets `Content-Type: application/json`
- No manual Content-Type header needed (was causing download issue)
- No timestamp for consistent caching
- Static generation for optimal performance

## Test plan
- [x] Type checking passed
- [x] Commit hook tests passed
- [x] Static build verified (builds to `○ /ping` static route)
- [ ] Deploy to staging and verify all endpoints return proper JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)