### PR TITLE
fix(home): update cache headers from Next.js paths to Vite asset paths

### DIFF
--- a/apps/home/public/_headers
+++ b/apps/home/public/_headers
@@ -7,7 +7,7 @@
   X-Content-Type-Options: nosniff
 
 # Static assets - long cache
-/_next/static/*
+/assets/*
   Cache-Control: public, max-age=31536000, immutable
 
 # Images - long cache


### PR DESCRIPTION
## Summary
Fixes cache headers for the home app to properly cache Vite static assets instead of stale Next.js paths.

## Bug Description
The `_headers` file referenced `/_next/static/*` for immutable caching, which is a Next.js path. The home app uses Vite, which outputs static assets to `/assets/*`, so the cache rule was never applied.

## Root Cause
Leftover Next.js configuration from before the Vite migration.

## Fix
- Replaced `/_next/static/*` with `/assets/*` for proper Vite static asset caching
- Kept all other headers intact (HTML revalidation, screenshots, llms.txt, security headers)

## Test Plan
- ✅ Verified `/assets/*` path is present in headers
- ✅ Verified `/_next/static/*` path is removed
- ✅ E2E verification checks pass

## Checklist
- [x] Changes match commit message
- [x] E2E verification passes
- [ ] Tests pass (pre-existing blog test failure, unrelated to this change)
- [ ] Linting passes
- [ ] Documentation updated (if needed)

## Summary by Sourcery

Bug Fixes:
- Correct static asset cache rules to use the /assets/* path so Vite-built assets receive immutable caching instead of the obsolete /_next/static/* path.