### PR TITLE
fix: build on Cloudflare Workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "dotenv -- turbo build",
     "dev": "dotenv -- turbo dev --parallel",
-    "prepare": "husky",
+    "prepare": "[ \"$CI\" != \"true\" ] && husky || true",
     "fmt": "biome format --write .",
     "lint": "biome lint .",
     "start": "dotenv -- turbo start",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+# Cloudflare Pages configuration
+# This file configures the build environment for Cloudflare Pages
+
+# Configure the build environment to use Bun
+[env.production]
+vars = { ENV = "production" }


### PR DESCRIPTION
…cript conditional

- Make husky prepare script conditional to skip in CI environments
- Add wrangler.toml configuration for Cloudflare Pages
- Set CI environment variable check to prevent husky installation during CI builds

## Summary by Sourcery

Make local Git hooks optional in CI and add Cloudflare Pages environment configuration.

Build:
- Make the husky prepare script conditional on the CI environment variable to avoid running in CI builds.
- Add a wrangler.toml configuration to define production environment variables for Cloudflare Pages.