### PR TITLE
feat(home): Redesign homepage with Anthropic-inspired card layout

### DIFF
--- a/apps/blog/app/page.tsx
+++ b/apps/blog/app/page.tsx
@@ -25,7 +25,7 @@ export default async function Page() {
     .map(([tag]) => tag)
 
   return (
-    <div className="min-h-screen bg-neutral-50 pb-10">
+    <div className="bg-cream-warm min-h-screen pb-10">
       <Header longText="Data Engineering" />
       <Container>
         <div className="mb-12 text-center">

--- a/apps/blog/components/content-card.tsx
+++ b/apps/blog/components/content-card.tsx
@@ -1,0 +1,116 @@
+import {
+  GeometricPattern,
+  OrganicBlob,
+  WavyLines,
+} from '@duyet/components/illustrations/AbstractShapes'
+import { cn } from '@duyet/libs/utils'
+import Link from 'next/link'
+
+interface ContentCardProps {
+  title: string
+  href: string
+  category?: string
+  description?: string
+  tags?: string[]
+  date?: string
+  color?: 'ivory' | 'oat' | 'cream' | 'cactus' | 'sage' | 'lavender'
+  illustration?: 'wavy' | 'geometric' | 'blob' | 'none'
+  className?: string
+}
+
+const colorClasses = {
+  ivory: 'bg-ivory text-neutral-900',
+  oat: 'bg-oat-light text-neutral-900',
+  cream: 'bg-cream text-neutral-900',
+  cactus: 'bg-cactus-light text-neutral-900',
+  sage: 'bg-sage-light text-neutral-900',
+  lavender: 'bg-lavender-light text-neutral-900',
+}
+
+const illustrationColorClasses = {
+  ivory: 'text-neutral-400',
+  oat: 'text-neutral-400',
+  cream: 'text-neutral-400',
+  cactus: 'text-cactus',
+  sage: 'text-sage',
+  lavender: 'text-lavender',
+}
+
+const illustrations = {
+  wavy: WavyLines,
+  geometric: GeometricPattern,
+  blob: OrganicBlob,
+  none: null,
+}
+
+export function ContentCard({
+  title,
+  href,
+  category,
+  description,
+  tags,
+  date,
+  color = 'ivory',
+  illustration = 'none',
+  className,
+}: ContentCardProps) {
+  const IllustrationComponent = illustrations[illustration]
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'group relative overflow-hidden rounded-2xl p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-md',
+        colorClasses[color],
+        className,
+      )}
+    >
+      <div className="relative z-10 flex min-h-[200px] flex-col gap-3">
+        {category && (
+          <div className="inline-flex items-center">
+            <span className="rounded-full bg-white/70 px-3 py-1 text-xs font-medium uppercase tracking-wide">
+              {category}
+            </span>
+          </div>
+        )}
+
+        <h3 className="font-serif text-xl font-bold leading-snug md:text-2xl">
+          {title}
+        </h3>
+
+        {description && (
+          <p className="line-clamp-3 text-sm leading-relaxed text-neutral-700">
+            {description}
+          </p>
+        )}
+
+        <div className="mt-auto flex flex-col gap-2">
+          {tags && tags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {tags.slice(0, 3).map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full bg-white/70 px-2.5 py-0.5 text-xs font-medium text-neutral-700"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {date && (
+            <time className="text-xs font-medium text-neutral-600">{date}</time>
+          )}
+        </div>
+      </div>
+
+      {IllustrationComponent && (
+        <div className="absolute bottom-0 right-0 h-32 w-32 opacity-20 transition-opacity group-hover:opacity-30">
+          <IllustrationComponent
+            className={cn('h-full w-full', illustrationColorClasses[color])}
+          />
+        </div>
+      )}
+    </Link>
+  )
+}

