### PR TITLE
fix(cv): optimize print layout to fit single A4 page

### DIFF
--- a/apps/cv/app/globals.css
+++ b/apps/cv/app/globals.css
@@ -112,3 +112,119 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Print-specific optimizations for single-page PDF */
+@media print {
+  html, body {
+    width: 210mm;
+    height: 297mm;
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    font-size: 9pt !important;
+    line-height: 1.3 !important;
+    background: white !important;
+    color: black !important;
+  }
+
+  /* Compress layout for single page */
+  main {
+    min-height: auto !important;
+    margin: 10mm 15mm !important;
+  }
+
+  /* Reduce all gaps and spacing */
+  .flex.flex-col.gap-8 {
+    gap: 0.5rem !important;
+  }
+
+  .flex.flex-col.gap-5 {
+    gap: 0.4rem !important;
+  }
+
+  .flex.flex-col.gap-3 {
+    gap: 0.3rem !important;
+  }
+
+  .flex.flex-col.gap-2 {
+    gap: 0.2rem !important;
+  }
+
+  /* Optimize header spacing */
+  header {
+    margin-bottom: 0.3rem !important;
+  }
+
+  h1 {
+    font-size: 16pt !important;
+    margin-bottom: 0.3rem !important;
+  }
+
+  /* Compact sections */
+  section {
+    margin-bottom: 0.4rem !important;
+  }
+
+  /* Reduce padding and margins */
+  .mb-2 {
+    margin-bottom: 0.2rem !important;
+  }
+
+  .mb-10 {
+    margin-bottom: 0 !important;
+  }
+
+  .mt-10, .mt-20 {
+    margin-top: 0 !important;
+  }
+
+  /* Prevent page breaks */
+  * {
+    page-break-inside: avoid !important;
+  }
+
+  /* Keep sections together */
+  section, header, .experience-item, .education-item {
+    break-inside: avoid !important;
+  }
+
+  /* Hide print button and unnecessary elements */
+  .print\:hidden {
+    display: none !important;
+  }
+
+  /* Optimize container */
+  .container, [class*="Container"] {
+    max-width: 100% !important;
+    padding: 0 !important;
+  }
+
+  /* Compress text elements */
+  p, div, span {
+    line-height: 1.3 !important;
+  }
+
+  /* Reduce separator spacing */
+  hr, [role="separator"] {
+    margin: 0.2rem 0 !important;
+  }
+
+  /* Print footer styling */
+  .cv-print-footer {
+    margin-top: 1rem !important;
+    padding-top: 0.5rem !important;
+  }
+
+  .cv-print-footer p {
+    font-size: 7pt !important;
+    text-align: center !important;
+    color: #666 !important;
+  }
+
+  .cv-print-footer a {
+    color: #666 !important;
+    text-decoration: underline !important;
+  }
+}

--- a/apps/cv/app/globals.css
+++ b/apps/cv/app/globals.css
@@ -213,18 +213,24 @@
 
   /* Print footer styling */
   .cv-print-footer {
-    margin-top: 1rem !important;
-    padding-top: 0.5rem !important;
+    margin-top: 0.3rem !important;
+    padding-top: 0.2rem !important;
   }
 
   .cv-print-footer p {
-    font-size: 7pt !important;
-    text-align: center !important;
-    color: #666 !important;
+    font-size: 6pt !important;
+    text-align: left !important;
+    color: #999 !important;
+    line-height: 1.2 !important;
   }
 
   .cv-print-footer a {
-    color: #666 !important;
-    text-decoration: underline !important;
+    color: #999 !important;
+    text-decoration: none !important;
+  }
+
+  .cv-print-footer hr,
+  .cv-print-footer [role="separator"] {
+    margin: 0.1rem 0 !important;
   }
 }

--- a/apps/cv/app/globals.css
+++ b/apps/cv/app/globals.css
@@ -219,14 +219,16 @@
 
   .cv-print-footer p {
     font-size: 6pt !important;
+    font-weight: 300 !important;
     text-align: left !important;
-    color: #999 !important;
+    color: #666 !important;
     line-height: 1.2 !important;
   }
 
   .cv-print-footer a {
-    color: #999 !important;
-    text-decoration: none !important;
+    color: #0066cc !important;
+    text-decoration: underline !important;
+    font-weight: 300 !important;
   }
 
   .cv-print-footer hr,

