### PR TITLE
feat(home): Add AI chatbot link to home app

### DIFF
--- a/apps/home/app/components/icons/AIIcon.tsx
+++ b/apps/home/app/components/icons/AIIcon.tsx
@@ -1,0 +1,26 @@
+export default function AIIcon() {
+  return (
+    <svg
+      width="80"
+      height="80"
+      viewBox="0 0 64 64"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="transition-transform duration-300 ease-out group-hover:scale-110"
+    >
+      {/* Chat bubble */}
+      <path
+        d="M12 10C10.8954 10 10 10.8954 10 12V40C10 41.1046 10.8954 42 12 42H36L48 52V42H52C53.1046 42 54 41.1046 54 40V12C54 10.8954 53.1046 10 52 10H12Z"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      {/* Dots inside (representing AI thinking/typing) */}
+      <circle cx="22" cy="26" r="2.5" fill="currentColor" />
+      <circle cx="32" cy="26" r="2.5" fill="currentColor" />
+      <circle cx="42" cy="26" r="2.5" fill="currentColor" />
+    </svg>
+  )
+}

--- a/apps/home/app/config/urls.ts
+++ b/apps/home/app/config/urls.ts
@@ -13,6 +13,7 @@ export const urls: Urls = {
   '/llms.txt': { target: '/llms.txt', desc: 'LLMs.txt', system: true },
 
   '/': 'https://duyet.net',
+  '/ai': { target: 'https://ai.duyet.net', desc: 'AI chatbot' },
   '/blog': 'https://blog.duyet.net',
   '/cv': 'https://cv.duyet.net',
   '/about': { target: '/about', desc: 'about me', system: false },

--- a/apps/home/app/page.tsx
+++ b/apps/home/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import AboutIcon from './components/icons/AboutIcon'
+import AIIcon from './components/icons/AIIcon'
 import BlogIcon from './components/icons/BlogIcon'
 import HomelabIcon from './components/icons/HomelabIcon'
 import InsightsIcon from './components/icons/InsightsIcon'
@@ -59,6 +60,15 @@ export default function HomePage() {
       url:
         process.env.NEXT_PUBLIC_DUYET_PHOTOS_URL || 'https://photos.duyet.net',
       color: 'bg-white',
+      iconColor: 'text-neutral-900',
+    },
+    {
+      icon: AIIcon,
+      title: 'Chat',
+      description:
+        'Ask me anything. AI-powered chatbot for questions about duyet.net and related topics.',
+      url: process.env.NEXT_PUBLIC_DUYET_AI_URL || 'https://ai.duyet.net',
+      color: 'bg-[#dbeafe]',
       iconColor: 'text-neutral-900',
     },
     {
@@ -206,9 +216,10 @@ export default function HomePage() {
             </div>
           </Link>
 
-          {/* About */}
+          {/* Chat */}
           <Link
             href={links[5].url}
+            target="_blank"
             rel="noopener noreferrer"
             className={`group flex flex-col p-6 ${links[5].color} rounded-3xl`}
           >
@@ -223,6 +234,26 @@ export default function HomePage() {
             </h3>
             <p className="text-sm leading-relaxed text-neutral-700">
               {links[5].description}
+            </p>
+          </Link>
+
+          {/* About */}
+          <Link
+            href={links[6].url}
+            rel="noopener noreferrer"
+            className={`group flex flex-col p-6 ${links[6].color} rounded-3xl`}
+          >
+            <div className={`mb-4 ${links[6].iconColor}`}>
+              {(() => {
+                const Icon = links[6].icon
+                return <Icon />
+              })()}
+            </div>
+            <h3 className="mb-2 text-xl font-semibold text-neutral-900">
+              {links[6].title}
+            </h3>
+            <p className="text-sm leading-relaxed text-neutral-700">
+              {links[6].description}
             </p>
           </Link>
         </div>


### PR DESCRIPTION
- Create AIIcon component for the chatbot section
- Add Chat link card in the home page grid layout
- Add /ai URL mapping to apps/home config for easy access
- Support NEXT_PUBLIC_DUYET_AI_URL environment variable override

## Summary by Sourcery

Integrate an AI-powered chatbot link into the home page, including UI, routing, and configuration support

New Features:
- Add Chat card to home page grid using new AIIcon component linking to the AI chatbot
- Configure '/ai' route in home app config to point to the AI chatbot

Enhancements:
- Support overriding the AI chatbot URL via NEXT_PUBLIC_DUYET_AI_URL environment variable