### PR TITLE
fix(llm-timeline): restore filtered result totals

### DIFF
--- a/apps/llm-timeline/components/__tests__/filters.test.tsx
+++ b/apps/llm-timeline/components/__tests__/filters.test.tsx
@@ -6,25 +6,16 @@ import {
   it,
   render,
 } from "../../test-setup";
+import { DEFAULT_FILTERS } from "../../lib/utils";
 import { Filters } from "../filters";
 
 afterEach(cleanup);
-
-const baseFilters = {
-  search: "",
-  license: "all" as const,
-  type: "all" as const,
-  org: "",
-  source: "all" as const,
-  domain: "all",
-  params: "all",
-};
 
 describe("Filters", () => {
   it("shows total result context when resultCount is below totalCount", () => {
     const { getByText } = render(
       <Filters
-        filters={{ ...baseFilters, license: "open" }}
+        filters={{ ...DEFAULT_FILTERS, license: "open" }}
         onFilterChange={() => {}}
         resultCount={42}
         totalCount={100}
@@ -37,7 +28,7 @@ describe("Filters", () => {
   it("hides total result context when resultCount matches totalCount", () => {
     const { queryByText } = render(
       <Filters
-        filters={baseFilters}
+        filters={DEFAULT_FILTERS}
         onFilterChange={() => {}}
         resultCount={100}
         totalCount={100}
@@ -50,7 +41,7 @@ describe("Filters", () => {
   it("keeps total result context hidden when only filter state changes", () => {
     const { queryByText } = render(
       <Filters
-        filters={{ ...baseFilters, license: "open" }}
+        filters={{ ...DEFAULT_FILTERS, license: "open" }}
         onFilterChange={() => {}}
         resultCount={100}
         totalCount={100}

--- a/apps/llm-timeline/components/__tests__/filters.test.tsx
+++ b/apps/llm-timeline/components/__tests__/filters.test.tsx
@@ -21,7 +21,7 @@ const baseFilters = {
 };
 
 describe("Filters", () => {
-  it("shows total result context when filtered", () => {
+  it("shows total result context when resultCount is below totalCount", () => {
     const { getByText } = render(
       <Filters
         filters={{ ...baseFilters, license: "open" }}
@@ -34,10 +34,23 @@ describe("Filters", () => {
     expect(getByText("of 100 total")).toBeDefined();
   });
 
-  it("hides total result context when unfiltered", () => {
+  it("hides total result context when resultCount matches totalCount", () => {
     const { queryByText } = render(
       <Filters
         filters={baseFilters}
+        onFilterChange={() => {}}
+        resultCount={100}
+        totalCount={100}
+      />
+    );
+
+    expect(queryByText("of 100 total")).toBeNull();
+  });
+
+  it("keeps total result context hidden when only filter state changes", () => {
+    const { queryByText } = render(
+      <Filters
+        filters={{ ...baseFilters, license: "open" }}
         onFilterChange={() => {}}
         resultCount={100}
         totalCount={100}

--- a/apps/llm-timeline/components/__tests__/filters.test.tsx
+++ b/apps/llm-timeline/components/__tests__/filters.test.tsx
@@ -1,0 +1,49 @@
+import {
+  afterEach,
+  cleanup,
+  describe,
+  expect,
+  it,
+  render,
+} from "../../test-setup";
+import { Filters } from "../filters";
+
+afterEach(cleanup);
+
+const baseFilters = {
+  search: "",
+  license: "all" as const,
+  type: "all" as const,
+  org: "",
+  source: "all" as const,
+  domain: "all",
+  params: "all",
+};
+
+describe("Filters", () => {
+  it("shows total result context when filtered", () => {
+    const { getByText } = render(
+      <Filters
+        filters={{ ...baseFilters, license: "open" }}
+        onFilterChange={() => {}}
+        resultCount={42}
+        totalCount={100}
+      />
+    );
+
+    expect(getByText("of 100 total")).toBeDefined();
+  });
+
+  it("hides total result context when unfiltered", () => {
+    const { queryByText } = render(
+      <Filters
+        filters={baseFilters}
+        onFilterChange={() => {}}
+        resultCount={100}
+        totalCount={100}
+      />
+    );
+
+    expect(queryByText("of 100 total")).toBeNull();
+  });
+});

--- a/apps/llm-timeline/components/app-client.tsx
+++ b/apps/llm-timeline/components/app-client.tsx
@@ -123,7 +123,7 @@ export function AppClient({
           filters={filters}
           onFilterChange={handleFilterChange}
           resultCount={filteredModels.length}
-          totalCount={filteredModels.length}
+          totalCount={initialModels.length}
           liteMode={liteMode}
           onLiteModeToggle={() => setLiteMode((prev) => !prev)}
         />


### PR DESCRIPTION
## Summary
- restore the unfiltered LLM Timeline model count passed to `Filters`
- add coverage for filtered vs unfiltered result-total text

## Root cause
Recent UI work passed `filteredModels.length` as both `resultCount` and `totalCount`, so filtered result summaries could never show the original total.

## Validation
- `bun test` in `apps/llm-timeline`
- `bun run check-types` in `apps/llm-timeline`
- `bun run lint` in `apps/llm-timeline` (passes with existing generated routeTree unused-import warning)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for the Filters component to verify correct total count display behavior.

* **Bug Fixes**
  * Fixed Filters component to accurately display the total count of all available items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->