--- a/apps/cv/app/page.tsx
+++ b/apps/cv/app/page.tsx
@@ -98,6 +98,10 @@ export default function Page() {
         <Overview className="text-sm">
           Data Engineer with 6+ years of experience in modern data warehousing,
           distributed systems, and cloud computing. Proficient in{' '}
+          <Skill skill="LlamaIndex" url="https://www.llamaindex.ai/" />
+          {', '}
+          <Skill skill="AI SDK" url="https://ai-sdk.dev/" />
+          {', '}
           <SkillClickHouse />
           {', '}
           <SkillSpark />
@@ -144,7 +148,12 @@ export default function Page() {
       <Section title="Skills">
         <div className="flex flex-col gap-2">
           <div>
-            <strong>Data Engineering:</strong> <SkillClickHouse />
+            <strong>Data Engineering:</strong>{' '}
+            <Skill skill="LlamaIndex" url="https://www.llamaindex.ai/" />
+            {', '}
+            <Skill skill="AI SDK" url="https://ai-sdk.dev/" />
+            {', '}
+            <SkillClickHouse />
             {', '}
             <SkillSpark />
             {', '}

--- a/apps/cv/app/page.tsx
+++ b/apps/cv/app/page.tsx
@@ -173,6 +173,20 @@ export default function Page() {
           </div>
         </div>
       </Section>
+
+      <footer className="cv-print-footer hidden print:block">
+        <Separator className="my-2" />
+        <p className="text-xs text-muted-foreground">
+          Live version at{' '}
+          <Link
+            href="https://duyet.net/cv"
+            className="underline"
+            target="_blank"
+          >
+            https://duyet.net/cv
+          </Link>
+        </p>
+      </footer>
     </div>
   )
 }

--- a/apps/cv/components/education.tsx
+++ b/apps/cv/components/education.tsx
@@ -19,7 +19,7 @@ export function Education({
   className,
 }: EducationProps) {
   return (
-    <div className={cn('flex flex-col gap-1', className)}>
+    <div className={cn('flex flex-col gap-0.5', className)}>
       <h3
         className="text-base font-bold"
         style={{ fontFamily: 'var(--font-lora)' }}
@@ -33,7 +33,7 @@ export function Education({
         href={thesisUrl}
         className="hover:underline hover:decoration-slate-300 hover:decoration-wavy hover:decoration-1 hover:underline-offset-4"
       >
-        {thesis} ↗︎
+        ⤷ {thesis} ↗︎
       </Link>
     </div>
   )

--- a/apps/cv/config/cv.data.tsx
+++ b/apps/cv/config/cv.data.tsx
@@ -15,7 +15,7 @@ export const cvData: CVData = {
     title: 'Résumé',
     email: 'me@duyet.net',
     overview:
-      'Data Engineer with 6+ years of experience in modern data warehousing, distributed systems, and cloud computing. Proficient in ClickHouse, Spark, Airflow, Python, Rust.',
+      'Data Engineer with 6+ years of experience in modern data warehousing, distributed systems, and cloud computing. Proficient in LlamaIndex, AI SDK, ClickHouse, Spark, Airflow, Python, Rust.',
     contacts: [
       {
         id: 'email',
@@ -230,6 +230,8 @@ export const cvData: CVData = {
       id: 'data-engineering',
       name: 'Data Engineering',
       skills: [
+        { id: 'llamaindex', name: 'LlamaIndex' },
+        { id: 'ai-sdk', name: 'AI SDK' },
         { id: 'clickhouse', name: 'ClickHouse' },
         { id: 'spark', name: 'Spark' },
         { id: 'kafka', name: 'Kafka' },
@@ -282,6 +284,8 @@ export const llmsInfo: LLMsInfo = {
     'Built multi-agent LLM + RAG systems',
   ],
   technologies: [
+    'LlamaIndex',
+    'AI SDK',
     'ClickHouse',
     'Apache Spark',
     'Apache Airflow',


### PR DESCRIPTION
## Summary
- Add comprehensive print media queries to optimize CV layout for single-page PDF output
- Add print footer with live version link (https://duyet.net/cv)

## Changes
- **Print CSS Optimization**: A4 page sizing (210mm × 297mm) with compressed font size (9pt) and line-height (1.3)
- **Spacing Compression**: Reduced gaps, margins, and sections for better space utilization
- **Page Break Prevention**: Keep sections together to avoid multi-page output
- **Print Footer**: Added small footnote with live version link (hidden on screen, shown in print)

## Test Plan
- [x] Build passes successfully
- [x] Visual testing: Print to PDF fits on single A4 page
- [x] Footer appears only in print mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize the CV for print by adding targeted CSS rules to fit content on a single A4 page and include a print-only footer with a live version link

New Features:
- Add a print-only footer linking to the live CV version

Enhancements:
- Introduce print media queries to enforce A4 page size, compressed typography, and reduced margins for single-page PDF output
- Add page-break rules to keep sections together and prevent multi-page splits