### PR TITLE
chore(ci): reduce llm timeline sync workflow drift

### DIFF
--- a/.github/workflows/data-sync-llm-timeline.yml
+++ b/.github/workflows/data-sync-llm-timeline.yml
@@ -55,11 +55,13 @@ jobs:
 
           branch="chore/llm-timeline-data-sync"
           head="${{ github.repository_owner }}:$branch"
+          pr_title="chore(llm-timeline): sync model data from Google Sheets + Epoch AI"
+          pr_body="Automated LLM Timeline data sync from Google Sheets and Epoch AI."
 
           git config user.name "duyetbot"
           git config user.email "duyetbot@users.noreply.github.com"
           git switch "$branch" 2>/dev/null || git switch --create "$branch"
-          git commit -m "chore(llm-timeline): sync model data from Google Sheets + Epoch AI" \
+          git commit -m "$pr_title" \
             -m "Co-Authored-By: duyet <me@duyet.net>" \
             -m "Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>"
           git push --force-with-lease "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$branch"
@@ -68,12 +70,12 @@ jobs:
 
           if [ -n "$pr_number" ]; then
             gh pr edit "$pr_number" \
-              --title "chore(llm-timeline): sync model data from Google Sheets + Epoch AI" \
-              --body "Automated LLM Timeline data sync from Google Sheets and Epoch AI."
+              --title "$pr_title" \
+              --body "$pr_body"
           else
             gh pr create \
               --base "${{ github.ref_name }}" \
               --head "$head" \
-              --title "chore(llm-timeline): sync model data from Google Sheets + Epoch AI" \
-              --body "Automated LLM Timeline data sync from Google Sheets and Epoch AI."
+              --title "$pr_title" \
+              --body "$pr_body"
           fi

--- a/.github/workflows/data-sync-llm-timeline.yml
+++ b/.github/workflows/data-sync-llm-timeline.yml
@@ -66,7 +66,7 @@ jobs:
             -m "Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>"
           git push --force-with-lease "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$branch"
 
-          pr_number="$(gh pr list --head "$head" --state open --json number --jq '.[0].number')"
+          pr_number="$(gh pr list --head "$head" --state open --json number --jq '.[0].number // empty')"
 
           if [ -n "$pr_number" ]; then
             gh pr edit "$pr_number" \

--- a/docs/reviews/code-smell-dead-code-2026-04-29.md
+++ b/docs/reviews/code-smell-dead-code-2026-04-29.md
@@ -1,0 +1,27 @@
+# Code Smell & Dead Code Review - 2026-04-29
+
+Scope: recent changes in `duyet/monorepo` since the previous automation run at `2026-04-27T21:03:15Z`.
+
+Recently changed files:
+
+- `.github/workflows/data-sync-llm-timeline.yml`
+
+## Findings Fixed
+
+### Warning: repeated generated PR metadata in workflow shell
+
+- File: `.github/workflows/data-sync-llm-timeline.yml:62`
+- File: `.github/workflows/data-sync-llm-timeline.yml:71`
+- File: `.github/workflows/data-sync-llm-timeline.yml:77`
+- Finding: the LLM Timeline sync PR title was repeated in the commit message, existing-PR edit path, and new-PR create path. The PR body was also repeated across the edit and create paths. That makes future wording updates easy to apply inconsistently.
+- Fix: moved the generated PR title and body into local shell variables and reused them in the commit, edit, and create commands.
+- Confidence: confident.
+
+## Dead Code Notes
+
+No dead-code removals were made. The only post-run changed file is a GitHub Actions workflow, and no unused functions, variables, imports, or non-test code declarations were introduced there.
+
+Search evidence:
+
+- `git log --since='2026-04-27T21:03:15Z' --name-only` found only `.github/workflows/data-sync-llm-timeline.yml` after the last run.
+- `rg -n "chore\\(llm-timeline\\): sync model data from Google Sheets \\+ Epoch AI|Automated LLM Timeline data sync from Google Sheets and Epoch AI" .github/workflows/data-sync-llm-timeline.yml` found five repeated metadata literals before the fix.

--- a/docs/reviews/code-smell-dead-code-2026-04-29.md
+++ b/docs/reviews/code-smell-dead-code-2026-04-29.md
@@ -8,6 +8,13 @@ Recently changed files:
 
 ## Findings Fixed
 
+### Warning: implicit empty fallback for generated sync PR lookup
+
+- File: `.github/workflows/data-sync-llm-timeline.yml:67`
+- Finding: the generated sync PR lookup relied on the default `gh --jq` behavior when no open PR exists. Making the empty fallback explicit keeps the shell branch condition clear and avoids future jq behavior drift around absent array elements.
+- Fix: changed the jq expression to `.[0].number // empty` so the create path explicitly runs when no matching PR exists.
+- Confidence: confident.
+
 ### Warning: repeated generated PR metadata in workflow shell
 
 - File: `.github/workflows/data-sync-llm-timeline.yml:62`
@@ -25,3 +32,4 @@ Search evidence:
 
 - `git log --since='2026-04-27T21:03:15Z' --name-only` found only `.github/workflows/data-sync-llm-timeline.yml` after the last run.
 - `rg -n "chore\\(llm-timeline\\): sync model data from Google Sheets \\+ Epoch AI|Automated LLM Timeline data sync from Google Sheets and Epoch AI" .github/workflows/data-sync-llm-timeline.yml` found five repeated metadata literals before the fix.
+- `gh pr list --head duyet:no-such-branch-for-code-smell-20260429 --state open --json number --jq '.[0].number // empty' | wc -c` returned `0`, confirming the fallback is empty for no matches.


### PR DESCRIPTION
## Summary
- Reuse one generated PR title/body in the LLM Timeline sync workflow
- Add the 2026-04-29 code smell/dead-code review report with search evidence

## Verification
- git diff --check
- ruby YAML load for .github/workflows/data-sync-llm-timeline.yml
- bash -n on extracted workflow run script after replacing GitHub expressions
- npx @biomejs/biome@2.4.7 check targeted paths (not processed because repo ignores these YAML/Markdown paths)

## Summary by Sourcery

Deduplicate generated PR metadata in the LLM timeline data-sync workflow and document the related code-smell review.

Enhancements:
- Define reusable shell variables for the LLM timeline sync PR title and body and use them consistently for commits and PR edits/creation in the workflow script.

Documentation:
- Add a code smell and dead-code review report for 2026-04-29 describing the resolved workflow metadata duplication and search evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized GitHub Actions data sync workflow by consolidating pull request metadata into reusable variables, eliminating duplication across multiple command invocations and improving workflow maintainability

* **Documentation**
  * Added code review documentation detailing workflow optimizations and improvements implemented

<!-- end of auto-generated comment: release notes by coderabbit.ai -->