### PR TITLE
feat(rust): data normalizers via wasm

### DIFF
--- a/apps/llm-timeline/lib/normalizers.ts
+++ b/apps/llm-timeline/lib/normalizers.ts
@@ -1,33 +1,41 @@
 /**
  * Shared field normalization functions
  * Used by all data source adapters for consistent data formatting
+ *
+ * Heavy regex work is delegated to the Rust/WASM module (crates/normalizers).
+ * Build the WASM module first: `bun run wasm:build` at repo root.
  */
 
-const MONTH_MAP: Record<string, string> = {
-  january: "01",
-  february: "02",
-  march: "03",
-  april: "04",
-  may: "05",
-  june: "06",
-  july: "07",
-  august: "08",
-  september: "09",
-  october: "10",
-  november: "11",
-  december: "12",
-  jan: "01",
-  feb: "02",
-  mar: "03",
-  apr: "04",
-  jun: "06",
-  jul: "07",
-  aug: "08",
-  sep: "09",
-  oct: "10",
-  nov: "11",
-  dec: "12",
-};
+import {
+  initSync,
+  normalize_date as wasm_normalize_date,
+  normalize_params as wasm_normalize_params,
+  normalize_license as wasm_normalize_license,
+  map_accessibility as wasm_map_accessibility,
+  normalize_type as wasm_normalize_type,
+  normalize_text as wasm_normalize_text,
+  convert_numeric_params as wasm_convert_numeric_params,
+  format_training_compute as wasm_format_training_compute,
+} from "@duyet/wasm/pkg/normalizers/normalizers.js"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+// Resolve WASM binary relative to the @duyet/wasm package location
+// The JS bindings are at packages/wasm/pkg/normalizers/normalizers.js,
+// and the WASM binary sits next to them.
+let _initialized = false
+function ensureInit() {
+  if (_initialized) return
+  // Use require.resolve equivalent to find the package location
+  const jsPath = import.meta.resolve("@duyet/wasm/pkg/normalizers/normalizers.js")
+  const wasmUrl = new URL("normalizers_bg.wasm", jsPath)
+  const wasmPath = decodeURIComponent(
+    wasmUrl.protocol === "file:" ? wasmUrl.pathname : wasmUrl.href,
+  )
+  const wasmBuffer = readFileSync(resolve(wasmPath))
+  initSync({ module: wasmBuffer })
+  _initialized = true
+}
 
 /**
  * Normalize a raw date string into YYYY-MM-DD format
@@ -35,54 +43,9 @@ const MONTH_MAP: Record<string, string> = {
  *          Feb/2026, 2024-01-15T00:00:00, etc.
  */
 export function normalizeDate(raw: string): string | null {
-  const s = raw.trim();
-  if (!s || s.toLowerCase() === "tba" || s.toLowerCase() === "tbd" || s === "-")
-    return null;
-
-  // Already YYYY-MM-DD
-  if (/^\d{4}-\d{2}-\d{2}$/.test(s)) return s;
-
-  // ISO datetime: 2024-01-15T00:00:00 → 2024-01-15
-  const isoMatch = s.match(/^(\d{4}-\d{2}-\d{2})T/);
-  if (isoMatch) return isoMatch[1];
-
-  // Already YYYY-MM (partial date, assume first of month)
-  if (/^\d{4}-\d{2}$/.test(s)) return `${s}-01`;
-
-  // Plain year e.g. "2024"
-  if (/^\d{4}$/.test(s)) return `${s}-01-01`;
-
-  // "Q1 2024" / "Q2/2024" etc.
-  const quarterMatch = s.match(/Q([1-4])[\s/]+(20\d{2})/i);
-  if (quarterMatch) {
-    const q = parseInt(quarterMatch[1], 10);
-    const y = quarterMatch[2];
-    const month = String((q - 1) * 3 + 1).padStart(2, "0");
-    return `${y}-${month}-01`;
-  }
-
-  // "Feb/2026" / "Jan/2025" style (Google Sheets format)
-  const slashMonthMatch = s.match(/^([a-z]{3,})\/(20\d{2})$/i);
-  if (slashMonthMatch) {
-    const month = MONTH_MAP[slashMonthMatch[1].toLowerCase()];
-    if (month) return `${slashMonthMatch[2]}-${month}-01`;
-  }
-
-  // "Jan 2024" / "January 2024" / "Jan, 2024"
-  const monthMatch = s.match(/^([a-z]+)[,.\s]+(20\d{2})$/i);
-  if (monthMatch) {
-    const month = MONTH_MAP[monthMatch[1].toLowerCase()];
-    if (month) return `${monthMatch[2]}-${month}-01`;
-  }
-
-  // "2024 Jan" format
-  const reverseMatch = s.match(/^(20\d{2})[,.\s]+([a-z]+)$/i);
-  if (reverseMatch) {
-    const month = MONTH_MAP[reverseMatch[2].toLowerCase()];
-    if (month) return `${reverseMatch[1]}-${month}-01`;
-  }
-
-  return null;
+  ensureInit()
+  const result = wasm_normalize_date(raw)
+  return result || null
 }
 
 /**
@@ -90,119 +53,48 @@ export function normalizeDate(raw: string): string | null {
  * Handles: "175B", "1.8T", "~45B", "175 billion", plain numbers, etc.
  */
 export function normalizeParams(raw: string): string | null {
-  const s = raw.trim().toLowerCase();
-  if (
-    !s ||
-    s === "unknown" ||
-    s === "n/a" ||
-    s === "-" ||
-    s === "tbd" ||
-    s === "tba"
-  )
-    return null;
-
-  // Already in format like "175B", "1.8T", "70B", "~45B"
-  if (/^[~<>≈]?\d+(\.\d+)?[bBtTmMkK]/.test(raw.trim())) return raw.trim();
-
-  // Compound format like "230B-A10B" (MoE active params)
-  if (/^\d+(\.\d+)?[bBtTmMkK]-[aA]\d+(\.\d+)?[bBtTmMkK]/.test(raw.trim()))
-    return raw.trim();
-
-  // "175 billion" / "1.8 trillion" / "70 million"
-  const wordMatch = s.match(
-    /^([~<>≈]?\d+(?:\.\d+)?)\s*(billion|trillion|million|thousand|b|t|m|k)/
-  );
-  if (wordMatch) {
-    const num = wordMatch[1];
-    const unit = wordMatch[2];
-    const unitMap: Record<string, string> = {
-      billion: "B",
-      b: "B",
-      trillion: "T",
-      t: "T",
-      million: "M",
-      m: "M",
-      thousand: "K",
-      k: "K",
-    };
-    return `${num}${unitMap[unit]}`;
-  }
-
-  // Plain number — treat as billions
-  const numMatch = s.match(/^(\d+(?:\.\d+)?)$/);
-  if (numMatch) {
-    const n = parseFloat(numMatch[1]);
-    if (n > 0) return `${n}B`;
-  }
-
-  return raw.trim() || null;
+  ensureInit()
+  const result = wasm_normalize_params(raw)
+  return result || null
 }
 
 /**
  * Normalize license/accessibility string to standard type
  */
