### PR TITLE
chore: add service to homelab app

### DIFF
--- a/apps/homelab/lib/mockData.ts
+++ b/apps/homelab/lib/mockData.ts
@@ -207,6 +207,14 @@ const serviceConfigs = [
     memRange: [200, 400],
   },
   {
+    name: 'duyetbot',
+    namespace: 'llm',
+    node: 'minipc-02',
+    port: 8081,
+    cpuRange: [2, 4],
+    memRange: [400, 700],
+  },
+  {
     name: 'clickhouse',
     namespace: 'analytics',
     node: 'minipc-02',


### PR DESCRIPTION
Add duyetbot service configuration to the llm namespace in the homelab dashboard. The service runs on minipc-02 at port 8081 with appropriate CPU and memory allocations.

## Summary by Sourcery

Chores:
- Add duyetbot service configuration under the llm namespace in homelab mockData