### PR TITLE
fix: content display issue

### DIFF
--- a/apps/blog/_posts/2015/04/tim-hieu-ve-giay-phep-gnu.md
+++ b/apps/blog/_posts/2015/04/tim-hieu-ve-giay-phep-gnu.md
@@ -16,7 +16,7 @@ description: GNU (GNU General Public License) là giấy phép phần mềm tự
 
 ## 1. Nhà phát hành
 
-GNU (GNU General Public License – Giấy phép công cộng GNU, còn được gọi là GNU GPL hay đơn giản là GPL) là giấy phép phần mềm tự do phổ biến nhất, ban đầu được thiết kê bới Richard Stallman, dành cho dự án GNU. Phiên bản 2 của giấy phép này được phát hành năm 1991, và phiên bản 3, phiên bản hiện tại, được phát hành năm 2007.
+GNU (GNU General Public License – Giấy phép công cộng GNU, còn được gọi là GNU GPL hay đơn giản là GPL) là giấy phép phần mềm tự do phổ biến nhất, ban đầu được thiết kế bởi Richard Stallman, dành cho dự án GNU. Phiên bản 2 của giấy phép này được phát hành năm 1991, và phiên bản 3, phiên bản hiện tại, được phát hành năm 2007.
 
 Nội dung toàn văn giấy phép GNU (phiên bản 3) tại link sau: [https://opensource.org/licenses/GPL-3.0](https://opensource.org/licenses/GPL-3.0)
 

--- a/apps/blog/_posts/2019/05/phuong-tien-cong-cong-san-francisco.md
+++ b/apps/blog/_posts/2019/05/phuong-tien-cong-cong-san-francisco.md
@@ -5,7 +5,10 @@ featured: true
 author: Duyet
 category: Story
 tags:
-
+  - San Francisco
+  - Travel
+  - Transportation
+  - Public Transit
 thumbnail: https://1.bp.blogspot.com/-HbKS4i_0yqA/XM0Kbzu24bI/AAAAAAAA_hQ/84Pq1m-TK3QRHfv5GAFijK87OniCXDrnwCK4BGAYYCw/s1600/1969-12-31%2B04.00.00%2B27.jpg
 
 slug: /2019/05/phuong-tien-cong-cong-san-francisco.html

--- a/apps/blog/_posts/2021/04/spark-kubernetes-performance-tuning.md
+++ b/apps/blog/_posts/2021/04/spark-kubernetes-performance-tuning.md
@@ -65,3 +65,24 @@ Reference: https://kb.databricks.com/data/append-slow-with-spark-2.0.0.html
 Experimental. Enables shuffle file tracking for executors, which allows dynamic allocation without the need for an external shuffle service. This option will try to keep alive executors that are storing shuffle data for active jobs.
 
 Enable this optimization: `spark.dynamicAllocation.shuffleTracking.enabled=true`
+
+Reference: https://spark.apache.org/docs/latest/configuration.html#dynamic-allocation
+
+# Summary
+
+These performance tuning techniques can significantly improve Spark application performance when running on Kubernetes:
+
+1. **Adaptive Query Execution (AQE)** - Runtime optimization for better query plans
+2. **Kryo Serialization** - Faster and more compact serialization
+3. **Java Pointer Tuning** - Reduced memory consumption
+4. **Ignoring Data Locality** - Better performance with remote storage like S3
+5. **I/O with S3** - Faster file operations with cloud storage
+6. **Dynamic Allocation Shuffle Tracking** - Better resource utilization without external shuffle service
+
+Always test these optimizations with your specific workload to ensure they provide the expected performance improvements.
+
+# References
+
+- [Spark Configuration Guide](https://spark.apache.org/docs/latest/configuration.html)
+- [Spark Tuning Guide](https://spark.apache.org/docs/latest/tuning.html)
+- [Databricks: Adaptive Query Execution](https://docs.databricks.com/spark/latest/spark-sql/aqe.html)

--- a/apps/blog/_posts/2024/11/clickhouse-rust-udf.md
+++ b/apps/blog/_posts/2024/11/clickhouse-rust-udf.md
@@ -21,7 +21,7 @@ SELECT customTransform(data) FROM raw_events;
 ```
 
 - [Implementation: `extract-url`](#implementation-extract-url)
-- [Configurate ClickHouse](#configurate-clickhouse)
+- [Configure ClickHouse](#configure-clickhouse)
 - [Advances](#advances)
   - [`executable_pool`](#executable_pool)
   - [Functions with constant parameters](#functions-with-constant-parameters)
@@ -80,14 +80,18 @@ anyhow = "1.0.82"
 
 ```rust
 use anyhow::Result;
-use shared::io::process_stdin;
 use std::boxed::Box;
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead};
 
 pub type ProcessFn = Box<dyn Fn(&str) -> Option<String>>;
 
+/// Helper function to check if a character is whitespace
+fn is_whitespace(c: char) -> bool {
+    c.is_whitespace()
+}
+
 /// Returns the index to the start and the end of the URL
-/// if the the given string includes a
+/// if the given string includes a
 /// URL or alike. Otherwise, returns `None`.
 pub fn detect_url(s: &str) -> Option<(usize, usize)> {
     let patterns = vec!["http://", "https://", "ftp://", "ftps://", "file://"];
@@ -98,7 +102,7 @@ pub fn detect_url(s: &str) -> Option<(usize, usize)> {
                 let end = s
                     .chars()
                     .skip(pos + pattern.len())
-                    .position(|g| is_whitespace(g.to_string().as_str()))
+                    .position(|c| is_whitespace(c))
                     .unwrap_or(s.len() - pos - pattern.len());
                 return Some((pos, pos + end + pattern.len()));
             }
@@ -208,7 +212,7 @@ sudo chmod 755 /var/lib/clickhouse/user_scripts/extract-url
 
 The `user_scripts_path` setting defines the directory for user script files, which is `/var/lib/clickhouse/user_scripts` by default. You will also need to copy the binary to all instances if you have a cluster with more than one machine.
 
-# Configurate ClickHouse
+# Configure ClickHouse
 
 To add a UDF following the [Executable User Defined Functions](https://clickhouse.com/docs/en/sql-reference/functions/udf#executable-user-defined-functions) document, the configuration of executable user-defined functions can be located in one or more **xml** files. The path to the configuration is specified in the [user_defined_executable_functions_config](https://clickhouse.com/docs/en/operations/server-configuration-parameters/settings#server_configuration_parameters-user_defined_executable_functions_config) parameter.
 


### PR DESCRIPTION
- Add missing tags to San Francisco transportation post
- Fix Vietnamese spelling error in GNU GPL license post
- Fix Rust code example in ClickHouse UDF post (remove non-existent imports, add missing helper function)
- Fix typo "Configurate" -> "Configure" in ClickHouse UDF post
- Add proper conclusion and references to Spark Kubernetes performance tuning post

These fixes address content quality issues including:
- Metadata completeness (tags)
- Grammar and spelling accuracy
- Code example correctness and completeness
- Technical documentation completeness

## Summary by Sourcery

Improve content quality across multiple blog posts by adding missing metadata, correcting typos and code examples, and enriching technical documentation.

Bug Fixes:
- Fix Vietnamese spelling error in the GNU GPL license post
- Correct typo and invalid imports in the ClickHouse UDF Rust example
- Fix section heading typo in the ClickHouse UDF post

Enhancements:
- Add missing tags to the San Francisco transportation post
- Enhance Spark Kubernetes performance tuning post with a conclusion, summary and additional references