### PR TITLE
chore(insights): simplify cache sync client lifecycle

### DIFF
--- a/apps/insights/scripts/sync-analytics-cache.ts
+++ b/apps/insights/scripts/sync-analytics-cache.ts
@@ -20,11 +20,9 @@ type QuerySpec = {
   queryParams?: Record<string, unknown>;
 };
 
-const UNSPLASH_USERNAME = process.env.UNSPLASH_USERNAME;
+type ClickHouseClient = ReturnType<typeof createClient>;
 
-function getLocalPort(): number {
-  return Number(process.env.CLICKHOUSE_SSH_LOCAL_PORT || "18123");
-}
+const UNSPLASH_USERNAME = process.env.UNSPLASH_USERNAME;
 
 function useSshClickHouse(): boolean {
   return (
@@ -42,14 +40,13 @@ function getSshHost(): string {
 }
 
 function getClickHouseConfig() {
-  const useSsh = useSshClickHouse();
-  const host = useSsh ? "127.0.0.1" : process.env.CLICKHOUSE_HOST;
-  const port = useSsh ? String(getLocalPort()) : process.env.CLICKHOUSE_PORT || "8123";
+  const host = process.env.CLICKHOUSE_HOST;
+  const port = process.env.CLICKHOUSE_PORT || "8123";
   const user = process.env.CLICKHOUSE_USER;
   const password = process.env.CLICKHOUSE_PASSWORD;
   const database = process.env.CLICKHOUSE_DATABASE;
   const protocol =
-    (useSsh ? "http" : process.env.CLICKHOUSE_PROTOCOL) ||
+    process.env.CLICKHOUSE_PROTOCOL ||
     (["443", "8443", "9440"].includes(port) ? "https" : "http");
 
   const missing = [];
@@ -312,11 +309,8 @@ async function runSshClickHouseQuery(
     .map((line) => JSON.parse(line));
 }
 
-async function fetchRows(
-  client: ReturnType<typeof createClient>,
-  spec: QuerySpec
-) {
-  if (useSshClickHouse()) {
+async function fetchRows(client: ClickHouseClient | null, spec: QuerySpec) {
+  if (!client) {
     return runSshClickHouseQuery(spec.query, spec.queryParams);
   }
 
@@ -365,14 +359,16 @@ async function main() {
     rmSync(tempPath);
   }
 
-  const clickhouse = createClient({
-    ...getClickHouseConfig(),
-    request_timeout: 60_000,
-    clickhouse_settings: {
-      max_execution_time: 60,
-      max_result_rows: "100000",
-    },
-  });
+  const clickhouse = useSshClickHouse()
+    ? null
+    : createClient({
+        ...getClickHouseConfig(),
+        request_timeout: 60_000,
+        clickhouse_settings: {
+          max_execution_time: 60,
+          max_result_rows: "100000",
+        },
+      });
 
   const instance = await DuckDBInstance.create(tempPath);
   const connection = await instance.connect();
@@ -400,7 +396,7 @@ async function main() {
     await Bun.write(cachePath, Bun.file(tempPath));
     rmSync(tempPath);
   } finally {
-    await clickhouse.close();
+    await clickhouse?.close();
     rmSync(tempDir, { force: true, recursive: true });
   }
 

--- a/apps/insights/scripts/sync-analytics-cache.ts
+++ b/apps/insights/scripts/sync-analytics-cache.ts
@@ -21,6 +21,9 @@ type QuerySpec = {
 };
 
 type ClickHouseClient = ReturnType<typeof createClient>;
+type FetchRowsSource =
+  | { mode: "direct"; client: ClickHouseClient }
+  | { mode: "ssh" };
 
 const UNSPLASH_USERNAME = process.env.UNSPLASH_USERNAME;
 
@@ -309,12 +312,12 @@ async function runSshClickHouseQuery(
     .map((line) => JSON.parse(line));
 }
 
-async function fetchRows(client: ClickHouseClient | null, spec: QuerySpec) {
-  if (!client) {
+async function fetchRows(source: FetchRowsSource, spec: QuerySpec) {
+  if (source.mode === "ssh") {
     return runSshClickHouseQuery(spec.query, spec.queryParams);
   }
 
-  const result = await client.query({
+  const result = await source.client.query({
     query: spec.query,
     format: "JSONEachRow",
     query_params: spec.queryParams,
@@ -359,23 +362,26 @@ async function main() {
     rmSync(tempPath);
   }
 
-  const clickhouse = useSshClickHouse()
-    ? null
-    : createClient({
-        ...getClickHouseConfig(),
-        request_timeout: 60_000,
-        clickhouse_settings: {
-          max_execution_time: 60,
-          max_result_rows: "100000",
-        },
-      });
+  const rowSource: FetchRowsSource = useSshClickHouse()
+    ? { mode: "ssh" }
+    : {
+        mode: "direct",
+        client: createClient({
+          ...getClickHouseConfig(),
+          request_timeout: 60_000,
+          clickhouse_settings: {
+            max_execution_time: 60,
+            max_result_rows: "100000",
+          },
+        }),
+      };
 
   const instance = await DuckDBInstance.create(tempPath);
   const connection = await instance.connect();
 
   try {
     for (const spec of querySpecs) {
-      const rows = await fetchRows(clickhouse, spec);
+      const rows = await fetchRows(rowSource, spec);
       await replaceTable(connection, spec, rows, tempDir);
       console.log(`  ${spec.table}: ${rows.length} rows`);
     }
@@ -396,7 +402,9 @@ async function main() {
     await Bun.write(cachePath, Bun.file(tempPath));
     rmSync(tempPath);
   } finally {
-    await clickhouse?.close();
+    if (rowSource.mode === "direct") {
+      await rowSource.client.close();
+    }
     rmSync(tempDir, { force: true, recursive: true });
   }
 

--- a/docs/reviews/code-smell-dead-code-2026-05-01.md
+++ b/docs/reviews/code-smell-dead-code-2026-05-01.md
@@ -1,0 +1,32 @@
+# Code Smell and Dead Code Review - 2026-05-01
+
+## Scope
+
+- Reviewed changes since `2026-04-29T21:00:53Z`.
+- Recent modified files:
+  - `CLAUDE.md`
+  - `apps/insights/app/ai/utils/data-fetchers.ts`
+  - `apps/insights/scripts/sync-analytics-cache.ts`
+  - `apps/photos/lib/duckdb-provider.ts`
+
+## Findings
+
+### Warning: unused ClickHouse HTTP client in SSH cache sync mode
+
+- File: `apps/insights/scripts/sync-analytics-cache.ts`
+- Lines before fix: `368-375`, `319-321`, `403`
+- Issue: `main()` always created a ClickHouse HTTP client, but `fetchRows()` immediately bypassed that client in SSH mode and used `runSshClickHouseQuery()` instead.
+- Fix: create the HTTP client only for direct ClickHouse mode, pass `null` in SSH mode, close the client only when it exists, and keep the HTTP config helper direct-mode-only.
+- Behavior impact: none intended. Direct mode still uses the same client config. SSH mode still runs the same SSH query path.
+
+## Dead Code Evidence
+
+No confident dead-code removals were found in recently modified non-test files.
+
+Search evidence:
+
+```bash
+rg -n "\b(useSshClickHouse|getSshHost|getClickHouseConfig|materializeQueryParams|sqlString|querySpecs|UNSPLASH_USERNAME)\b" . -g '!**/*.test.*' -g '!**/__tests__/**'
+```
+
+The reviewed symbols all had live non-test references, or were part of the same executable script flow.

--- a/docs/reviews/code-smell-dead-code-2026-05-01.md
+++ b/docs/reviews/code-smell-dead-code-2026-05-01.md
@@ -3,7 +3,7 @@
 ## Scope
 
 - Reviewed changes since `2026-04-29T21:00:53Z`.
-- Recent modified files:
+- Recently modified files:
   - `CLAUDE.md`
   - `apps/insights/app/ai/utils/data-fetchers.ts`
   - `apps/insights/scripts/sync-analytics-cache.ts`
@@ -16,7 +16,7 @@
 - File: `apps/insights/scripts/sync-analytics-cache.ts`
 - Lines before fix: `368-375`, `319-321`, `403`
 - Issue: `main()` always created a ClickHouse HTTP client, but `fetchRows()` immediately bypassed that client in SSH mode and used `runSshClickHouseQuery()` instead.
-- Fix: create the HTTP client only for direct ClickHouse mode, pass `null` in SSH mode, close the client only when it exists, and keep the HTTP config helper direct-mode-only.
+- Fix: create the HTTP client only for direct ClickHouse mode, use an explicit SSH fetch mode when no HTTP client is needed, close the client only when it exists, and keep the HTTP config helper direct-mode-only.
 - Behavior impact: none intended. Direct mode still uses the same client config. SSH mode still runs the same SSH query path.
 
 ## Dead Code Evidence


### PR DESCRIPTION
## Summary
- create the ClickHouse HTTP client only for direct cache sync mode
- keep SSH cache sync on the existing SSH query path without an unused client lifecycle
- add the 2026-05-01 code-smell/dead-code review note with search evidence

## Verification
- bunx --bun biome lint apps/insights/scripts/sync-analytics-cache.ts docs/reviews/code-smell-dead-code-2026-05-01.md
- bun run --cwd apps/insights check-types
- bun run --cwd apps/insights build (inconclusive locally: prerender stopped producing output after existing env/API warnings; CI will verify)

## Summary by Sourcery

Simplify the ClickHouse cache sync client lifecycle by only instantiating the HTTP client for direct connections while keeping SSH-based sync on its existing path and documenting the resolved code smell.

Enhancements:
- Create the ClickHouse HTTP client only when not using SSH, passing a nullable client into query execution and closing it conditionally to avoid an unused client lifecycle in SSH mode.

Documentation:
- Add a dated code-smell/dead-code review document describing the previous unused ClickHouse client behavior, its fix, and the supporting search evidence.