### PR TITLE
feat(llm-timeline): add route-level SEO metadata with OG tags and canonicals

### DIFF
--- a/apps/llm-timeline/src/routes/license/$type.tsx
+++ b/apps/llm-timeline/src/routes/license/$type.tsx
@@ -26,11 +26,17 @@ export const Route = createFileRoute("/license/$type")({
   head: ({ params }) => {
     const type = params.type as LicenseType;
     if (!LICENSES.includes(type)) return {};
+    const canonicalUrl = `https://llm-timeline.duyet.net/license/${type}`;
     return {
       meta: [
         { title: `${LICENSE_LABELS[type]} Models | LLM Timeline` },
         { name: "description", content: LICENSE_DESCRIPTIONS[type] },
+        { property: "og:type", content: "website" },
+        { property: "og:url", content: canonicalUrl },
+        { property: "og:title", content: `${LICENSE_LABELS[type]} Models | LLM Timeline` },
+        { property: "og:description", content: LICENSE_DESCRIPTIONS[type] },
       ],
+      links: [{ rel: "canonical", href: canonicalUrl }],
     };
   },
   component: LicensePage,

--- a/apps/llm-timeline/src/routes/org/$slug.tsx
+++ b/apps/llm-timeline/src/routes/org/$slug.tsx
@@ -14,6 +14,7 @@ export const Route = createFileRoute("/org/$slug")({
   head: ({ params }) => {
     const org = organizations.find((o) => slugify(o) === params.slug);
     if (!org) return {};
+    const canonicalUrl = `https://llm-timeline.duyet.net/org/${params.slug}`;
     return {
       meta: [
         { title: `${org} LLM Models | LLM Timeline` },
@@ -21,7 +22,15 @@ export const Route = createFileRoute("/org/$slug")({
           name: "description",
           content: `A comprehensive timeline of Large Language Model releases from ${org}.`,
         },
+        { property: "og:type", content: "website" },
+        { property: "og:url", content: canonicalUrl },
+        { property: "og:title", content: `${org} LLM Models | LLM Timeline` },
+        {
+          property: "og:description",
+          content: `A comprehensive timeline of Large Language Model releases from ${org}.`,
+        },
       ],
+      links: [{ rel: "canonical", href: canonicalUrl }],
     };
   },
   component: OrgPage,

--- a/apps/llm-timeline/src/routes/year/$year.tsx
+++ b/apps/llm-timeline/src/routes/year/$year.tsx
@@ -14,6 +14,7 @@ export const Route = createFileRoute("/year/$year")({
     const year = params.year;
     const yearNum = parseInt(year, 10);
     if (Number.isNaN(yearNum) || !years.includes(yearNum)) return {};
+    const canonicalUrl = `https://llm-timeline.duyet.net/year/${year}`;
     return {
       meta: [
         { title: `LLM Models Released in ${year} | LLM Timeline` },
@@ -21,7 +22,15 @@ export const Route = createFileRoute("/year/$year")({
           name: "description",
           content: `A comprehensive timeline of Large Language Model releases from ${year}.`,
         },
+        { property: "og:type", content: "website" },
+        { property: "og:url", content: canonicalUrl },
+        { property: "og:title", content: `LLM Models Released in ${year} | LLM Timeline` },
+        {
+          property: "og:description",
+          content: `A comprehensive timeline of Large Language Model releases from ${year}.`,
+        },
       ],
+      links: [{ rel: "canonical", href: canonicalUrl }],
     };
   },
   component: YearPage,


### PR DESCRIPTION
## Summary
- Add canonical URLs to dynamic routes (license, year, org)
- Add OpenGraph tags (og:type, og:url, og:title, og:description)
- Maintains existing title and description meta tags

## Test plan
- [ ] SEO metadata appears correctly in page source for license, year, and org routes
- [ ] OpenGraph tags validate with social media preview tools
- [ ] Canonical URLs point to correct production URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add SEO metadata for dynamic organization, year, and license routes to improve sharing and canonicalization.

Enhancements:
- Add canonical URLs to org, year, and license dynamic routes.
- Add OpenGraph meta tags (type, URL, title, description) for org, year, and license pages to improve social sharing previews.