### PR TITLE
fix(llm-timeline): update metadata to reflect current dataset stats (1950-2026, 3923+ models)

### DIFF
--- a/apps/llm-timeline/src/routes/__root.tsx
+++ b/apps/llm-timeline/src/routes/__root.tsx
@@ -66,7 +66,7 @@ export const Route = createRootRoute({
       {
         name: "description",
         content:
-          "Interactive timeline of Large Language Model releases from 2017 to present.",
+          "Interactive timeline of 3,923+ Large Language Model releases from 1950–2026 across 1,378+ organizations.",
       },
     ],
     links: [


### PR DESCRIPTION
## Summary
- Updates meta description from "2017 to present" to "1950–2026" with current model count (3,923+) and organization count (1,378+)
- Matches live site statistics at https://llm-timeline.duyet.net

## Test plan
- [x] Metadata updated to reflect current dataset
- [x] Verified against live site statistics
- [x] Code review passed via simplify skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct metadata description to match the current LLM timeline date range and model/organization counts.