### PR TITLE
chore(photos): remove unused cache fields

### DIFF
--- a/apps/insights/app/ai/utils/data-fetchers.ts
+++ b/apps/insights/app/ai/utils/data-fetchers.ts
@@ -188,7 +188,7 @@ export async function getCCUsageMetrics(
     ${getDuckDBDateCondition(days, "date")}
   `;
 
-  let results = await executeAnalyticsQuery(query, duckDBQuery);
+  const results = await executeAnalyticsQuery(query, duckDBQuery);
 
   if (!results || results.length === 0) {
     return {

--- a/apps/photos/lib/duckdb-provider.ts
+++ b/apps/photos/lib/duckdb-provider.ts
@@ -6,7 +6,6 @@ import type { Photo } from "./types";
 
 interface DuckDBPhotoRow {
   photo_id: string;
-  provider: string;
   created_at: string;
   updated_at: string;
   width: number;
@@ -141,7 +140,6 @@ export async function getAllDuckDBPhotos(): Promise<Photo[]> {
       `
         SELECT
           photo_id,
-          provider,
           CAST(created_at AS VARCHAR) as created_at,
           CAST(updated_at AS VARCHAR) as updated_at,
           width,


### PR DESCRIPTION
## Summary
- remove the unused DuckDB photo `provider` row field and SELECT item
- change the CC usage cache metrics result binding from `let` to `const`

## Findings fixed
- warning: `apps/insights/app/ai/utils/data-fetchers.ts:191` used `let` for a value Biome confirmed is never reassigned
- info: `apps/photos/lib/duckdb-provider.ts:9` and `apps/photos/lib/duckdb-provider.ts:144` carried a DuckDB `provider` field with zero reads in the mapper; `rg -n "row\.provider|^\s*provider,\s*$|provider: string;" apps/photos/lib/duckdb-provider.ts` returns no matches after cleanup

## Verification
- `bunx --bun biome lint apps/insights/app/ai/utils/data-fetchers.ts apps/photos/lib/duckdb-provider.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false` in `apps/photos`
- `./node_modules/.bin/tsc --noEmit --pretty false` in `apps/insights`
- `git diff --check -- apps/insights/app/ai/utils/data-fetchers.ts apps/photos/lib/duckdb-provider.ts`

Note: root `bun run lint` still reports pre-existing unrelated warnings outside the recent-change scope.

## Summary by Sourcery

Remove unused photo cache field and tighten CC usage metrics result binding.

Enhancements:
- Change CC usage metrics query result binding to use an immutable constant.
- Drop the unused DuckDB photo provider field from the row interface and SELECT projection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code quality and data retrieval efficiency through internal optimizations and structural enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->