### PR TITLE
docs(docs): sync CLAUDE workflows for ai-percentage data sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ This is a **Bun monorepo** managed by **Turborepo** containing:
 10. **ai-percentage** (`apps/ai-percentage/`) - Dashboard showing the percentage of code written by AI across repositories
     - Live at https://ai-percentage.duyet.net (Cloudflare Pages)
     - Static SPA; use `bun run build` locally and `bun run cf:deploy:prod` for production deploy
+    - Data depends on `apps/data-sync` via `bun run sync ai-code-percentage`
 
 11. **data-sync** (`apps/data-sync/`) - CLI for syncing analytics and activity data into ClickHouse
     - Use `bun run sync <name>`, `bun run migrate`, and `bun run cleanup` for operational data workflows
@@ -147,6 +148,7 @@ Place environment files as `.env` or `.env.local` in the root directory.
   - `apps/api`: `bun run dev` uses Wrangler, `bun run deploy` builds then deploys the worker, and `bun run test:watch` is available for iterative API testing.
   - `apps/cv`: `bun run preview` serves the built app locally to validate production output before deploy.
   - `apps/data-sync`: `bun run sync:all`, `sync:wakatime`, `sync:cloudflare`, `sync:github`, `sync:unsplash`, `migrate:up|down|status|verify`, and `cleanup:dry-run`.
+  - `apps/data-sync`: `bun run sync ai-code-percentage` refreshes the dataset used by `apps/ai-percentage`.
   - `apps/llm-timeline`: `bun run rss`, `llms-txt`, `sitemap`, and `sync:dry` for content generation and sync checks.
   - Several apps also expose `cf:deploy:prod`; check the app `package.json` before using the generic root deploy flow for production.
 


### PR DESCRIPTION
## Summary
- add ai-percentage data dependency note to root CLAUDE workflow docs
- document the  command in notable data-sync workflows

## Validation
- verified commands against current app scripts in package.json
- AGENTS.md remains synced via symlink to CLAUDE.md