### PR TITLE
fix(photos): improve photo grid layout with responsive spacing

### DIFF
--- a/apps/photos/components/PhotoGrid.tsx
+++ b/apps/photos/components/PhotoGrid.tsx
@@ -67,7 +67,7 @@ export default function PhotoGrid({ photos, className }: PhotoGridProps) {
 
   return (
     <ErrorBoundary>
-      <div className={cn('w-full', className)}>
+      <div className={cn('w-full px-4 md:px-6 lg:px-8', className)}>
         <Masonry
           breakpointCols={MASONRY_CONFIG.breakpoints}
           className={masonryClasses.container}

--- a/apps/photos/lib/GridUtilities.ts
+++ b/apps/photos/lib/GridUtilities.ts
@@ -60,15 +60,15 @@ export function getColumnsForViewport(width: number): number {
 
 /**
  * Generate responsive CSS classes for masonry grid
- * Updated for seamless fit with no padding or gaps
+ * Applies responsive gaps between columns and photos
  */
 export function getMasonryClasses(): {
   container: string
   column: string
 } {
   return {
-    container: 'flex w-full',
-    column: 'bg-clip-padding',
+    container: 'flex w-full gap-4 md:gap-6 lg:gap-8',
+    column: 'bg-clip-padding space-y-4 md:space-y-6 lg:space-y-8',
   }
 }
 


### PR DESCRIPTION
Add responsive gaps between masonry grid columns and individual photos. This prevents photos from appearing cramped edge-to-edge and provides better visual breathing room:

- Add horizontal padding (px-4/md:px-6/lg:px-8) to photo grid container
- Add responsive gaps between columns (gap-4/md:gap-6/lg:gap-8)
- Add vertical spacing between photos in columns (space-y-4/md:space-y-6/lg:space-y-8)
- Update grid utility comments to reflect proper spacing implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve the photo grid layout by adding responsive horizontal padding to the container and introducing gaps between columns and vertical spacing between photos.

Enhancements:
- Add horizontal padding (px-4/md:px-6/lg:px-8) to the photo grid container
- Introduce responsive gaps between masonry columns (gap-4/md:gap-6/lg:gap-8)
- Add responsive vertical spacing between photos in each column (space-y-4/md:space-y-6/lg:space-y-8)