### PR TITLE
fix: dark mode title visibility on blog posts

### DIFF
--- a/apps/blog/app/[year]/[month]/[slug]/content/content.tsx
+++ b/apps/blog/app/[year]/[month]/[slug]/content/content.tsx
@@ -15,7 +15,7 @@ export default function Content({ post }: { post: Post }) {
         <h1
           className={cn(
             'mt-2 inline-block break-words py-2',
-            'font-serif text-neutral-900',
+            'font-serif text-neutral-900 dark:text-neutral-100',
             'text-4xl font-bold tracking-normal',
             'md:text-5xl md:tracking-tight',
             'lg:text-6xl lg:tracking-tight',

--- a/apps/blog/app/[year]/[month]/[slug]/meta/meta.tsx
+++ b/apps/blog/app/[year]/[month]/[slug]/meta/meta.tsx
@@ -22,21 +22,25 @@ export default function Content({ post, className }: ContentProps) {
       <div
         className={cn(
           'flex flex-row flex-wrap items-center gap-3',
-          'rounded-2xl bg-neutral-50 px-6 py-4',
-          'text-sm text-neutral-600',
+          'rounded-2xl bg-neutral-50 dark:bg-neutral-800 px-6 py-4',
+          'text-sm text-neutral-600 dark:text-neutral-400',
           className,
         )}
       >
-        <time className="font-medium text-neutral-700">
-          {post.date.toString()}
+        <time className="font-medium text-neutral-700 dark:text-neutral-300">
+          {new Date(post.date).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
+          })}
         </time>
-        <time className="text-neutral-500">
+        <time className="text-neutral-500 dark:text-neutral-400">
           ({distanceToNow(new Date(post.date))})
         </time>
-        <span className="text-neutral-400">•</span>
+        <span className="text-neutral-400 dark:text-neutral-600">•</span>
         <Link
           href={`/category/${post.category_slug}`}
-          className="font-medium text-neutral-800 transition-colors hover:text-neutral-900 hover:underline hover:underline-offset-4"
+          className="font-medium text-neutral-800 dark:text-neutral-200 transition-colors hover:text-neutral-900 dark:hover:text-neutral-100 hover:underline hover:underline-offset-4"
         >
           {post.category}
         </Link>
@@ -46,14 +50,14 @@ export default function Content({ post, className }: ContentProps) {
               href={`/tag/${getSlug(tag)}`}
               key={tag}
               title={`Tag: ${tag}`}
-              className="rounded-full bg-neutral-200 px-3 py-1 text-xs font-medium text-neutral-700 transition-colors hover:bg-neutral-300 hover:text-neutral-900"
+              className="rounded-full bg-neutral-200 dark:bg-neutral-700 px-3 py-1 text-xs font-medium text-neutral-700 dark:text-neutral-300 transition-colors hover:bg-neutral-300 dark:hover:bg-neutral-600 hover:text-neutral-900 dark:hover:text-neutral-100"
             >
               {tag}
             </Link>
           ))}
         </div>
         <a
-          className="text-neutral-500 transition-colors hover:text-neutral-900"
+          className="text-neutral-500 dark:text-neutral-400 transition-colors hover:text-neutral-900 dark:hover:text-neutral-100"
           href={post.edit_url}
           rel="noopener noreferrer"
           target="_blank"


### PR DESCRIPTION
- Add dark mode text color to post title (dark:text-neutral-100)
- Add dark mode background to metadata box (dark:bg-neutral-800)
- Add dark mode variants for all metadata text elements
- Improve date format from raw string to localized format (e.g., "Jun 18, 2023")

## Summary by Sourcery

Add dark mode support across blog post components and improve post date formatting.

Enhancements:
- Add dark mode styling for post titles, metadata container and text, tags, and edit links
- Format post dates using localized short date format (e.g., "Jun 18, 2023")