### PR TITLE
fix(insights): keep root prerender deterministic

### DIFF
--- a/apps/insights/src/routes/index.tsx
+++ b/apps/insights/src/routes/index.tsx
@@ -1,30 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { getCCUsageMetrics } from "@/app/ai/utils";
-import { getWakaTimeMetrics } from "@/app/wakatime/wakatime-utils";
 import { OverviewDashboard } from "@/components/dashboard/OverviewDashboard";
 
 export const Route = createFileRoute("/")({
   loader: async () => {
-    const shouldFetchLiveMetrics =
-      typeof window === "undefined" &&
-      (process.env.CI || process.env.GITHUB_ACTIONS);
-
-    if (!shouldFetchLiveMetrics) {
-      return {
-        aiMetrics: null,
-        wakaTimeMetrics: null,
-      };
-    }
-
-    const [aiMetrics, wakaTimeMetrics] = await Promise.allSettled([
-      getCCUsageMetrics(30),
-      getWakaTimeMetrics(30),
-    ]);
-
+    // Keep the root route deterministic for Cloudflare Pages prerendering.
+    // Live metrics pages load their own data on their dedicated routes.
     return {
-      aiMetrics: aiMetrics.status === "fulfilled" ? aiMetrics.value : null,
-      wakaTimeMetrics:
-        wakaTimeMetrics.status === "fulfilled" ? wakaTimeMetrics.value : null,
+      aiMetrics: null,
+      wakaTimeMetrics: null,
     };
   },
   head: () => ({


### PR DESCRIPTION
## Summary
- avoid live metrics fetching in the Insights root route loader
- keep Cloudflare Pages prerender deterministic so dist/client/index.html is emitted
- document that live metrics load on dedicated metric routes

## Verification
- git diff --check
- bun run build && test -f dist/client/index.html && bun run check-types (apps/insights)

## Summary by Sourcery

Make the Insights root route loader deterministic by removing live metrics fetching during prerender.

Bug Fixes:
- Stop fetching live metrics in the Insights root route loader to keep Cloudflare Pages prerender deterministic and ensure dist/client/index.html is emitted.

Documentation:
- Clarify that live metrics are loaded on their own dedicated metric routes instead of via the root route.