### PR TITLE
fix(ui): unify dark mode colors across all apps

### DIFF
--- a/apps/blog/app/layout.tsx
+++ b/apps/blog/app/layout.tsx
@@ -47,8 +47,8 @@ export default function RootLayout({
       {/* <AxiomWebVitals /> */}
       <body
         className={cn(
-          'bg-white text-gray-700 subpixel-antialiased',
-          'transition-colors duration-1000 dark:bg-slate-900 dark:text-slate-50',
+          'bg-[var(--background)] text-[var(--foreground)] subpixel-antialiased',
+          'transition-colors duration-1000',
         )}
       >
         <ThemeProvider>

--- a/apps/cv/app/layout.tsx
+++ b/apps/cv/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({ children }: LayoutProps) {
     >
       <Head />
 
-      <body className="bg-white text-gray-700 antialiased dark:bg-slate-900 dark:text-slate-50">
+      <body className="bg-[var(--background)] text-[var(--foreground)] antialiased">
         <ThemeProvider>
           <main>
             <Container className="mb-20 mt-10 min-h-screen max-w-3xl md:mt-20 print:mb-10 print:mt-10">

--- a/apps/insights/app/layout.tsx
+++ b/apps/insights/app/layout.tsx
@@ -1,3 +1,4 @@
+import '@duyet/components/styles.css'
 import './globals.css'
 
 import Analytics from '@duyet/components/Analytics'
@@ -30,7 +31,7 @@ export default function RootLayout({ children }: LayoutProps) {
   return (
     <html className={inter.className} lang="en" suppressHydrationWarning>
       <Head />
-      <body className="bg-white text-gray-700 antialiased dark:bg-slate-900 dark:text-slate-50">
+      <body className="bg-[var(--background)] text-[var(--foreground)] antialiased">
         <ThemeProvider>
           <Header longText="Insights" shortText="Insights" />
 

--- a/apps/photos/app/globals.css
+++ b/apps/photos/app/globals.css
@@ -3,8 +3,8 @@
 @tailwind utilities;
 
 :root {
-  --background: hsl(0 0% 100%);
-  --foreground: hsl(222.2 47.4% 11.2%);
+  --background: #ffffff; /* Unified: white */
+  --foreground: #374151; /* Unified: gray-700 */
 
   --muted: hsl(210 40% 96.1%);
   --muted-foreground: hsl(215.4 16.3% 46.9%);
@@ -36,8 +36,8 @@
 }
 
 .dark {
-  --background: hsl(224 71% 4%);
-  --foreground: hsl(213 31% 91%);
+  --background: #0f172a; /* Unified: slate-900 */
+  --foreground: #f8fafc; /* Unified: slate-50 */
 
   --muted: hsl(223 47% 11%);
   --muted-foreground: hsl(215.4 16.3% 56.9%);

--- a/apps/photos/app/layout.tsx
+++ b/apps/photos/app/layout.tsx
@@ -66,8 +66,8 @@ export default function RootLayout({
       <Head />
       <body
         className={cn(
-          'bg-white text-gray-700 subpixel-antialiased',
-          'transition-colors duration-1000 dark:bg-slate-900 dark:text-slate-50',
+          'bg-[var(--background)] text-[var(--foreground)] subpixel-antialiased',
+          'transition-colors duration-1000',
         )}
       >
         <ThemeProvider>

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -18,4 +18,17 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
+
+  /* Unified dark mode CSS variables for consistent theming across all apps */
+  :root {
+    /* Light mode colors */
+    --background: #ffffff;
+    --foreground: #374151; /* gray-700 */
+  }
+
+  :root.dark {
+    /* Dark mode colors - consistent across blog, cv, insights */
+    --background: #0f172a; /* slate-900 */
+    --foreground: #f8fafc; /* slate-50 */
+  }
 }


### PR DESCRIPTION
## 🎨 Summary

Fixes #279 - Dark Mode Inconsistency Across Subdomains

This PR establishes a unified dark mode color scheme across **all apps** (blog, cv, insights, photos) by introducing shared CSS variables.

## 🔧 Changes

### Core Changes
- **`packages/components/styles.css`**: Added unified CSS variables for light and dark mode
  - `--background`: `#ffffff` (light) / `#0f172a` (dark - slate-900)
  - `--foreground`: `#374151` (light - gray-700) / `#f8fafc` (dark - slate-50)

### App Updates (4 apps)
- **`apps/insights/app/layout.tsx`**: 
  - ✅ Added import for `@duyet/components/styles.css`
  - ✅ Replaced hardcoded colors with CSS variables
  
- **`apps/blog/app/layout.tsx`**:
  - ✅ Replaced hardcoded colors with CSS variables
  - ✅ Preserved transition animation
  
- **`apps/cv/app/layout.tsx`**:
  - ✅ Replaced hardcoded colors with CSS variables

- **`apps/photos/app/globals.css`**:
  - ✅ Updated existing CSS variables to match unified values
  - ✅ Compatible with Tailwind v3 setup

## ✅ Benefits

1. **Visual Consistency**: All apps now use identical dark mode colors
2. **Maintainability**: Single source of truth for base theming
3. **Future-proof**: Easy to update colors globally
4. **No Breaking Changes**: All 4 apps build successfully

## 🧪 Testing

- ✅ All apps build successfully (`yarn build`)
- ✅ Linting passes (`yarn lint`)
- ✅ Code formatted with Prettier (`yarn fmt`)
- ✅ No TypeScript errors

## 📸 Visual Changes

**Before:**
- Different color values and approaches across apps
- Insights missing shared styles import

**After:**
- All apps use consistent `--background` and `--foreground` CSS variables
- Unified slate-900/slate-50 dark mode palette

## 🔄 Cross-Subdomain State Sync (Future Enhancement)

**Note**: This PR fixes **color consistency**. Theme state (dark/light preference) is still stored in localStorage per domain.

For cross-subdomain theme synchronization (blog.duyet.net ↔ cv.duyet.net), see follow-up discussion in #279.

## 🚀 Deployment

Ready to merge - all checks passing.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>