### PR TITLE
fix: background tooltip in insights app

### DIFF
--- a/apps/insights/components/ui/chart/ChartTooltip.tsx
+++ b/apps/insights/components/ui/chart/ChartTooltip.tsx
@@ -80,7 +80,7 @@ export const ChartTooltipContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs shadow-xl",
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border bg-card px-2.5 py-1.5 text-xs shadow-xl",
           className
         )}
       >
@@ -146,14 +146,14 @@ export const ChartTooltipContent = React.forwardRef<
                   )}
                 >
                   <div className="grid gap-1.5">
-                    <span className="text-gray-600">
+                    <span className="text-muted-foreground">
                       {itemConfig?.label || String(item.name || "Value")}
                     </span>
                   </div>
                   {formatter ? (
                     formatter(item.value, item.name, item, index, item.payload)
                   ) : (
-                    <span className="font-mono font-medium tabular-nums text-gray-900">
+                    <span className="font-mono font-medium tabular-nums text-foreground">
                       {String(item.value || "")}
                     </span>
                   )}


### PR DESCRIPTION
Replace hard-coded gray colors with theme-aware Tailwind classes to properly support light and dark modes:
- Background: bg-white → bg-card
- Border: border-gray-200 → border-border
- Label text: text-gray-600 → text-muted-foreground
- Value text: text-gray-900 → text-foreground

This ensures the tooltip respects the current theme instead of always appearing with a white background.

## Summary by Sourcery

Bug Fixes:
- Fix chart tooltip background and text colors so they correctly adapt to the current theme.