### PR TITLE
feat(home): add UTM tracking tags to home app URLs

### DIFF
--- a/apps/home/app/about/page.tsx
+++ b/apps/home/app/about/page.tsx
@@ -2,6 +2,27 @@ import Link from 'next/link'
 
 export const dynamic = 'force-static'
 
+/**
+ * Add UTM tracking parameters to URL
+ */
+function addUtmParams(
+  url: string,
+  campaign: string = 'about_page',
+  content?: string
+): string {
+  // Don't add UTM params to internal routes
+  if (url.startsWith('/')) return url
+
+  const urlObj = new URL(url)
+  urlObj.searchParams.set('utm_source', 'home')
+  urlObj.searchParams.set('utm_medium', 'website')
+  urlObj.searchParams.set('utm_campaign', campaign)
+  if (content) {
+    urlObj.searchParams.set('utm_content', content)
+  }
+  return urlObj.toString()
+}
+
 // Claude-style SVG Icons - minimal, geometric, soft
 const ResumeIcon = () => (
   <svg
@@ -184,7 +205,7 @@ export default function About() {
       title: 'Resume',
       description:
         'Experience building scalable data infrastructure and leading engineering teams.',
-      url: 'https://cv.duyet.net',
+      url: addUtmParams('https://cv.duyet.net', 'about_page', 'resume_card'),
       color: 'bg-orange-100/50',
     },
     {
@@ -192,7 +213,7 @@ export default function About() {
       title: 'GitHub',
       description:
         'Open source contributions and personal projects in Python, Rust, and TypeScript.',
-      url: 'https://github.com/duyet',
+      url: addUtmParams('https://github.com/duyet', 'about_page', 'github_card'),
       color: 'bg-purple-100/50',
     },
     {
@@ -200,7 +221,11 @@ export default function About() {
       title: 'LinkedIn',
       description:
         'Professional network and career highlights in data engineering.',
-      url: 'https://linkedin.com/in/duyet',
+      url: addUtmParams(
+        'https://linkedin.com/in/duyet',
+        'about_page',
+        'linkedin_card'
+      ),
       color: 'bg-blue-100/50',
     },
     {
@@ -208,7 +233,7 @@ export default function About() {
       title: 'Blog',
       description:
         'Technical writings on data engineering, distributed systems, and open source.',
-      url: BLOG_URL,
+      url: addUtmParams(BLOG_URL, 'about_page', 'blog_card'),
       color: 'bg-amber-100/60',
     },
   ]
@@ -216,18 +241,37 @@ export default function About() {
   const skills = [
     {
       name: 'Python',
-      link: 'https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=python',
+      link: addUtmParams(
+        'https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=python',
+        'about_page',
+        'skill_python'
+      ),
     },
     {
       name: 'Rust',
-      link: 'https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=rust',
+      link: addUtmParams(
+        'https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=rust',
+        'about_page',
+        'skill_rust'
+      ),
     },
     {
       name: 'Javascript',
-      link: 'https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=javascript',
+      link: addUtmParams(
+        'https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=javascript',
+        'about_page',
+        'skill_javascript'
+      ),
     },
     { name: 'Spark' },
-    { name: 'Airflow', link: `${BLOG_URL}/tag/airflow/` },
+    {
+      name: 'Airflow',
+      link: addUtmParams(
+        `${BLOG_URL}/tag/airflow/`,
+        'about_page',
+        'skill_airflow'
+      ),
+    },
     { name: 'AWS' },
     { name: 'GCP' },
   ]

--- a/apps/home/app/page.tsx
+++ b/apps/home/app/page.tsx
@@ -10,6 +10,27 @@ import ResumeIcon from './components/icons/ResumeIcon'
 export const dynamic = 'force-static'
 export const revalidate = 3600
 
+/**
+ * Add UTM tracking parameters to URL
+ */
+function addUtmParams(
+  url: string,
+  campaign: string = 'homepage',
+  content?: string
+): string {
+  // Don't add UTM params to internal routes
+  if (url.startsWith('/')) return url
+
+  const urlObj = new URL(url)
+  urlObj.searchParams.set('utm_source', 'home')
+  urlObj.searchParams.set('utm_medium', 'website')
+  urlObj.searchParams.set('utm_campaign', campaign)
+  if (content) {
+    urlObj.searchParams.set('utm_content', content)
+  }
+  return urlObj.toString()
+}
+
 export default function HomePage() {
   const links = [
     {
@@ -17,7 +38,11 @@ export default function HomePage() {
       title: 'Blog',
       description:
         'Technical writings on data engineering, distributed systems, and open source.',
-      url: process.env.NEXT_PUBLIC_DUYET_BLOG_URL || 'https://blog.duyet.net',
+      url: addUtmParams(
+        process.env.NEXT_PUBLIC_DUYET_BLOG_URL || 'https://blog.duyet.net',
+        'homepage',
+        'blog_card'
+      ),
       color: 'bg-[#f5dcd0]',
       iconColor: 'text-neutral-900',
     },
@@ -26,7 +51,11 @@ export default function HomePage() {
       title: 'Resume',
       description:
         'Experience building scalable data infrastructure and leading engineering teams.',
-      url: process.env.NEXT_PUBLIC_DUYET_CV_URL || 'https://cv.duyet.net',
+      url: addUtmParams(
+        process.env.NEXT_PUBLIC_DUYET_CV_URL || 'https://cv.duyet.net',
+        'homepage',
+        'resume_card'
+      ),
       color: 'bg-[#f0d9a8]',
       iconColor: 'text-neutral-900',
     },
@@ -35,9 +64,12 @@ export default function HomePage() {
       title: 'Insights',
       description:
         'Analytics dashboard showcasing data from GitHub, WakaTime, and more.',
-      url:
+      url: addUtmParams(
         process.env.NEXT_PUBLIC_DUYET_INSIGHTS_URL ||
-        'https://insights.duyet.net',
+          'https://insights.duyet.net',
+        'homepage',
+        'insights_card'
+      ),
       color: 'bg-[#a8d5ba]',
       iconColor: 'text-neutral-900',
     },
@@ -46,9 +78,12 @@ export default function HomePage() {
       title: 'Homelab',
       description:
         'Homelab monitoring dashboard (beta).',
-      url:
+      url: addUtmParams(
         process.env.NEXT_PUBLIC_DUYET_HOMELAB_URL ||
-        'https://homelab.duyet.net',
+          'https://homelab.duyet.net',
+        'homepage',
+        'homelab_card'
+      ),
       color: 'bg-[#c5c5ff]',
       iconColor: 'text-neutral-900',
     },
@@ -57,8 +92,11 @@ export default function HomePage() {
       title: 'Photos',
       description:
         'Photography portfolio and visual stories from travels and daily life.',
-      url:
+      url: addUtmParams(
         process.env.NEXT_PUBLIC_DUYET_PHOTOS_URL || 'https://photos.duyet.net',
+        'homepage',
+        'photos_card'
+      ),
       color: 'bg-white',
       iconColor: 'text-neutral-900',
     },
@@ -67,7 +105,11 @@ export default function HomePage() {
       title: 'Chat',
       description:
         'Ask me anything. AI-powered chatbot for questions about duyet.net and related topics.',
-      url: process.env.NEXT_PUBLIC_DUYET_AI_URL || 'https://ai.duyet.net',
+      url: addUtmParams(
+        process.env.NEXT_PUBLIC_DUYET_AI_URL || 'https://ai.duyet.net',
+        'homepage',
+        'ai_card'
+      ),
       color: 'bg-[#dbeafe]',
       iconColor: 'text-neutral-900',
     },
@@ -261,14 +303,22 @@ export default function HomePage() {
         {/* Social Links */}
         <div className="flex justify-center gap-10 text-sm font-medium text-neutral-600">
           <Link
-            href="https://github.com/duyet"
+            href={addUtmParams(
+              'https://github.com/duyet',
+              'homepage',
+              'footer_github'
+            )}
             target="_blank"
             className="transition-colors duration-200 hover:text-neutral-900"
           >
             GitHub
           </Link>
           <Link
-            href="https://linkedin.com/in/duyet"
+            href={addUtmParams(
+              'https://linkedin.com/in/duyet',
+              'homepage',
+              'footer_linkedin'
+            )}
             target="_blank"
             className="transition-colors duration-200 hover:text-neutral-900"
           >


### PR DESCRIPTION
Add UTM tracking parameters to all external URLs in the home app for better analytics tracking.

Changes:
- Add addUtmParams helper function to homepage and about page
- Apply UTM tags to all navigation cards (blog, resume, insights, homelab, photos, ai)
- Apply UTM tags to footer social links (GitHub, LinkedIn)
- Apply UTM tags to about page cards and skill links
- Use utm_source=home, utm_medium=website with campaign and content parameters

## Summary by Sourcery

Add UTM tracking parameters to all external URLs in the home and about pages for enhanced analytics tracking, using a helper to set utm_source, utm_medium, utm_campaign, and utm_content fields.

New Features:
- Introduce addUtmParams helper in homepage and about page to append UTM parameters to external URLs
- Apply UTM tracking to homepage navigation cards (blog, resume, insights, homelab, photos, AI chat) and footer social links (GitHub, LinkedIn)
- Extend UTM tagging to about page external cards (resume, GitHub, LinkedIn, blog) and skill links (Python, Rust, JavaScript, Airflow) with contextual campaign and content parameters