### PR TITLE
feat(home): add route-level SEO metadata for about page with ProfilePage schema

### DIFF
--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -2,8 +2,87 @@ import Header from "@duyet/components/Header";
 import { createFileRoute } from "@tanstack/react-router";
 import { addUtmParams } from "../../app/lib/utm";
 
+const profilePageJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  dateCreated: "2020-01-01",
+  dateModified: new Date().toISOString().split("T")[0],
+  mainEntity: {
+    "@type": "Person",
+    name: "Duyet Le",
+    jobTitle: "Senior Data & AI Engineer",
+    email: "me@duyet.net",
+    url: "https://duyet.net",
+    sameAs: [
+      "https://github.com/duyet",
+      "https://linkedin.com/in/duyet",
+      "https://blog.duyet.net",
+    ],
+    description:
+      "Senior Data & AI Engineer with 6+ years of experience building scalable data infrastructure, AI/ML platforms, and distributed systems. Expertise in modern data warehousing, real-time processing, and cloud-native architectures.",
+    knowsAbout: [
+      "Data Engineering",
+      "AI/ML Infrastructure",
+      "Platform Engineering",
+      "LlamaIndex",
+      "AI SDK",
+      "LangGraph",
+      "ClickHouse",
+      "Apache Spark",
+      "Apache Airflow",
+      "Python",
+      "Rust",
+      "TypeScript",
+      "Kubernetes",
+      "AWS",
+      "GCP",
+      "Kafka",
+      "BigQuery",
+      "Helm",
+      "Distributed Systems",
+      "Cloud Computing",
+      "Data Warehousing",
+      "Machine Learning Infrastructure",
+      "DevOps",
+    ],
+    worksFor: {
+      "@type": "Organization",
+      name: "Cartrack",
+      url: "https://cartrack.us",
+    },
+    alumniOf: {
+      "@type": "CollegeOrUniversity",
+      name: "University of Information Technology",
+    },
+  },
+});
+
 export const Route = createFileRoute("/about")({
   component: AboutPage,
+  head: () => ({
+    meta: [
+      {
+        title: "About Duyet | Senior Data & AI Engineer",
+      },
+      {
+        name: "description",
+        content:
+          "Senior Data & AI Engineer with 6+ years of experience building scalable data infrastructure, AI/ML platforms, and distributed systems. Expertise in modern data engineering, real-time processing, and cloud-native architectures.",
+      },
+    ],
+    links: [
+      {
+        rel: "canonical",
+        href: "https://duyet.net/about",
+      },
+    ],
+    scripts: [
+      {
+        type: "application/ld+json",
+        children: profilePageJsonLd,
+      },
+    ],
+  }),
 });
 
 // Claude-style SVG Icons - minimal, geometric, soft


### PR DESCRIPTION
## Summary
- Add `head()` export to about page with title, meta description, and canonical URL
- Add ProfilePage structured data (JSON-LD) with embedded Person schema
- Title: "About Duyet | Senior Data & AI Engineer"
- Meta description emphasizes data engineering, AI/ML, and platform work
- Canonical URL: `https://duyet.net/about`
- Person schema includes skills, work history, education, and social links

## Test plan
- [x] Unit tests pass (31 tests in home app)
- [x] Code review via `simplify` skill - no issues found
- [x] SEO metadata added per Unit 12 requirements
- [ ] E2E verification (build currently blocked by pre-existing CSS import issue in __root.tsx)

## Notes
- The home app has a pre-existing build error unrelated to these changes (missing CSS import in __root.tsx)
- This is a straightforward SEO enhancement following TanStack Router patterns
- Person schema data is currently duplicated with CV app - future improvement would be to extract to shared config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add SEO metadata and structured data to the about page route.

New Features:
- Expose route-level head metadata for the about page including title, meta description, canonical URL, and JSON-LD script for search engines.

Enhancements:
- Add ProfilePage JSON-LD with embedded Person schema describing the site owner’s profile and professional details.