### PR TITLE
feat(rust): csv parser via wasm

### DIFF
--- a/apps/llm-timeline/lib/csv.ts
+++ b/apps/llm-timeline/lib/csv.ts
@@ -3,65 +3,14 @@
  * Used by all data source adapters
  */
 
+import { parse_csv } from "@duyet/wasm/pkg/csv-parser/csv_parser.js";
+
 /**
- * RFC 4180 compliant CSV parser
+ * RFC 4180 compliant CSV parser (WASM-backed)
  * Handles quoted fields, embedded commas, and newlines
  */
 export function parseCsv(text: string): string[][] {
-  const rows: string[][] = [];
-  let i = 0;
-
-  while (i < text.length) {
-    const row: string[] = [];
-
-    while (i < text.length) {
-      if (text[i] === '"') {
-        // Quoted field
-        i++; // skip opening quote
-        let field = "";
-        while (i < text.length) {
-          if (text[i] === '"' && text[i + 1] === '"') {
-            field += '"';
-            i += 2;
-          } else if (text[i] === '"') {
-            i++; // skip closing quote
-            break;
-          } else {
-            field += text[i++];
-          }
-        }
-        row.push(field);
-        if (text[i] === ",") i++;
-        else if (text[i] === "\r") i++;
-      } else {
-        // Unquoted field — read until comma or newline
-        let field = "";
-        while (
-          i < text.length &&
-          text[i] !== "," &&
-          text[i] !== "\n" &&
-          text[i] !== "\r"
-        ) {
-          field += text[i++];
-        }
-        row.push(field.trim());
-        if (text[i] === ",") i++;
-        else if (text[i] === "\r") i++;
-      }
-
-      // End of row
-      if (i >= text.length || text[i] === "\n") {
-        i++; // skip newline
-        break;
-      }
-    }
-
-    if (row.length > 0 && !(row.length === 1 && row[0] === "")) {
-      rows.push(row);
-    }
-  }
-
-  return rows;
+  return JSON.parse(parse_csv(text)) as string[][];
 }
 
 /**

--- a/apps/llm-timeline/package.json
+++ b/apps/llm-timeline/package.json
@@ -26,6 +26,7 @@
     "@duyet/components": "*",
     "@duyet/libs": "*",
     "@duyet/urls": "*",
+    "@duyet/wasm": "*",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -349,6 +349,7 @@
         "@duyet/components": "*",
         "@duyet/libs": "*",
         "@duyet/urls": "*",
+        "@duyet/wasm": "*",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-router": "^1.0.0",
         "@tanstack/react-start": "^1.0.0",

--- a/crates/csv-parser/Cargo.toml
+++ b/crates/csv-parser/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "duyet-csv-parser"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+csv = "1"
+serde.workspace = true
+serde_json.workspace = true
+wasm-bindgen.workspace = true
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/crates/csv-parser/src/lib.rs
+++ b/crates/csv-parser/src/lib.rs
@@ -1,0 +1,113 @@
+use wasm_bindgen::prelude::*;
+
+/// Parse a CSV string (RFC 4180) and return a JSON 2D string array.
+///
+/// Handles quoted fields, embedded commas, embedded newlines, and escaped
+/// double-quotes (`""`).
+#[wasm_bindgen]
+pub fn parse_csv(input: &str) -> String {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .flexible(true)
+        .from_reader(input.as_bytes());
+
+    let rows: Vec<Vec<String>> = reader
+        .records()
+        .filter_map(|result| result.ok())
+        .filter(|record| !record.is_empty())
+        .map(|record| record.iter().map(|field| field.to_string()).collect())
+        .collect();
+
+    serde_json::to_string(&rows).unwrap_or_else(|_| "[]".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_csv() {
+        let json = parse_csv("a,b,c\n1,2,3");
+        let rows: Vec<Vec<String>> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec!["a", "b", "c"],
+                vec!["1", "2", "3"],
+            ]
+        );
+    }
+
+    #[test]
+    fn quoted_field_with_comma() {
+        let json = parse_csv("name,desc\n\"hello, world\",test");
+        let rows: Vec<Vec<String>> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec!["name", "desc"],
+                vec!["hello, world", "test"],
+            ]
+        );
+    }
+
+    #[test]
+    fn escaped_quotes() {
+        let json = parse_csv("a,b\n\"he said \"\"hi\"\"\",ok");
+        let rows: Vec<Vec<String>> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec!["a", "b"],
+                vec!["he said \"hi\"", "ok"],
+            ]
+        );
+    }
+
+    #[test]
+    fn newline_in_quoted_field() {
+        let json = parse_csv("a,b\n\"line1\nline2\",ok");
+        let rows: Vec<Vec<String>> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec!["a", "b"],
+                vec!["line1\nline2", "ok"],
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_input() {
+        let json = parse_csv("");
+        let rows: Vec<Vec<String>> = serde_json::from_str(&json).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn trailing_newline_only_row() {
+        // A single trailing newline should not produce an extra empty row
+        let json = parse_csv("a,b\n1,2\n");
+        let rows: Vec<Vec<String>> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec!["a", "b"],
+                vec!["1", "2"],
+            ]
+        );
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        let json = parse_csv("a,b\r\n1,2\r\n");
+        let rows: Vec<Vec<String>> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                vec!["a", "b"],
+                vec!["1", "2"],
+            ]
+        );
+    }
+}

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -6,7 +6,7 @@
 // Import directly from the generated module:
 //
 //   import { noop } from "@duyet/wasm/pkg/placeholder/placeholder.js"
-//   import { parseCsv } from "@duyet/wasm/pkg/csv-parser/csv_parser.js"
+//   import { parse_csv } from "@duyet/wasm/pkg/csv-parser/csv_parser.js"
 //
 // Each WASM module must be initialized before use (auto-happens on first import
 // with wasm-pack's --target web output).


### PR DESCRIPTION
## Summary
- Add `crates/csv-parser/` Rust crate using the `csv` crate for RFC 4180 parsing
- Replace character-by-character TS `parseCsv` with WASM call
- Column detection logic (`normalizeHeader`, `detectColumns`) stays in TS
- 7 Rust tests pass, 45 JS tests pass

## Test plan
- [x] `cargo test -p duyet-csv-parser` — 7/7 pass
- [x] `bun run wasm:build` — builds both placeholder + csv-parser
- [x] `cd apps/llm-timeline && bun test` — 45/45 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace the TypeScript CSV parser with a WASM-backed Rust implementation and wire it into the LLM timeline app.

New Features:
- Introduce a Rust-based CSV parser crate compiled to WASM and exposed via a parse_csv binding.

Enhancements:
- Switch the LLM timeline CSV parsing to use the shared WASM CSV parser package instead of the inlined TypeScript implementation.

Build:
- Add the @duyet/wasm package as a dependency of the LLM timeline app for access to the generated WASM modules.

Tests:
- Add Rust unit tests covering core CSV parsing behaviors including quoting, newlines, and various edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * CSV parsing now uses a WebAssembly-backed parser for improved performance, replacing the previous manual implementation.
  
* **Tests**
  * Added unit tests for CSV parsing covering RFC 4180 scenarios including quoted fields, newlines, and CRLF endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->