### PR TITLE
fix(agents): add mobile hamburger menu trigger for left sidebar access

### DIFF
--- a/apps/agents/components/chat/chat-top-bar.tsx
+++ b/apps/agents/components/chat/chat-top-bar.tsx
@@ -2,6 +2,7 @@ import {
   DownloadSimple as Download,
   FileCode as FileJson,
   FileText,
+  List,
   Plus,
 } from "@phosphor-icons/react";
 import { toast } from "sonner";
@@ -20,12 +21,14 @@ interface ChatTopBarProps {
   onNewChat: () => void;
   conversationTitle?: string;
   conversationId?: string;
+  onOpenSidebar?: () => void;
 }
 
 export function ChatTopBar({
   onNewChat,
   conversationTitle,
   conversationId,
+  onOpenSidebar,
 }: ChatTopBarProps) {
   const { exportConversation, isExporting } = useExportConversation();
   const canExport = Boolean(conversationId);
@@ -48,6 +51,17 @@ export function ChatTopBar({
   return (
     <header className="sticky top-0 z-30 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
       <div className="flex h-14 items-center gap-2 px-4">
+        {onOpenSidebar ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onOpenSidebar}
+            aria-label="Open sidebar"
+            className="md:hidden size-9 shrink-0 rounded-full"
+          >
+            <List weight="regular" className="size-4" />
+          </Button>
+        ) : null}
         <div className="flex min-w-0 flex-1 items-center">
           <h1 className="truncate text-sm font-medium">
             {conversationTitle || "New chat"}

--- a/apps/agents/components/chat/workspace.tsx
+++ b/apps/agents/components/chat/workspace.tsx
@@ -301,6 +301,7 @@ export function ChatWorkspace() {
             conversationId={activeId ?? undefined}
             conversationTitle={activeConversation?.title}
             onNewChat={handleNewChat}
+            onOpenSidebar={() => setLeftRailOpen(true)}
           />
 
           <div className="flex min-h-0 flex-1 flex-col">


### PR DESCRIPTION
## Summary
- Adds hamburger menu button (List icon) to ChatTopBar component
- Button opens left sidebar with conversation history on mobile devices
- Visible only on mobile breakpoints (<768px) using `md:hidden` Tailwind class
- Uses existing `setLeftRailOpen` state management from workspace
- Follows existing button patterns (ghost variant, rounded-full styling)

## Test plan
- [x] Code review: simplify skill found no issues (reuse, quality, efficiency)
- [x] Unit tests: Existing agents tests pass (81 pass, 2 skip, 3 pre-existing failures unrelated to changes)
- [ ] Manual browser testing: Open dev server with mobile viewport (<768px), verify hamburger menu appears and opens sidebar
- [ ] Desktop testing: Verify hamburger menu is hidden on larger screens (≥768px)

## Files changed
- `apps/agents/components/chat/chat-top-bar.tsx` - Added hamburger button with List icon, mobile-only visibility
- `apps/agents/components/chat/workspace.tsx` - Passed `onOpenSidebar` callback to ChatTopBar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a mobile-only control to open the left sidebar from the chat top bar.

New Features:
- Expose an optional onOpenSidebar callback on ChatTopBar and wire it from ChatWorkspace to open the left rail.
- Add a mobile-only hamburger button in ChatTopBar that triggers opening the conversation history sidebar.