### PR TITLE
docs(docs): add turbo check-types command to quality section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `bun run lint` - Lint the workspace with Biome
 - `bun run fmt` - Format all TypeScript, TSX, and Markdown files with Biome
-- `bun run turbo check-types` - Run workspace TypeScript checks via Turbo (used in CI)
+- `bun run check-types` - Run workspace TypeScript checks via Turbo (used in CI)
 - `bun run test` - Run tests across all packages using Turbo
 
 ### Individual App Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `bun run lint` - Lint the workspace with Biome
 - `bun run fmt` - Format all TypeScript, TSX, and Markdown files with Biome
+- `bun run turbo check-types` - Run workspace TypeScript checks via Turbo (used in CI)
 - `bun run test` - Run tests across all packages using Turbo
 
 ### Individual App Development

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "[ \"$CI\" != \"true\" ] && husky || true",
     "fmt": "biome format --write .",
     "lint": "biome lint .",
+    "check-types": "turbo check-types",
     "start": "dotenv -- turbo start",
     "test": "dotenv -- turbo test",
     "config": "turbo run config",


### PR DESCRIPTION
## Summary\n- add missing Turbo error: error preparing engine: Could not find the following tasks in project: check-types command to Code Quality section\n- keep AGENTS/CLAUDE sync via existing symlink\n\n## Why\n- CI workflows run this command, so documenting it avoids command drift\n\n## Verification\n- checked  references for Turbo error: error preparing engine: Could not find the following tasks in project: check-types\n

## Summary by Sourcery

Documentation:
- Add the `bun run turbo check-types` command to the code quality section to describe the workspace TypeScript checks run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the type-checking command available in development.

* **Chores**
  * Added a new script for running type checks across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->