### PR TITLE
feat(cv): add route-level SEO metadata for PDF view

### DIFF
--- a/apps/cv/src/routes/pdf.tsx
+++ b/apps/cv/src/routes/pdf.tsx
@@ -4,8 +4,24 @@ import { createFileRoute } from "@tanstack/react-router";
 export const Route = createFileRoute("/pdf")({
   head: () => ({
     meta: [
-      { title: "Duyet Le | Resume" },
-      { name: "description", content: "" },
+      { title: "CV - PDF View | duyet.net" },
+      {
+        name: "description",
+        content:
+          "View and download Duyet Le's CV as a PDF. Software engineer specializing in full-stack development, Rust, and modern web technologies.",
+      },
+      { property: "og:title", content: "CV - PDF View | duyet.net" },
+      {
+        property: "og:description",
+        content:
+          "View and download Duyet Le's CV as a PDF. Software engineer specializing in full-stack development, Rust, and modern web technologies.",
+      },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://cv.duyet.net/pdf" },
+      {
+        rel: "canonical",
+        href: "https://cv.duyet.net/pdf",
+      },
     ],
   }),
   component: Page,


### PR DESCRIPTION
## Summary
- Add comprehensive SEO metadata to the CV PDF route (/pdf)
- Include title, meta description, canonical URL, and OpenGraph tags
- Improve search engine discoverability and social media preview quality

## Changes
- Updated `apps/cv/src/routes/pdf.tsx` with proper `head()` export
- Title: "CV - PDF View | duyet.net"
- Meta description explaining the PDF view purpose
- Canonical URL: https://cv.duyet.net/pdf
- OpenGraph tags (title, description, type, url)

## Test plan
- [x] Unit tests pass (cv app tests)
- [x] Code follows TanStack Router conventions
- [x] SEO metadata matches pattern used in __root.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhance SEO metadata for the CV PDF route to improve discoverability and social sharing previews.

New Features:
- Add descriptive title and meta description for the /pdf CV view.
- Add Open Graph metadata and canonical URL for the CV PDF route.