### PR TITLE
feat(post): add Paperclip section and update GLM model note

### DIFF
--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -43,7 +43,7 @@ I didn't stop writing, tons of drafts in my [obsidian](https://obsidian.md/), no
     ]},
     { label: "Model", items: [
       { label: "Opus 4.6", link: "#z-claude-mi-claude-or-claude" },
-      { label: "GLM 4.7", link: "#z-claude-mi-claude-or-claude" }
+      { label: "GLM 4.7 (GLM 5.1 is too slow)", link: "#z-claude-mi-claude-or-claude" }
     ]},
     { label: "Provider", items: [
       { label: "OpenRouter", link: "#claude-code-openrouter-on-github-actions" },
@@ -336,6 +336,12 @@ cancel the deploy check job
 ```
 
 Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Each task has an 8-character ID, and a session can hold up to 50 scheduled tasks. Recurring tasks auto-expire after 3 days. Set `CLAUDE_CODE_DISABLE_CRON=1` to disable the scheduler entirely.
+
+### Paperclip
+
+If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the lead, a handful of Sonnet workers doing the grunt work, and a Haiku reviewer catching the obvious stuff. You define the org chart, assign tasks, and let them coordinate. It's wild.
+
+<video src="https://github.com/user-attachments/assets/773bdfb2-6d1e-4e30-8c5f-3487d5b70c8f" width="600" controls></video>
 
 ### Claude Code (+ OpenRouter) on GitHub Actions
 

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -341,6 +341,8 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6. You define the org chart, assign tasks, and let them coordinate. It's wild.
 
+It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
+
 <video src="https://github.com/user-attachments/assets/773bdfb2-6d1e-4e30-8c5f-3487d5b70c8f" width="600" controls></video>
 
 ### Claude Code (+ OpenRouter) on GitHub Actions

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -339,7 +339,7 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 ### Paperclip
 
-If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the lead, a handful of Sonnet workers doing the grunt work, and a Haiku reviewer catching the obvious stuff. You define the org chart, assign tasks, and let them coordinate. It's wild.
+If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and a Sonnet reviewer keeping things in check. You define the org chart, assign tasks, and let them coordinate. It's wild.
 
 It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. The CEO agent marks something as "needs revision", the staff engineer disagrees and bumps it back with a comment, then the reviewer jumps in and reopens the whole thing. Nobody writes code, everyone writes status updates. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
 

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -339,7 +339,7 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 ### Paperclip
 
-If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and a Sonnet reviewer keeping things in check. You define the org chart, assign tasks, and let them coordinate. It's wild.
+If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6, whatever OpenRouter has that day. You define the org chart, assign tasks, and let them coordinate. It's wild.
 
 It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. The CEO agent marks something as "needs revision", the staff engineer disagrees and bumps it back with a comment, then the reviewer jumps in and reopens the whole thing. Nobody writes code, everyone writes status updates. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
 

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -339,7 +339,7 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 ### Paperclip
 
-If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. Zero-human org - you define roles, assign models, let them coordinate. I run Duet Company on it: Opus as CEO, GLM 4.7 workers, Gemma 4 or Qwen 3.6 as reviewers. They reassign tickets back and forth all day. Corporate bureaucracy in AI form.
+If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6. You define the org chart, assign tasks, and let them coordinate. It's wild.
 
 <video src="https://github.com/user-attachments/assets/773bdfb2-6d1e-4e30-8c5f-3487d5b70c8f" width="600" controls></video>
 

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -343,7 +343,7 @@ If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://papercli
 
 It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
 
-<video src="https://github.com/user-attachments/assets/773bdfb2-6d1e-4e30-8c5f-3487d5b70c8f" width="600" controls></video>
+<video src="https://github.com/user-attachments/assets/773bdfb2-6d1e-4e30-8c5f-3487d5b70c8f" className="w-full max-w-[600px]" controls playsInline></video>
 
 ### Claude Code (+ OpenRouter) on GitHub Actions
 

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -341,6 +341,8 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the lead, a handful of Sonnet workers doing the grunt work, and a Haiku reviewer catching the obvious stuff. You define the org chart, assign tasks, and let them coordinate. It's wild.
 
+It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. The CEO agent marks something as "needs revision", the staff engineer disagrees and bumps it back with a comment, then the reviewer jumps in and reopens the whole thing. Nobody writes code, everyone writes status updates. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
+
 <video src="https://github.com/user-attachments/assets/773bdfb2-6d1e-4e30-8c5f-3487d5b70c8f" width="600" controls></video>
 
 ### Claude Code (+ OpenRouter) on GitHub Actions

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -339,7 +339,7 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 ### Paperclip
 
-If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6, whatever OpenRouter has that day. You define the org chart, assign tasks, and let them coordinate. It's wild.
+If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6, you name it. You define the org chart, assign tasks, and let them coordinate. It's wild.
 
 It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. The CEO agent marks something as "needs revision", the staff engineer disagrees and bumps it back with a comment, then the reviewer jumps in and reopens the whole thing. Nobody writes code, everyone writes status updates. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
 

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -341,7 +341,7 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6, you name it. You define the org chart, assign tasks, and let them coordinate. It's wild.
 
-It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. The CEO agent marks something as "needs revision", the staff engineer disagrees and bumps it back with a comment, then the reviewer jumps in and reopens the whole thing. Nobody writes code, everyone writes status updates. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
+It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
 
 <video src="https://github.com/user-attachments/assets/773bdfb2-6d1e-4e30-8c5f-3487d5b70c8f" width="600" controls></video>
 

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -339,9 +339,7 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 ### Paperclip
 
-If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6, you name it. You define the org chart, assign tasks, and let them coordinate. It's wild.
-
-It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
+If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. Zero-human org - you define roles, assign models, let them coordinate. I run Duet Company on it: Opus as CEO, GLM 4.7 workers, Gemma 4 or Qwen 3.6 as reviewers. They reassign tickets back and forth all day. Corporate bureaucracy in AI form.
 
 <video src="https://github.com/user-attachments/assets/773bdfb2-6d1e-4e30-8c5f-3487d5b70c8f" width="600" controls></video>
 

--- a/apps/blog/_posts/2026/01/ai.mdx
+++ b/apps/blog/_posts/2026/01/ai.mdx
@@ -339,7 +339,7 @@ Under the hood, Claude uses `CronCreate`, `CronList`, and `CronDelete` tools. Ea
 
 ### Paperclip
 
-If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6. You define the org chart, assign tasks, and let them coordinate. It's wild.
+If [OpenClaw](https://openclaw.ai) is the employee, [Paperclip](https://paperclip.dev) is the company. For zero-human companies, Paperclip lets you spin up an entire org where every role - CEO, staff engineers, reviewers - is a Claude Code instance, from the smartest model down to the cheapest. I'm using it now to run Duet Company: one Opus agent as the CEO, a squad of cheap GLM 4.7 workers burning through tickets, and whatever free model is available as the reviewer - Gemma 4, Qwen 3.6. I defined the org chart, set some goals and cronjobs, and it just starts going - assigning tasks, breaking them down, discovering more work on its own. It's wild.
 
 It looks like a real enterprise now - the agents keep reassigning tickets back and forth to each other all day. I accidentally built corporate bureaucracy in AI form. At least they don't schedule unnecessary meetings... yet.
 


### PR DESCRIPTION
## Summary
- Update "Top on my list" card: GLM 4.7 → "GLM 4.7 (GLM 5.1 is too slow)"
- Add new **Paperclip** section after "Claude cron scheduling tools" with zero-human company concept and demo video

## Test plan
- [ ] Blog builds successfully
- [ ] New Paperclip section renders with video embed
- [ ] GLM label updated in ClaudeCardNested component

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update AI blog post content to refine model recommendations and introduce a new Paperclip section with an embedded demo video.

New Features:
- Add a new Paperclip section describing zero-human companies and linking to Paperclip with an embedded demo video.

Enhancements:
- Clarify the GLM model recommendation in the Top on my list card to note GLM 5.1 performance issues.

Documentation:
- Expand the AI blog post with additional context about Paperclip and its zero-human company concept.