### PR TITLE
fix(blog): use real post title in page title instead of slug

### DIFF
--- a/apps/blog/src/routes/$year/$month/$slug.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug.tsx
@@ -17,6 +17,9 @@ export const Route = createFileRoute("/$year/$month/$slug")({
     const slug = rawSlug.replace(/\.(md|html)$/, "");
     const post = (loaderData as { post?: Post } | undefined)?.post;
     const title = post?.title || slug.replace(/-/g, " ");
+    const ogImage = post?.thumbnail
+      ? new URL(post.thumbnail, "https://blog.duyet.net").toString()
+      : undefined;
     return {
       meta: [
         { title: `${title} | Tôi là Duyệt` },
@@ -34,9 +37,7 @@ export const Route = createFileRoute("/$year/$month/$slug")({
               { property: "og:description", content: post.excerpt },
             ]
           : []),
-        ...(post?.thumbnail
-          ? [{ property: "og:image", content: post.thumbnail }]
-          : []),
+        ...(ogImage ? [{ property: "og:image", content: ogImage }] : []),
       ],
       links: [
         {

--- a/apps/blog/src/routes/$year/$month/$slug.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug.tsx
@@ -12,17 +12,31 @@ import Content from "./-content";
 import Meta from "./-meta";
 
 export const Route = createFileRoute("/$year/$month/$slug")({
-  head: ({ params }) => {
+  head: ({ params, loaderData }) => {
     const { year, month, slug: rawSlug } = params;
     const slug = rawSlug.replace(/\.(md|html)$/, "");
+    const post = (loaderData as { post?: Post } | undefined)?.post;
+    const title = post?.title || slug.replace(/-/g, " ");
     return {
       meta: [
-        { title: `${slug.replace(/-/g, " ")} | Tôi là Duyệt` },
+        { title: `${title} | Tôi là Duyệt` },
         { property: "og:type", content: "article" },
         {
           property: "og:url",
           content: `https://blog.duyet.net/${year}/${month}/${slug}`,
         },
+        ...(post?.title
+          ? [{ property: "og:title", content: post.title }]
+          : []),
+        ...(post?.excerpt
+          ? [
+              { name: "description", content: post.excerpt },
+              { property: "og:description", content: post.excerpt },
+            ]
+          : []),
+        ...(post?.thumbnail
+          ? [{ property: "og:image", content: post.thumbnail }]
+          : []),
       ],
       links: [
         {


### PR DESCRIPTION
## Summary

- Fix blog post pages showing URL slug as `<title>` instead of the actual post title from frontmatter
- e.g. `/2026/01/ai/` now shows "Coding Agents | Tôi là Duyệt" instead of "ai | Tôi là Duyệt"
- Add `og:title`, `description`, `og:description`, and `og:image` meta tags for SEO

## Changes

- `apps/blog/src/routes/$year/$month/$slug.tsx`: use `loaderData` in `head()` to access real post title, with slug fallback

## Test plan

- [ ] `bun run check-types` passes in `apps/blog`
- [ ] `bun run test` passes (47 blog tests)
- [ ] Visit a post page and verify `<title>` shows real post title
- [ ] View source of SSG-rendered page to confirm title in HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update blog post page metadata to use the actual post title and add SEO meta tags.

New Features:
- Add Open Graph title, description, and image meta tags, as well as standard description, to blog post pages when available from post data.

Bug Fixes:
- Use the real blog post title from loader data instead of the URL slug when setting the page title, with a slug-based fallback when no title is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced SEO and social sharing: page titles now prefer actual post titles with a fallback to slug-derived titles.
  * Conditional Open Graph/meta tags added: title, description, and thumbnail image are included when the post provides them.
  * Added meta description support for improved search visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->