### PR TITLE
fix(photos): fix inverted dark mode styling

### DIFF
--- a/apps/photos/app/layout.tsx
+++ b/apps/photos/app/layout.tsx
@@ -72,8 +72,7 @@ export default function RootLayout({
       <Head />
       <body
         className={cn(
-          'bg-cream-warm text-[var(--foreground)] subpixel-antialiased',
-          'dark:bg-[var(--background)]',
+          'bg-[var(--background)] text-[var(--foreground)] subpixel-antialiased',
           'transition-colors duration-1000',
         )}
       >

--- a/apps/photos/components/PhotoMetadata.tsx
+++ b/apps/photos/components/PhotoMetadata.tsx
@@ -54,8 +54,8 @@ export default function PhotoMetadata({
 
       {/* Expandable Metadata Panel */}
       {isExpanded && (
-        <div className="absolute left-0 top-full z-10 mt-2 min-w-64 max-w-xs rounded border border-black/10 bg-black px-3 py-2 text-left shadow-lg dark:border-white/10">
-          <div className="space-y-1 text-[11px] text-white/90">
+        <div className="absolute left-0 top-full z-10 mt-2 min-w-64 max-w-xs rounded border border-neutral-200 bg-white px-3 py-2 text-left shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+          <div className="space-y-1 text-[11px] text-neutral-700 dark:text-neutral-200">
             {/* Date */}
             <div>{formatPhotoDate(photo.created_at)}</div>
 


### PR DESCRIPTION
- Fix layout to use CSS variables consistently for both light and dark modes
- Remove hardcoded bg-cream-warm to use var(--background) instead
- Fix PhotoMetadata component to properly support dark mode instead of always using black background
- Update PhotoMetadata to use neutral colors with proper dark mode variants

## Summary by Sourcery

Fix inverted dark mode styling in the photos app by replacing hardcoded background classes with CSS variables and updating the PhotoMetadata component to use neutral color variants for both light and dark themes.

Bug Fixes:
- Fix inverted dark mode styling in PhotoMetadata panel by correcting background, border, and text colors.
- Replace hardcoded cream background in root layout with a CSS variable for consistent theming.

Enhancements:
- Standardize CSS variable usage for background and foreground colors in the root layout.
- Update PhotoMetadata component to use neutral color palettes with appropriate dark mode variants.