### PR TITLE
docs(docs): sync llm timeline workflow notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ GitHub Actions automatically deploy:
 - **Preview**: PRs get preview deployments with URLs commented by @duyetbot
 - Both deploy workflows run type checks (`bun run turbo check-types`), unit tests, and lint before deploy jobs.
 - **Data sync**: `.github/workflows/data-sync-llm-timeline.yml` runs weekly (Monday 06:00 UTC) and supports manual `workflow_dispatch` dry runs.
+  - Manual dry run uses `dry_run=true` and runs `bun scripts/sync-data.ts --dry-run --verbose` in `apps/llm-timeline`.
+  - Non-dry runs commit `apps/llm-timeline/lib/data.ts` updates to `chore/llm-timeline-data-sync` with title `chore(llm-timeline): sync model data from Google Sheets + Epoch AI`.
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary\n- sync root AGENTS/CLAUDE workflow notes with current LLM Timeline sync CI behavior\n- document manual dry run input and command\n- document non-dry-run PR branch/title behavior\n\n## Scope\n- docs only (, with  symlinked)\n\n## Validation\n- verified against

## Summary by Sourcery

Document the current LLM timeline data-sync workflow behavior in the Claude/agents documentation.

Documentation:
- Describe how to trigger manual dry runs for the LLM timeline data-sync workflow, including inputs and command used.
- Explain the behavior of non-dry-run LLM timeline data syncs, including the target branch and pull request title for committed updates.