### PR TITLE
chore: add URL redirects for blog categories

### DIFF
--- a/apps/blog/public/_redirects
+++ b/apps/blog/public/_redirects
@@ -1,0 +1,3 @@
+# Category redirects
+/category/data-engineer /category/data-engineering 301
+/category/bigdata /category/data 301

--- a/apps/blog/vercel.json
+++ b/apps/blog/vercel.json
@@ -1,0 +1,14 @@
+{
+  "redirects": [
+    {
+      "source": "/category/data-engineer",
+      "destination": "/category/data-engineering",
+      "permanent": true
+    },
+    {
+      "source": "/category/bigdata",
+      "destination": "/category/data",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
Add redirects to support legacy category URLs:
- /category/data-engineer → /category/data-engineering
- /category/bigdata → /category/data

Supports both Cloudflare Pages (_redirects) and Vercel (vercel.json) deployments.

## Summary by Sourcery

Deployment:
- Add redirect rules for legacy blog category URLs (/category/data-engineer → /category/data-engineering, /category/bigdata → /category/data) in Cloudflare Pages (_redirects) and Vercel (vercel.json) configurations