### PR TITLE
fix(insights): honor ssh cache sync mode

### DIFF
--- a/apps/insights/scripts/sync-analytics-cache.ts
+++ b/apps/insights/scripts/sync-analytics-cache.ts
@@ -42,7 +42,7 @@ function getSshHost(): string {
 }
 
 function getClickHouseConfig() {
-  const useSsh = process.env.CLICKHOUSE_USE_SSH_TUNNEL === "1";
+  const useSsh = useSshClickHouse();
   const host = useSsh ? "127.0.0.1" : process.env.CLICKHOUSE_HOST;
   const port = useSsh ? String(getLocalPort()) : process.env.CLICKHOUSE_PORT || "8123";
   const user = process.env.CLICKHOUSE_USER;


### PR DESCRIPTION
## Summary
- use the shared SSH-mode helper when building the cache sync ClickHouse config
- prevents CLICKHOUSE_USE_SSH=1 runs from requiring CLICKHOUSE_HOST before the SSH query path is used

## Evidence
- Recent commit 7ca95f86 added apps/insights/scripts/sync-analytics-cache.ts with useSshClickHouse() accepting CLICKHOUSE_USE_SSH=1 and CLICKHOUSE_USE_SSH_TUNNEL=1, while getClickHouseConfig() only checked CLICKHOUSE_USE_SSH_TUNNEL=1.
- Repro after fix: UNSPLASH_USERNAME=test CLICKHOUSE_USE_SSH=1 CLICKHOUSE_USER=u CLICKHOUSE_PASSWORD=p CLICKHOUSE_DATABASE=d bun scripts/sync-analytics-cache.ts now reaches SSH ClickHouse authentication instead of failing on missing CLICKHOUSE_HOST.

## Tests
- bun run test (apps/insights)
- bun run check-types (apps/insights)

## Summary by Sourcery

Bug Fixes:
- Ensure cache sync uses the shared SSH ClickHouse mode helper so CLICKHOUSE_USE_SSH is honored without requiring CLICKHOUSE_HOST.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH tunnel configuration logic to properly recognize multiple environment variable options for SSH-tunneled connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->