### PR TITLE
chore(home): reduce stale about metadata risk

### DIFF
--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -2,6 +2,8 @@ import Header from "@duyet/components/Header";
 import { createFileRoute } from "@tanstack/react-router";
 import { addUtmParams } from "../../app/lib/utm";
 
+const experienceYears = "8+ years";
+
 const profilePageJsonLd = JSON.stringify({
   "@context": "https://schema.org",
   "@type": "ProfilePage",
@@ -18,8 +20,7 @@ const profilePageJsonLd = JSON.stringify({
       "https://linkedin.com/in/duyet",
       "https://blog.duyet.net",
     ],
-    description:
-      "Senior Data & AI Engineer with 8+ years of experience building scalable data infrastructure, AI/ML platforms, and distributed systems. Expertise in modern data warehousing, real-time processing, and cloud-native architectures.",
+    description: `Senior Data & AI Engineer with ${experienceYears} of experience building scalable data infrastructure, AI/ML platforms, and distributed systems. Expertise in modern data warehousing, real-time processing, and cloud-native architectures.`,
     knowsAbout: [
       "Data Engineering",
       "AI/ML Infrastructure",
@@ -66,8 +67,7 @@ export const Route = createFileRoute("/about")({
       },
       {
         name: "description",
-        content:
-          "Senior Data & AI Engineer with 8+ years of experience building scalable data infrastructure, AI/ML platforms, and distributed systems. Expertise in modern data engineering, real-time processing, and cloud-native architectures.",
+        content: `Senior Data & AI Engineer with ${experienceYears} of experience building scalable data infrastructure, AI/ML platforms, and distributed systems. Expertise in modern data engineering, real-time processing, and cloud-native architectures.`,
       },
     ],
     links: [
@@ -357,9 +357,9 @@ function AboutPage() {
               About
             </h1>
             <p className="mx-auto max-w-3xl text-lg leading-relaxed text-neutral-700">
-              Data & AI Engineer with 8+ years of experience. I am confident in my
-              knowledge of Data Engineering, AI/ML concepts, best practices and
-              state-of-the-art data and Cloud technologies.
+              Data & AI Engineer with {experienceYears} of experience. I am
+              confident in my knowledge of Data Engineering, AI/ML concepts,
+              best practices and state-of-the-art data and Cloud technologies.
             </p>
           </div>
 

--- a/docs/reviews/code-smell-dead-code-2026-04-26.md
+++ b/docs/reviews/code-smell-dead-code-2026-04-26.md
@@ -1,0 +1,30 @@
+# Code Smell and Dead Code Review - 2026-04-26
+
+Scope: changes since `2026-04-25T21:00:52Z`.
+
+Recently changed files:
+
+- `CLAUDE.md`
+- `apps/home/src/routes/about.tsx`
+- `apps/photos/__tests__/photos-data.test.ts`
+- `apps/photos/public/photos-data.json`
+
+## Warning
+
+### Repeated experience value in about page metadata
+
+- File: `apps/home/src/routes/about.tsx:23`
+- File: `apps/home/src/routes/about.tsx:70`
+- File: `apps/home/src/routes/about.tsx:360`
+- Finding: the same `8+ years` value appeared in JSON-LD, meta description, and visible copy. The recent change fixed two stale metadata strings while the visible page already had the newer value, which shows the repetition can drift.
+- Fix: introduced one `experienceYears` constant and reused it in all three strings.
+
+## Dead Code
+
+No dead-code removals were made.
+
+Search evidence:
+
+- `rg "ResumeIcon|GithubIcon|LinkedInIcon|BlogIcon" apps/home/src/routes/about.tsx -n` found definitions at lines 89, 134, 174, and 207 plus usages in the `links` data at lines 270, 278, 290, and 302.
+- `rg "photos-data.json|photosDataPath|generated gallery dataset" apps packages -n --glob '!**/__tests__/**' --glob '!**/*.test.*'` found runtime and generation references in `apps/photos/hooks/usePhotos.ts`, `apps/photos/scripts/generate-photos-data.ts`, and `apps/photos/CLAUDE.md`.
+- `rg "readPublicJson|fetchPhotosData|cachedPhotos|cacheError|fetchPromise" apps/photos -n --glob '!**/__tests__/**' --glob '!**/*.test.*'` found each helper and cache binding referenced by `usePhotos`.


### PR DESCRIPTION
## Summary

- Add one `EXPERIENCE_YEARS` constant for the about page SEO and visible copy
- Add the code smell/dead-code review report for changes since `2026-04-25T21:00:52Z`

## Findings fixed

- Warning: `apps/home/src/routes/about.tsx` repeated the same experience value across JSON-LD, meta description, and visible copy. The recent change showed those strings can drift.

## Dead code

- No dead-code removals. Repo-wide `rg` evidence found references for the recently touched icons, photos dataset, and photo-loading helpers.

## Verification

- `TMPDIR=/tmp BUN_TMPDIR=/tmp BUN_INSTALL_CACHE_DIR=/tmp/bun-cache bunx @biomejs/biome@2.4.7 check apps/home/src/routes/about.tsx docs/reviews/code-smell-dead-code-2026-04-26.md`
- `git diff --check`

## Not run

- `bun run check-types` in `apps/home`: dependencies are not installed in the temporary clone.
- `bun install --frozen-lockfile`: blocked because this environment has Bun 1.3.3 while the repo lockfile/packageManager expects Bun 1.3.9 and the frozen lockfile would change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated repeated values in the About page into a centralized constant.

* **Documentation**
  * Added code-review documentation for ongoing quality assurance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->