### PR TITLE
chore(blog): Fix content in blog posts

### DIFF
--- a/apps/blog/_posts/2020/05/spark-on-k8s.md
+++ b/apps/blog/_posts/2020/05/spark-on-k8s.md
@@ -73,11 +73,9 @@ The [Kubernetes Operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-op
 
 The easiest way to install the [Kubernetes Operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator) for Apache Spark is to use the Helm chart.
 
-> **Note**: The Helm incubator repository has been deprecated. Use the official Spark Operator chart instead: `helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator`
-
 ```bash
-$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
-$ helm install incubator/sparkoperator --namespace spark-operator
+$ helm repo add spark-operator https://googlecloudplatform.github.io/spark-on-k8s-operator
+$ helm install spark-operator spark-operator/spark-operator --namespace spark-operator --create-namespace
 ```
 
 This will install the Kubernetes Operator for Apache Spark into the namespace `spark-operator`. The operator by default watches and handles SparkApplications in every namespaces.

--- a/apps/blog/_posts/2022/09/airflow-dataset.md
+++ b/apps/blog/_posts/2022/09/airflow-dataset.md
@@ -49,7 +49,7 @@ dataset = Dataset('s3://dag/output.txt', extra={'hi': 'bye'})
 
 start_date = datetime(2022, 1, 1)
 
-with DAG(dag_id='producer', start_date=start_date, schedule=[dataset]):
+with DAG(dag_id='consumer', start_date=start_date, schedule=[dataset]):
   BashOperator(task_id='consuming_1',
                bash_command="echo hello")
 ```
@@ -73,19 +73,19 @@ schemeless = Dataset("//example/dataset")
 csv_file = Dataset("example_dataset")
 ```
 
-# \***\*Datasets Chain\*\***
+# Datasets Chain
 
-A consumer DAG can update another dataset which triggering another DAGs.
+A consumer DAG can update another dataset which triggers another DAG.
 
 ```python
 dataset_1 = Dataset("/tmp/dataset_1.txt")
 dataset_2 = Dataset("/tmp/dataset_2.txt")
 
 with DAG(dag_id='dag_1', ...):
-	BashOperator(task_id='task_1', outlet=[dataset_1], bash_command="sleep 5")
+	BashOperator(task_id='task_1', outlets=[dataset_1], bash_command="sleep 5")
 
 with DAG(dag_id='dag_2', schedule=[dataset_1], ...):
-	BashOperator(task_id='task_2', outlet=[dataset_2], bash_command="sleep 5")
+	BashOperator(task_id='task_2', outlets=[dataset_2], bash_command="sleep 5")
 
 with DAG(dag_id='dag_3', schedule=[dataset_2], ...):
 	BashOperator(task_id='task_3', bash_command="sleep 5")

--- a/apps/blog/_posts/2023/06/fossil-data-platform-written-rust.md
+++ b/apps/blog/_posts/2023/06/fossil-data-platform-written-rust.md
@@ -128,7 +128,7 @@ transformations:
 # Going Production
 
 For easier to understand, the platform should be configured as shown in the figure below. It runs on Kubernetes with KEDA for fully automated scaling. During peak periods or migration, it can scale up to 1000 pods using Python-based workers.
-Data collector was written in Node.js, now rewriten in Rust thanks to [actix-web](https://actix.rs/).
+Data collector was written in Node.js, now rewritten in Rust thanks to [actix-web](https://actix.rs/).
 
 ![Data Engineering Team 2022](/media/2023/06/fossil-data-platform-written-rust/dp-overview.png)
 
@@ -168,9 +168,9 @@ my-project
 
 ### 2. `pyspark.RDD.pipe`
 
-This return an RDD created by piping elements to a forked external process - our binary of `transformation-rs`.
+This returns an RDD created by piping elements to a forked external process - our binary of `transformation-rs`.
 
-Imaging we already have this binary running on container to processing a file:
+Imagine we already have this binary running in a container for processing a file:
 
 ```bash
 ./transformation-rs --config config.toml -f dataset.json.gz
@@ -241,7 +241,7 @@ Despite being [the most loved language for seven consecutive years](https://surv
 - [launchbadge/sqlx](https://github.com/launchbadge/sqlx): 🧰 The Rust SQL Toolkit. An async, pure Rust SQL crate featuring compile-time checked queries without a DSL. Supports PostgreSQL, MySQL, SQLite, and MSSQL.
 
 I have discussed the future with my team, and I bet and considered the possibility of Rust becoming the new trend in Data Engineering.
-We could proud to have been one of the first teams to use Rust in building a Data Platform.
+We could be proud to have been one of the first teams to use Rust in building a Data Platform.
 However, even though Rust might become the standard when the platform is stable, it may still be difficult to hire new Rust developers, especially in Vietnam.
 
 We chose Rust for developing many of our applications due to its high level of security for concurrent processing, as well as its focus on correctness and performance. Rust's compiler is an excellent tool for identifying bugs, but ultimately, it is important to measure the running code and identify bottlenecks in order to solve them.


### PR DESCRIPTION
Fixed multiple content issues across blog posts:

**airflow-dataset.md:**
- Fix malformed heading (escaped markdown)
- Fix consumer DAG to have correct dag_id='consumer'
- Fix parameter from 'outlet' to 'outlets' for consistency
- Fix grammar: "which triggering another DAGs" → "which triggers another DAG"

**spark-on-k8s.md:**
- Update deprecated Helm commands to use current spark-operator repository
- Remove outdated incubator repository reference

**fossil-data-platform-written-rust.md:**
- Fix typo: "rewriten" → "rewritten"
- Fix grammar: "Imaging we" → "Imagine we"
- Fix grammar: "running on container to processing" → "running in a container for processing"
- Fix grammar: "This return" → "This returns"
- Fix grammar: "We could proud" → "We could be proud"