-export function normalizeLicense(raw: string): "open" | "closed" | "partial" {
-  const s = raw.trim();
-
-  // Emoji from "Public?" column: 🟢 = open/public, 🔴 = closed/private
-  if (s.includes("🟢")) return "open";
-  if (s.includes("🔴")) return "closed";
-  if (s.includes("🟡") || s.includes("🟠")) return "partial";
-
-  const lower = s.toLowerCase();
-  if (/open|apache|mit|gpl|lgpl|bsd|cc|creative|llama.?license/.test(lower))
-    return "open";
-  if (
-    /partial|research|non.commercial|limited|restricted|community/.test(lower)
-  )
-    return "partial";
-  if (/yes|public|true/.test(lower)) return "open";
-  if (/no|private|false|closed|proprietary/.test(lower)) return "closed";
-
-  return "closed";
+export function normalizeLicense(
+  raw: string,
+): "open" | "closed" | "partial" {
+  ensureInit()
+  return wasm_normalize_license(raw) as "open" | "closed" | "partial"
 }
 
 /**
  * Map accessibility string to license type (Epoch.ai format)
  */
 export function mapAccessibility(
-  accessibility: string
+  accessibility: string,
 ): "open" | "closed" | "partial" {
-  const s = accessibility.toLowerCase().trim();
-
-  if (s.includes("open") || s.includes("public") || s === "yes" || s === "true")
-    return "open";
-  if (
-    s.includes("closed") ||
-    s.includes("private") ||
-    s === "no" ||
-    s === "false"
-  )
-    return "closed";
-  if (s.includes("partial") || s.includes("research") || s.includes("limited"))
-    return "partial";
-
-  return "closed";
+  ensureInit()
+  return wasm_map_accessibility(accessibility) as
+    | "open"
+    | "closed"
+    | "partial"
 }
 
 /**
  * Normalize model type string
  */
 export function normalizeType(raw: string): "model" | "milestone" {
-  const s = raw.trim().toLowerCase();
-  if (/milestone|event|paper|architecture|announcement|breakthrough/.test(s))
-    return "milestone";
-  return "model";
+  ensureInit()
+  return wasm_normalize_type(raw) as "model" | "milestone"
 }
 
 /**
  * Normalize text: collapse whitespace, trim
  */
 export function normalizeText(raw: string): string {
-  return raw
-    .replace(/[\n\r]/g, " ")
-    .trim()
-    .replace(/\s+/g, " ");
+  ensureInit()
+  return wasm_normalize_text(raw)
 }
 
 /**
@@ -210,32 +102,12 @@ export function normalizeText(raw: string): string {
  * e.g., 175000000000.0 → "175B", 1000000000.0 → "1B"
  */
 export function convertNumericParams(
-  floatValue: number | string
+  floatValue: number | string,
 ): string | null {
-  if (!floatValue || floatValue === "" || floatValue === "0") return null;
-
-  const num =
-    typeof floatValue === "string" ? parseFloat(floatValue) : floatValue;
-  if (Number.isNaN(num) || num === 0) return null;
-
-  if (num >= 1e12) {
-    const t = num / 1e12;
-    return t === Math.floor(t) ? `${t}T` : `${t.toFixed(1)}T`;
-  }
-  if (num >= 1e9) {
-    const b = num / 1e9;
-    return b === Math.floor(b) ? `${b}B` : `${b.toFixed(1)}B`;
-  }
-  if (num >= 1e6) {
-    const m = num / 1e6;
-    return m === Math.floor(m) ? `${m}M` : `${m.toFixed(1)}M`;
-  }
-  if (num >= 1e3) {
-    const k = num / 1e3;
-    return k === Math.floor(k) ? `${k}K` : `${k.toFixed(1)}K`;
-  }
-
-  return `${Math.floor(num)}`;
+  ensureInit()
+  const input = typeof floatValue === "number" ? String(floatValue) : floatValue
+  const result = wasm_convert_numeric_params(input)
+  return result || null
 }
 
 /**
@@ -243,10 +115,6 @@ export function convertNumericParams(
  * e.g., 1.2e25 → "1.2e25 FLOP"
  */
 export function formatTrainingCompute(flop: number): string {
-  if (flop >= 1e15) {
-    const exp = Math.floor(Math.log10(flop));
-    const mantissa = flop / 10 ** exp;
-    return mantissa === 1 ? `1e${exp}` : `${mantissa.toFixed(1)}e${exp}`;
-  }
-  return `${flop}`;
+  ensureInit()
+  return wasm_format_training_compute(flop)
 }

--- a/apps/llm-timeline/package.json
+++ b/apps/llm-timeline/package.json
@@ -26,6 +26,7 @@
     "@duyet/components": "*",
     "@duyet/libs": "*",
     "@duyet/urls": "*",
+    "@duyet/wasm": "*",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -349,6 +349,7 @@
         "@duyet/components": "*",
         "@duyet/libs": "*",
         "@duyet/urls": "*",
+        "@duyet/wasm": "*",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-router": "^1.0.0",
         "@tanstack/react-start": "^1.0.0",

--- a/crates/normalizers/Cargo.toml
+++ b/crates/normalizers/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "duyet-normalizers"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen.workspace = true
+regex = "1"
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/crates/normalizers/src/lib.rs
+++ b/crates/normalizers/src/lib.rs
@@ -1,0 +1,454 @@
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use regex::Regex;
+use wasm_bindgen::prelude::*;
+
+fn month_map() -> &'static HashMap<&'static str, &'static str> {
+    static M: OnceLock<HashMap<&str, &str>> = OnceLock::new();
+    M.get_or_init(|| {
+        let mut m = HashMap::new();
+        m.insert("january", "01");
+        m.insert("february", "02");
+        m.insert("march", "03");
+        m.insert("april", "04");
+        m.insert("may", "05");
+        m.insert("june", "06");
+        m.insert("july", "07");
+        m.insert("august", "08");
+        m.insert("september", "09");
+        m.insert("october", "10");
+        m.insert("november", "11");
+        m.insert("december", "12");
+        m.insert("jan", "01");
+        m.insert("feb", "02");
+        m.insert("mar", "03");
+        m.insert("apr", "04");
+        m.insert("jun", "06");
+        m.insert("jul", "07");
+        m.insert("aug", "08");
+        m.insert("sep", "09");
+        m.insert("oct", "10");
+        m.insert("nov", "11");
+        m.insert("dec", "12");
+        m
+    })
+}
+
+macro_rules! re {
+    ($pattern:expr) => {{
+        static RE: OnceLock<Regex> = OnceLock::new();
+        RE.get_or_init(|| Regex::new($pattern).unwrap())
+    }};
+}
+
+/// Normalize a raw date string into YYYY-MM-DD format.
+/// Returns empty string for unparseable/TBA/TBD inputs (caller maps to null).
+#[wasm_bindgen]
+pub fn normalize_date(raw: &str) -> String {
+    let s = raw.trim();
+    if s.is_empty() || s.eq_ignore_ascii_case("tba") || s.eq_ignore_ascii_case("tbd") || s == "-" {
+        return String::new();
+    }
+
+    if re!(r"^\d{4}-\d{2}-\d{2}$").is_match(s) {
+        return s.to_string();
+    }
+
+    if let Some(caps) = re!(r"^(\d{4}-\d{2}-\d{2})T").captures(s) {
+        return caps[1].to_string();
+    }
+
+    if re!(r"^\d{4}-\d{2}$").is_match(s) {
+        return format!("{}-01", s);
+    }
+
+    if re!(r"^\d{4}$").is_match(s) {
+        return format!("{}-01-01", s);
+    }
+
+    if let Some(caps) = re!(r"(?i)Q([1-4])[\s/]+(20\d{2})").captures(s) {
+        let q: u32 = caps[1].parse().unwrap();
+        let y = &caps[2];
+        let month = (q - 1) * 3 + 1;
+        return format!("{}-{:02}-01", y, month);
+    }
+
+    let mmap = month_map();
+
+    if let Some(caps) = re!(r"(?i)^([a-z]{3,})/(20\d{2})$").captures(s) {
+        let month_name = caps[1].to_lowercase();
+        if let Some(&month) = mmap.get(month_name.as_str()) {
+            return format!("{}-{}-01", &caps[2], month);
+        }
+    }
+
+    if let Some(caps) = re!(r"(?i)^([a-z]+)[,.\s]+(20\d{2})$").captures(s) {
+        let month_name = caps[1].to_lowercase();
+        if let Some(&month) = mmap.get(month_name.as_str()) {
+            return format!("{}-{}-01", &caps[2], month);
+        }
+    }
+
+    if let Some(caps) = re!(r"(?i)^(20\d{2})[,.\s]+([a-z]+)$").captures(s) {
+        let month_name = caps[2].to_lowercase();
+        if let Some(&month) = mmap.get(month_name.as_str()) {
+            return format!("{}-{}-01", &caps[1], month);
+        }
+    }
+
+    String::new()
+}
+
+/// Normalize parameter count strings.
+/// Returns empty string for unknown/n/a (caller maps to null).
+#[wasm_bindgen]
+pub fn normalize_params(raw: &str) -> String {
+    let s = raw.trim();
+    let lower = s.to_lowercase();
+    if lower.is_empty()
+        || lower == "unknown"
+        || lower == "n/a"
+        || lower == "-"
+        || lower == "tbd"
+        || lower == "tba"
+    {
+        return String::new();
+    }
+
+    if re!(r"^[~<>≈]?\d+(\.\d+)?[bBtTmMkK]").is_match(s) {
+        return s.to_string();
+    }
+
+    if re!(r"^\d+(\.\d+)?[bBtTmMkK]-[aA]\d+(\.\d+)?[bBtTmMkK]").is_match(s) {
+        return s.to_string();
+    }
+
+    if let Some(caps) = re!(r"(?i)^([~<>≈]?\d+(?:\.\d+)?)\s*(billion|trillion|million|thousand|b|t|m|k)").captures(&lower) {
+        let num = &caps[1];
+        let unit = &caps[2];
+        let suffix = match unit {
+            "billion" | "b" => "B",
+            "trillion" | "t" => "T",
+            "million" | "m" => "M",
+            "thousand" | "k" => "K",
+            _ => "B",
+        };
+        return format!("{}{}", num, suffix);
+    }
+
+    if let Some(caps) = re!(r"^(\d+(?:\.\d+)?)$").captures(&lower) {
+        if let Ok(n) = caps[1].parse::<f64>() {
+            if n > 0.0 {
+                return format!("{}B", n);
+            }
+        }
+    }
+
+    if s.is_empty() { String::new() } else { s.to_string() }
+}
+
+/// Normalize license/accessibility string to standard type.
+#[wasm_bindgen]
+pub fn normalize_license(raw: &str) -> String {
+    let s = raw.trim();
+
+    if s.contains('\u{1f7e2}') { return "open".to_string(); }
+    if s.contains('\u{1f534}') { return "closed".to_string(); }
+    if s.contains('\u{1f7e1}') || s.contains('\u{1f7e0}') {
+        return "partial".to_string();
+    }
+
+    let lower = s.to_lowercase();
+
+    if re!(r"(?i)open|apache|mit|gpl|lgpl|bsd|cc|creative|llama.?license").is_match(&lower) {
+        return "open".to_string();
+    }
+    if re!(r"(?i)partial|research|non.commercial|limited|restricted|community").is_match(&lower) {
+        return "partial".to_string();
+    }
+    if re!(r"(?i)yes|public|true").is_match(&lower) {
+        return "open".to_string();
+    }
+    if re!(r"(?i)no|private|false|closed|proprietary").is_match(&lower) {
+        return "closed".to_string();
+    }
+
+    "closed".to_string()
+}
+
+/// Map accessibility string to license type (Epoch.ai format).
+#[wasm_bindgen]
+pub fn map_accessibility(accessibility: &str) -> String {
+    let s = accessibility.trim().to_lowercase();
+
+    if s.contains("open") || s.contains("public") || s == "yes" || s == "true" {
+        return "open".to_string();
+    }
+    if s.contains("closed") || s.contains("private") || s == "no" || s == "false" {
+        return "closed".to_string();
+    }
+    if s.contains("partial") || s.contains("research") || s.contains("limited") {
+        return "partial".to_string();
+    }
+
+    "closed".to_string()
+}
+
+/// Normalize model type string.
+#[wasm_bindgen]
+pub fn normalize_type(raw: &str) -> String {
+    let s = raw.trim().to_lowercase();
+    if re!(r"(?i)milestone|event|paper|architecture|announcement|breakthrough").is_match(&s) {
+        "milestone".to_string()
+    } else {
+        "model".to_string()
+    }
+}
+
+/// Normalize text: collapse whitespace, trim.
+#[wasm_bindgen]
+pub fn normalize_text(raw: &str) -> String {
+    let step1 = re!(r"[\n\r]").replace_all(raw, " ");
+    let trimmed = step1.trim();
+    re!(r"\s+").replace_all(trimmed, " ").to_string()
+}
+
+/// Convert parameter count from float to readable format.
+/// Returns empty string for zero/invalid inputs.
+#[wasm_bindgen]
+pub fn convert_numeric_params(float_value: &str) -> String {
+    if float_value.is_empty() || float_value == "0" {
+        return String::new();
+    }
+
+    let num: f64 = match float_value.parse() {
+        Ok(n) => n,
+        Err(_) => return String::new(),
+    };
+
+    if num == 0.0 || num.is_nan() {
+        return String::new();
+    }
+
+    if num >= 1e12 {
+        let t = num / 1e12;
+        return if t == t.floor() {
+            format!("{}T", t as u64)
+        } else {
+            format!("{:.1}T", t)
+        };
+    }
+    if num >= 1e9 {
+        let b = num / 1e9;
+        return if b == b.floor() {
+            format!("{}B", b as u64)
+        } else {
+            format!("{:.1}B", b)
+        };
+    }
+    if num >= 1e6 {
+        let m = num / 1e6;
+        return if m == m.floor() {
+            format!("{}M", m as u64)
+        } else {
+            format!("{:.1}M", m)
+        };
+    }
+    if num >= 1e3 {
+        let k = num / 1e3;
+        return if k == k.floor() {
+            format!("{}K", k as u64)
+        } else {
+            format!("{:.1}K", k)
+        };
+    }
+
+    format!("{}", num.floor() as u64)
+}
+
+/// Format a FLOP count as a readable string.
+#[wasm_bindgen]
+pub fn format_training_compute(flop: f64) -> String {
+    if flop >= 1e15 {
+        let exp = flop.log10().floor() as i32;
+        let mantissa = flop / 10f64.powi(exp);
+        if (mantissa - 1.0).abs() < f64::EPSILON {
+            format!("1e{}", exp)
+        } else {
+            format!("{:.1}e{}", mantissa, exp)
+        }
+    } else {
+        format!("{}", flop)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_date_yyyy_mm_dd() {
+        assert_eq!(normalize_date("2024-01-15"), "2024-01-15");
+    }
+
+    #[test]
+    fn test_normalize_date_iso_datetime() {
+        assert_eq!(normalize_date("2024-01-15T00:00:00"), "2024-01-15");
+    }
+
+    #[test]
+    fn test_normalize_date_yyyy_mm() {
+        assert_eq!(normalize_date("2024-01"), "2024-01-01");
+    }
+
+    #[test]
+    fn test_normalize_date_year_only() {
+        assert_eq!(normalize_date("2024"), "2024-01-01");
+    }
+
+    #[test]
+    fn test_normalize_date_quarter() {
+        assert_eq!(normalize_date("Q1 2024"), "2024-01-01");
+        assert_eq!(normalize_date("Q2 2024"), "2024-04-01");
+        assert_eq!(normalize_date("Q3 2024"), "2024-07-01");
+        assert_eq!(normalize_date("Q4 2024"), "2024-10-01");
+    }
+
+    #[test]
+    fn test_normalize_date_slash_month() {
+        assert_eq!(normalize_date("Feb/2026"), "2026-02-01");
+    }
+
+    #[test]
+    fn test_normalize_date_month_year() {
+        assert_eq!(normalize_date("Jan 2024"), "2024-01-01");
+        assert_eq!(normalize_date("January 2024"), "2024-01-01");
+        assert_eq!(normalize_date("Jan, 2024"), "2024-01-01");
+    }
+
+    #[test]
+    fn test_normalize_date_reverse() {
+        assert_eq!(normalize_date("2024 Jan"), "2024-01-01");
+    }
+
+    #[test]
+    fn test_normalize_date_tba() {
+        assert_eq!(normalize_date("TBA"), "");
+        assert_eq!(normalize_date("TBD"), "");
+        assert_eq!(normalize_date("-"), "");
+        assert_eq!(normalize_date(""), "");
+    }
+
+    #[test]
+    fn test_normalize_params_compact() {
+        assert_eq!(normalize_params("175B"), "175B");
+        assert_eq!(normalize_params("1.8T"), "1.8T");
+        assert_eq!(normalize_params("~45B"), "~45B");
+    }
+
+    #[test]
+    fn test_normalize_params_compound() {
+        assert_eq!(normalize_params("230B-A10B"), "230B-A10B");
+    }
+
+    #[test]
+    fn test_normalize_params_word() {
+        assert_eq!(normalize_params("175 billion"), "175B");
+        assert_eq!(normalize_params("1.8 trillion"), "1.8T");
+        assert_eq!(normalize_params("70 million"), "70M");
+    }
+
+    #[test]
+    fn test_normalize_params_plain_number() {
+        assert_eq!(normalize_params("175"), "175B");
+    }
+
+    #[test]
+    fn test_normalize_params_unknown() {
+        assert_eq!(normalize_params("unknown"), "");
+        assert_eq!(normalize_params("n/a"), "");
+        assert_eq!(normalize_params("-"), "");
+    }
+
+    #[test]
+    fn test_normalize_license_open() {
+        assert_eq!(normalize_license("Apache 2.0"), "open");
+        assert_eq!(normalize_license("MIT"), "open");
+        assert_eq!(normalize_license("Yes"), "open");
+    }
+
+    #[test]
+    fn test_normalize_license_closed() {
+        assert_eq!(normalize_license("No"), "closed");
+        assert_eq!(normalize_license("Proprietary"), "closed");
+    }
+
+    #[test]
+    fn test_normalize_license_partial() {
+        assert_eq!(normalize_license("Research only"), "partial");
+        assert_eq!(normalize_license("Non-commercial"), "partial");
+    }
+
+    #[test]
+    fn test_normalize_license_default() {
+        assert_eq!(normalize_license(""), "closed");
+        assert_eq!(normalize_license("something"), "closed");
+    }
+
+    #[test]
+    fn test_map_accessibility() {
+        assert_eq!(map_accessibility("Open access"), "open");
+        assert_eq!(map_accessibility("Closed"), "closed");
+        assert_eq!(map_accessibility("Research"), "partial");
+        assert_eq!(map_accessibility(""), "closed");
+    }
+
+    #[test]
+    fn test_normalize_type() {
+        assert_eq!(normalize_type("milestone"), "milestone");
+        assert_eq!(normalize_type("event"), "milestone");
+        assert_eq!(normalize_type("paper"), "milestone");
+        assert_eq!(normalize_type("model"), "model");
+        assert_eq!(normalize_type("llm"), "model");
+    }
+
+    #[test]
+    fn test_normalize_text() {
+        assert_eq!(normalize_text("  hello\nworld  "), "hello world");
+        assert_eq!(normalize_text("a   b"), "a b");
+    }
+
+    #[test]
+    fn test_convert_numeric_params() {
+        assert_eq!(convert_numeric_params("175000000000"), "175B");
+        assert_eq!(convert_numeric_params("1000000000"), "1B");
+        assert_eq!(convert_numeric_params("1500000000"), "1.5B");
+        assert_eq!(convert_numeric_params("0"), "");
+        assert_eq!(convert_numeric_params(""), "");
+    }
+
+    #[test]
+    fn test_convert_numeric_params_trillion() {
+        assert_eq!(convert_numeric_params("1800000000000"), "1.8T");
+        assert_eq!(convert_numeric_params("1000000000000"), "1T");
+    }
+
+    #[test]
+    fn test_convert_numeric_params_million() {
+        assert_eq!(convert_numeric_params("700000000"), "700M");
+        assert_eq!(convert_numeric_params("1500000"), "1.5M");
+    }
+
+    #[test]
+    fn test_convert_numeric_params_thousand() {
+        assert_eq!(convert_numeric_params("5000"), "5K");
+        assert_eq!(convert_numeric_params("1500"), "1.5K");
+    }
+
+    #[test]
+    fn test_format_training_compute() {
+        assert_eq!(format_training_compute(1.2e25), "1.2e25");
+        assert_eq!(format_training_compute(1e25), "1e25");
+        assert_eq!(format_training_compute(1e10), "10000000000");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `crates/normalizers/` Rust crate with OnceLock-cached regex patterns
- Port: `normalizeDate`, `normalizeParams`, `normalizeLicense`, `normalizeType`, `normalizeText`, `convertNumericParams`, `formatTrainingCompute`
- TS wrappers bridge WASM snake_case exports to existing camelCase API
- 26 Rust tests pass, 45 JS tests pass

## Key optimization
Regex patterns compiled once via `OnceLock<Regex>` macro instead of per-call.
Month lookup HashMap also cached via `OnceLock`.

## Test plan
- [x] `cargo test -p duyet-normalizers` — 26/26 pass
- [x] `cd apps/llm-timeline && bun test` — 45/45 pass
- [x] `bun run check-types` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)