--- a/apps/blog/components/featured-card.tsx
+++ b/apps/blog/components/featured-card.tsx
@@ -1,0 +1,78 @@
+import { AbstractShapes } from '@duyet/components/illustrations/AbstractShapes'
+import { cn } from '@duyet/libs/utils'
+import Link from 'next/link'
+
+interface FeaturedCardProps {
+  title: string
+  href: string
+  category?: string
+  description?: string
+  date?: string
+  color?: 'terracotta' | 'sage' | 'coral' | 'lavender'
+  className?: string
+}
+
+const colorClasses = {
+  terracotta: 'bg-terracotta-light text-neutral-900',
+  sage: 'bg-sage-light text-neutral-900',
+  coral: 'bg-coral-light text-neutral-900',
+  lavender: 'bg-lavender-light text-neutral-900',
+}
+
+const illustrationColors = {
+  terracotta: 'text-terracotta',
+  sage: 'text-sage',
+  coral: 'text-coral',
+  lavender: 'text-lavender',
+}
+
+export function FeaturedCard({
+  title,
+  href,
+  category,
+  description,
+  date,
+  color = 'terracotta',
+  className,
+}: FeaturedCardProps) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'group relative overflow-hidden rounded-3xl p-8 transition-all duration-300 hover:shadow-lg md:p-12',
+        colorClasses[color],
+        className,
+      )}
+    >
+      <div className="relative z-10 flex flex-col gap-4">
+        {category && (
+          <div className="inline-flex items-center">
+            <span className="rounded-full bg-white/80 px-3 py-1 text-xs font-medium uppercase tracking-wide">
+              {category}
+            </span>
+          </div>
+        )}
+
+        <h2 className="max-w-2xl font-serif text-3xl font-bold leading-tight md:text-4xl">
+          {title}
+        </h2>
+
+        {description && (
+          <p className="max-w-xl text-lg leading-relaxed text-neutral-700">
+            {description}
+          </p>
+        )}
+
+        {date && (
+          <time className="text-sm font-medium text-neutral-600">{date}</time>
+        )}
+      </div>
+
+      <div className="absolute bottom-0 right-0 h-48 w-48 opacity-30 transition-opacity group-hover:opacity-40 md:h-64 md:w-64">
+        <AbstractShapes
+          className={cn('h-full w-full', illustrationColors[color])}
+        />
+      </div>
+    </Link>
+  )
+}

--- a/apps/blog/components/home-cards.tsx
+++ b/apps/blog/components/home-cards.tsx
@@ -1,5 +1,6 @@
 import type { Series } from '@duyet/interfaces'
