### PR TITLE
feat(rust): WASM toolchain foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ yarn-error.log*
 # Screenshot files
 *-app.png
 .herenow/
+
+# Rust/WASM
+target/
+**/pkg/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,17 @@
+[workspace]
+resolver = "2"
+members = [
+    "crates/*",
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+
+[workspace.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-test = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+js-sys = "0.3"

--- a/bun.lock
+++ b/bun.lock
@@ -539,6 +539,14 @@
         "typescript": "^6.0.0",
       },
     },
+    "packages/wasm": {
+      "name": "@duyet/wasm",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@duyet/tsconfig": "*",
+        "typescript": "*",
+      },
+    },
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -796,6 +804,8 @@
     "@duyet/tsconfig": ["@duyet/tsconfig@workspace:packages/tsconfig"],
 
     "@duyet/urls": ["@duyet/urls@workspace:packages/urls"],
+
+    "@duyet/wasm": ["@duyet/wasm@workspace:packages/wasm"],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 

--- a/crates/placeholder/Cargo.toml
+++ b/crates/placeholder/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "duyet-placeholder"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen.workspace = true
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/crates/placeholder/src/lib.rs
+++ b/crates/placeholder/src/lib.rs
@@ -1,0 +1,16 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn noop() -> String {
+    "wasm-infrastructure-ready".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_noop() {
+        assert_eq!(noop(), "wasm-infrastructure-ready");
+    }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "config": "turbo run config",
     "deploy": "turbo deploy && bun run config",
     "cf:deploy": "bun scripts/cf-deploy.ts",
-    "cf:deploy:prod": "turbo run cf:deploy:prod"
+    "cf:deploy:prod": "turbo run cf:deploy:prod",
+    "wasm:build": "bun scripts/wasm-build.ts",
+    "wasm:build:release": "bun scripts/wasm-build.ts --release",
+    "wasm:test": "cargo test --workspace",
+    "wasm:clippy": "cargo clippy --workspace --target wasm32-unknown-unknown"
   },
   "lint-staged": {
     "*": "biome format --write"

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -1,0 +1,14 @@
+// @duyet/wasm - Rust/WASM modules compiled via wasm-pack
+//
+// Build first: `bun run wasm:build` at repo root
+//
+// Each crate under crates/ produces bindings in ./pkg/<crate-name>/
+// Import directly from the generated module:
+//
+//   import { noop } from "@duyet/wasm/pkg/placeholder/placeholder.js"
+//   import { parseCsv } from "@duyet/wasm/pkg/csv-parser/csv_parser.js"
+//
+// Each WASM module must be initialized before use (auto-happens on first import
+// with wasm-pack's --target web output).
+
+export {}

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@duyet/wasm",
+  "version": "0.1.0",
+  "license": "MIT",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "scripts": {
+    "build": "echo 'WASM modules built via cargo/wasm-pack at repo root'",
+    "test": "echo 'WASM tests run via cargo test — see bun run wasm:test'"
+  },
+  "devDependencies": {
+    "@duyet/tsconfig": "*",
+    "typescript": "*"
+  }
+}

--- a/packages/wasm/tsconfig.json
+++ b/packages/wasm/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@duyet/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts"]
+}

--- a/scripts/wasm-build.ts
+++ b/scripts/wasm-build.ts
@@ -1,0 +1,54 @@
+import { $ } from "bun"
+import { readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+
+const CRATES_DIR = join(import.meta.dir, "..", "crates")
+const OUT_DIR = join(import.meta.dir, "..", "packages", "wasm", "pkg")
+const release = Bun.argv.includes("--release")
+
+const crates = readdirSync(CRATES_DIR).filter((name) => {
+  const p = join(CRATES_DIR, name)
+  return statSync(p).isDirectory() && statSync(join(p, "Cargo.toml"), { throwIfNoEntry: false })
+})
+
+if (crates.length === 0) {
+  console.log("No WASM crates found in", CRATES_DIR)
+  process.exit(0)
+}
+
+console.log(`Building ${crates.length} crate(s): ${crates.join(", ")}`)
+
+const profile = release ? "release" : "dev"
+const cargoArgs = release ? ["--release"] : []
+
+// Build all crates for WASM target
+await $`cargo build --target wasm32-unknown-unknown ${cargoArgs}`.cwd(join(import.meta.dir, ".."))
+
+// Run wasm-pack for each crate
+for (const crate of crates) {
+  const cratePath = join(CRATES_DIR, crate)
+  const outPath = join(OUT_DIR, crate)
+
+  console.log(`\nwasm-pack: ${crate} -> ${outPath}`)
+
+  // Derive output name from crate name (replace hyphens with underscores)
+  const outName = crate.replace(/-/g, "_")
+
+  const args = [
+    "wasm-pack", "build",
+    "--target", "web",
+    "--out-dir", outPath,
+    "--out-name", outName,
+    ...(release ? ["--release"] : []),
+    cratePath,
+  ]
+
+  const proc = Bun.spawn(args, { stdout: "inherit", stderr: "inherit" })
+  const exitCode = await proc.exited
+  if (exitCode !== 0) {
+    console.error(`wasm-pack failed for ${crate} (exit ${exitCode})`)
+    process.exit(1)
+  }
+}
+
+console.log(`\nDone. ${crates.length} WASM module(s) built.`)

--- a/turbo.json
+++ b/turbo.json
@@ -93,6 +93,14 @@
     },
     "cf:deploy:prod": {
       "cache": false
+    },
+    "wasm:build": {
+      "outputs": ["packages/wasm/pkg/**"],
+      "dependsOn": []
+    },
+    "wasm:build:release": {
+      "outputs": ["packages/wasm/pkg/**"],
+      "dependsOn": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- Cargo workspace at repo root with `crates/*` members
- `@duyet/wasm` package as WASM module barrel
- `scripts/wasm-build.ts` auto-discovers and builds all crates via wasm-pack
- Turbo tasks `wasm:build` / `wasm:build:release` integrated
- Placeholder crate validates full Rust → WASM → JS pipeline (13KB binary)

## Test plan
- [x] `cargo test --workspace` passes
- [x] `bun run wasm:build` produces WASM artifacts
- [x] `bun run test` passes (15/15 packages)
- [x] `bun install` registers new workspace package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an initial Rust-based WASM toolchain and workspace integration across the monorepo.

New Features:
- Add a Rust Cargo workspace with shared dependencies for WASM crates under crates/*.
- Introduce a placeholder Rust crate compiled to WASM to validate the Rust → WASM → JS pipeline.
- Add an @duyet/wasm package as a barrel for consuming generated WASM bindings from JavaScript.

Enhancements:
- Add a Bun-based wasm-build script that discovers and builds all WASM crates via cargo and wasm-pack for dev and release profiles.
- Wire new WASM build, test, and lint (clippy) commands into the root package.json and Turbo tasks configuration.

Tests:
- Add a basic test for the placeholder WASM crate to verify the exported noop function and end-to-end toolchain.