### PR TITLE
feat(home): redesign app cards grid and update content

### DIFF
--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -52,7 +52,7 @@ const apps: AppItem[] = [
     href: "/claw",
     host: "claw.duyet.net",
     utmContent: "claw_bento",
-    description: "Open source alternative to Screenshot API",
+    description: "OpenClaw Management Dashboard",
     screenshot: "/screenshots/openclaw.png",
   },
   {
@@ -85,7 +85,6 @@ const apps: AppItem[] = [
     host: "github.com/duyet/claude-plugins",
     utmContent: "claude_plugins_bento",
     description: "Official plugins for Claude Code and AI SDK",
-    screenshot: "/screenshots/claude-plugins-art.png",
   },
   {
     name: "Stamp",
@@ -302,31 +301,32 @@ function HomePage() {
                 Apps
               </h2>
               <span className="text-sm text-neutral-500 dark:text-neutral-400">
-                Vibe
+                Managed by @duyetbot AI Agent
               </span>
             </div>
 
-            {/* Unified grid for all apps */}
+            {/* Apps with screenshots */}
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {apps.map((item, index) => {
-                const shortcutNumber = index < 4 ? index + 6 : undefined;
-                const delayClass = `animate-fade-in-delay-${Math.min(index + 7, 8)}`;
+              {apps
+                .filter((item) => item.screenshot)
+                .map((item, index) => {
+                  const shortcutNumber = index < 4 ? index + 6 : undefined;
+                  const delayClass = `animate-fade-in-delay-${Math.min(index + 7, 8)}`;
 
-                return (
-                  <BentoCard
-                    key={item.name}
-                    href={addUtmParams(
-                      item.href,
-                      "homepage",
-                      item.utmContent,
-                      item.host
-                    )}
-                    className="group flex flex-col overflow-hidden p-0"
-                    shortcutId={item.name.toLowerCase().replace(/\s+/g, "-")}
-                    shortcutNumber={shortcutNumber}
-                    animationClass={delayClass}
-                  >
-                    {item.screenshot && (
+                  return (
+                    <BentoCard
+                      key={item.name}
+                      href={addUtmParams(
+                        item.href,
+                        "homepage",
+                        item.utmContent,
+                        item.host
+                      )}
+                      className="group flex flex-col overflow-hidden p-0"
+                      shortcutId={item.name.toLowerCase().replace(/\s+/g, "-")}
+                      shortcutNumber={shortcutNumber}
+                      animationClass={delayClass}
+                    >
                       <div className="relative aspect-[16/9] w-full border-b border-neutral-200 flex items-center justify-center overflow-hidden bg-neutral-100 dark:bg-[#0a0a0a] dark:border-white/10">
                         <img
                           src={item.screenshot}
@@ -334,21 +334,54 @@ function HomePage() {
                           className="absolute inset-0 w-full h-full object-cover object-top opacity-90 transition-opacity group-hover:opacity-100"
                         />
                       </div>
-                    )}
-                    <div className="p-4 flex flex-col justify-center bg-white dark:bg-[#111]">
+                      <div className="p-4 flex flex-col justify-center bg-white dark:bg-[#111]">
+                        <h4 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                          {item.name}
+                        </h4>
+                        <p className="text-xs text-neutral-600 dark:text-neutral-400 line-clamp-1 mt-1">
+                          {item.description}
+                        </p>
+                        <div className="mt-1 text-xs text-neutral-500 dark:text-neutral-400 break-all">
+                          {item.host}
+                        </div>
+                      </div>
+                    </BentoCard>
+                  );
+                })}
+            </div>
+
+            {/* Apps without screenshots — compact row */}
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 mt-4">
+              {apps
+                .filter((item) => !item.screenshot)
+                .map((item, index) => {
+                  const delayClass = `animate-fade-in-delay-${Math.min(index + 7, 8)}`;
+
+                  return (
+                    <BentoCard
+                      key={item.name}
+                      href={addUtmParams(
+                        item.href,
+                        "homepage",
+                        item.utmContent,
+                        item.host
+                      )}
+                      className="group flex flex-col overflow-hidden p-4"
+                      shortcutId={item.name.toLowerCase().replace(/\s+/g, "-")}
+                      animationClass={delayClass}
+                    >
                       <h4 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
                         {item.name}
                       </h4>
-                      <p className="text-xs text-neutral-600 dark:text-neutral-400 line-clamp-1 mt-1">
+                      <p className="text-xs text-neutral-600 dark:text-neutral-400 line-clamp-2 mt-1">
                         {item.description}
                       </p>
-                      <div className="mt-1 text-xs text-neutral-500 dark:text-neutral-400 break-all">
+                      <div className="mt-2 text-xs text-neutral-500 dark:text-neutral-400 break-all">
                         {item.host}
                       </div>
-                    </div>
-                  </BentoCard>
-                );
-              })}
+                    </BentoCard>
+                  );
+                })}
             </div>
           </div>
 

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -352,7 +352,7 @@ function HomePage() {
             </div>
 
             {/* Apps without screenshots — compact row */}
-            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 mt-4">
+            <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
               {apps
                 .filter((item) => !item.screenshot)
                 .map((item, index) => {

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -331,6 +331,7 @@ function HomePage() {
                         <img
                           src={item.screenshot}
                           alt={item.name}
+                          loading="lazy"
                           className="absolute inset-0 w-full h-full object-cover object-top opacity-90 transition-opacity group-hover:opacity-100"
                         />
                       </div>
@@ -355,7 +356,9 @@ function HomePage() {
               {apps
                 .filter((item) => !item.screenshot)
                 .map((item, index) => {
-                  const delayClass = `animate-fade-in-delay-${Math.min(index + 7, 8)}`;
+                  const visualIndex = index + apps.filter((i) => i.screenshot).length;
+                  const delayClass = `animate-fade-in-delay-${Math.min(visualIndex + 7, 8)}`;
+                  const shortcutNumber = visualIndex < 4 ? visualIndex + 6 : undefined;
 
                   return (
                     <BentoCard
@@ -368,6 +371,7 @@ function HomePage() {
                       )}
                       className="group flex flex-col overflow-hidden p-4"
                       shortcutId={item.name.toLowerCase().replace(/\s+/g, "-")}
+                      shortcutNumber={shortcutNumber}
                       animationClass={delayClass}
                     >
                       <h4 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">


### PR DESCRIPTION
## Summary
- Split apps showcase into two grids: screenshot cards (3-col, tall) and compact text-only cards (4-col, short) for better visual hierarchy
- Remove screenshot from Claude Plugins card (moves to compact row)
- Update OpenClaw description to "OpenClaw Management Dashboard"
- Change section subtitle from "Vibe" to "Managed by @duyetbot AI Agent"

## Test plan
- [ ] Verify screenshot cards render in 3-column grid with 16:9 images
- [ ] Verify compact cards (Claude Plugins, AgentState, pageview) render in 4-column row
- [ ] Check responsive layout on mobile (1-col / 2-col breakpoints)
- [ ] Confirm dark mode styling for both card types

## Summary by Sourcery

Redesign the home apps section into separate grids for screenshot and compact cards while updating app metadata and section copy.

New Features:
- Split the apps showcase into a screenshot card grid and a compact text-only card grid for improved layout hierarchy.

Enhancements:
- Refine the OpenClaw app description to better reflect its purpose.
- Remove the Claude Plugins screenshot so it appears in the compact text-only apps row.
- Update the apps section subtitle to indicate management by the @duyetbot AI Agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned app listings into two grids: image-rich cards and compact no-image cards, with adjusted truncation, spacing and consistent title/description/host placement.
  * Screenshot images now load lazily; visual ordering, animations and shortcut numbering updated to reflect each subset.

* **Chores**
  * Updated an app description to "OpenClaw Management Dashboard" and changed the header label to "Managed by duyetbot AI Agent".
  * One app was converted to a non-screenshot (compact) card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->