-import Link from 'next/link'
+import { ContentCard } from './content-card'
+import { FeaturedCard } from './featured-card'
 
 interface HomeCardsProps {
   seriesList: Series[]
@@ -8,62 +9,65 @@ interface HomeCardsProps {
 
 export function HomeCards({ seriesList, topTags }: HomeCardsProps) {
   return (
-    <div className="mb-12 grid grid-cols-1 gap-4 md:grid-cols-2">
-      <div className="flex flex-col gap-4">
-        <Link
-          href="/featured"
-          className="bg-cactus-light group flex flex-col rounded-2xl p-6 transition-all hover:scale-[1.02]"
-        >
-          <h3 className="font-serif text-xl font-bold text-neutral-900">
-            Featured Posts →
-          </h3>
-        </Link>
+    <div className="mb-16 flex flex-col gap-6">
+      <FeaturedCard
+        title="Featured Posts"
+        href="/featured"
+        category="Highlights"
+        description="Explore my most popular and impactful articles on data engineering, software architecture, and technology insights."
+        color="terracotta"
+      />
 
-        <Link
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        <ContentCard
+          title="Explore by Topics"
           href="/tags"
-          className="bg-ivory-medium group flex min-h-[140px] flex-col rounded-2xl p-6 transition-all hover:scale-[1.02]"
-        >
-          <h3 className="mb-3 font-serif text-xl font-bold text-neutral-900">
-            Tags
-          </h3>
-          {topTags.length > 0 && (
-            <div className="mt-auto flex flex-wrap gap-2">
-              {topTags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full bg-white px-3 py-1 text-xs font-medium text-neutral-800"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
-        </Link>
+          category="Browse"
+          description="Discover content organized by technology, tools, and concepts."
+          tags={topTags}
+          color="oat"
+          illustration="geometric"
+        />
+
+        <ContentCard
+          title="Series"
+          href="/series"
+          category="Deep Dives"
+          description="Comprehensive multi-part guides on specific topics and technologies."
+          tags={seriesList.map((s) => s.name)}
+          color="sage"
+          illustration="wavy"
+        />
       </div>
 
-      <Link
-        href="/series"
-        className="bg-lavender group flex min-h-[140px] flex-col rounded-2xl p-6 transition-all hover:scale-[1.02]"
-      >
-        <h3 className="mb-2 font-serif text-xl font-bold text-neutral-900">
-          Series
-        </h3>
-        <p className="mb-3 text-sm text-neutral-700">
-          Deep dives into specific topics
-        </p>
-        {seriesList.length > 0 && (
-          <div className="mt-auto flex flex-wrap gap-2">
-            {seriesList.map((series) => (
-              <span
-                key={series.slug}
-                className="rounded-full bg-white px-3 py-1 text-xs font-medium text-neutral-800"
-              >
-                {series.name}
-              </span>
-            ))}
-          </div>
-        )}
-      </Link>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        <ContentCard
+          title="Latest Posts"
+          href="/feed"
+          category="Recent"
+          description="Stay updated with my newest articles and insights."
+          color="cream"
+          illustration="blob"
+        />
+
+        <ContentCard
+          title="Archives"
+          href="/archives"
+          category="History"
+          description="Browse through years of technical content and learning."
+          color="ivory"
+          illustration="geometric"
+        />
+
+        <ContentCard
+          title="About Me"
+          href="/about"
+          category="Profile"
+          description="Learn more about my journey in technology and data engineering."
+          color="lavender"
+          illustration="wavy"
+        />
+      </div>
     </div>
   )
 }

--- a/apps/blog/tailwind.config.mjs
+++ b/apps/blog/tailwind.config.mjs
@@ -13,7 +13,9 @@ export default {
       },
       colors: {
         ivory: {
+          DEFAULT: '#f5f3ef',
           medium: '#f0eee6',
+          light: '#f9f8f5',
         },
         cactus: {
           DEFAULT: '#bcd1ca',
@@ -22,12 +24,28 @@ export default {
         },
         oat: {
           DEFAULT: '#e3dacc',
+          light: '#ebe5db',
         },
         sage: {
           DEFAULT: '#b8ccc5',
+          light: '#d0ddd8',
         },
         lavender: {
           DEFAULT: '#c5c8dc',
+          light: '#dfe0ec',
+        },
+        terracotta: {
+          DEFAULT: '#e07856',
+          light: '#f4b8a0',
+          medium: '#e89879',
+        },
+        coral: {
+          DEFAULT: '#f39c7a',
+          light: '#ffc4a8',
+        },
+        cream: {
+          DEFAULT: '#faf8f3',
+          warm: '#f7f4ee',
         },
       },
     },

--- a/packages/components/illustrations/AbstractShapes.tsx
+++ b/packages/components/illustrations/AbstractShapes.tsx
@@ -1,0 +1,139 @@
+interface AbstractShapesProps {
+  className?: string
+}
+
+export function AbstractShapes({ className = '' }: AbstractShapesProps) {
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M50,80 Q60,70 70,80 T90,80"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        fill="none"
+        opacity="0.6"
+      />
+      <circle
+        cx="140"
+        cy="60"
+        r="20"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        opacity="0.5"
+      />
+      <path
+        d="M30,120 L50,140 L70,120 Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        opacity="0.4"
+      />
+      <rect
+        x="120"
+        y="120"
+        width="40"
+        height="40"
+        rx="8"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        opacity="0.5"
+      />
+    </svg>
+  )
+}
+
+export function WavyLines({ className = '' }: AbstractShapesProps) {
+  return (
+    <svg
+      viewBox="0 0 200 120"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M0,40 Q50,20 100,40 T200,40"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        fill="none"
+        opacity="0.5"
+      />
+      <path
+        d="M0,70 Q50,50 100,70 T200,70"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        fill="none"
+        opacity="0.4"
+      />
+    </svg>
+  )
+}
+
+export function GeometricPattern({ className = '' }: AbstractShapesProps) {
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <g opacity="0.3">
+        <circle cx="50" cy="50" r="8" fill="currentColor" />
+        <circle cx="100" cy="30" r="6" fill="currentColor" />
+        <circle cx="150" cy="60" r="10" fill="currentColor" />
+        <circle cx="80" cy="120" r="7" fill="currentColor" />
+        <circle cx="140" cy="140" r="9" fill="currentColor" />
+      </g>
+      <path
+        d="M40,100 L60,80 L80,100 L60,120 Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+        opacity="0.4"
+      />
+      <path
+        d="M120,90 L140,110 L160,90"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        fill="none"
+        opacity="0.5"
+      />
+    </svg>
+  )
+}
+
+export function OrganicBlob({ className = '' }: AbstractShapesProps) {
+  return (
+    <svg
+      viewBox="0 0 200 200"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M100,30 C130,30 160,50 170,80 C180,110 170,140 150,160 C130,180 110,190 80,180 C50,170 30,150 25,120 C20,90 40,50 70,35 C80,30 90,30 100,30 Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        opacity="0.4"
+      />
+      <path
+        d="M100,60 Q120,60 130,80 T140,120"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        fill="none"
+        opacity="0.5"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary

Comprehensive homepage redesign inspired by the Anthropic design aesthetic, featuring a modern card-based layout with hand-drawn illustrations and warm color palette.

### Design System Enhancements
- Added terracotta, coral, and cream color variants to Tailwind config
- Extended existing color palette (ivory, oat, sage, lavender) with light variants
- Updated homepage background to warm cream tone for better visual warmth

### New Components
- **FeaturedCard**: Large hero card for featured content with integrated illustrations
- **ContentCard**: Flexible card component with category labels, descriptions, and tags
- **SVG Illustrations**: Hand-drawn style components (AbstractShapes, WavyLines, GeometricPattern, OrganicBlob)

### Layout Improvements
- Large featured card at the top with prominent call-to-action
- 2-column grid for primary navigation cards (Topics, Series)
- 3-column grid for secondary navigation (Latest, Archives, About)
- Fully responsive mobile-first design
- Smooth hover animations and transitions

### Visual Design
- Warm, inviting color palette (terracotta, sage green, coral, beige)
- Minimalist hand-drawn style illustrations
- Category labels with rounded badge styling
- Clear typography hierarchy with serif headings
- Subtle shadows and smooth transitions

### Technical Details
- TypeScript type-safe components
- Tailwind CSS utility classes
- Next.js 15 compatible
- Accessible markup with semantic HTML
- Optimized SVG illustrations

## Test Plan
- [x] TypeScript type checking passes
- [x] Code formatting with Prettier
- [x] Production build successful
- [x] Responsive design verified
- [x] Hover states and transitions working
- [ ] Visual regression testing
- [ ] Accessibility audit
- [ ] Cross-browser testing

## Screenshots

The new design features:
1. Large featured card with terracotta background and hand-drawn illustration
2. 2-column grid with Topics (oat) and Series (sage) cards
3. 3-column grid with Latest (cream), Archives (ivory), and About (lavender) cards

Generated with Claude Code

## Summary by Sourcery

Redesign the homepage with an Anthropic-inspired card layout, introducing reusable card components, hand-drawn illustration assets, and an expanded warm color palette for a modern, responsive experience

New Features:
- Introduce FeaturedCard and ContentCard components for modular card-based homepage sections
- Add hand-drawn style SVG illustration components (AbstractShapes, WavyLines, GeometricPattern, OrganicBlob)
- Expand Tailwind CSS theme with new warm color variants (terracotta, coral, cream, and extended light tones)

Enhancements:
- Redesign homepage with a warm cream background, responsive card grids, and smooth hover animations
- Ensure TypeScript type safety and accessible semantic markup throughout the new components