### PR TITLE
feat(rust): string utilities via wasm

### DIFF
--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "duyet-utils"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen.workspace = true
+
+[dev-dependencies]
+wasm-bindgen-test.workspace = true

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,0 +1,148 @@
+use wasm_bindgen::prelude::*;
+
+/// Escape special regex characters in a string.
+///
+/// Characters escaped: . * + ? ^ $ { } ( ) | [ ] \
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(escape_reg_exp("hello+world"), "hello\\+world");
+/// ```
+#[wasm_bindgen]
+pub fn escape_reg_exp(input: &str) -> String {
+    let mut out = String::with_capacity(input.len() * 2);
+    for ch in input.chars() {
+        match ch {
+            '.' | '*' | '+' | '?' | '^' | '$' | '{' | '}' | '(' | ')' | '|' | '[' | ']' | '\\' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Convert a string to a URL-safe slug.
+///
+/// - Lowercases the input
+/// - Strips non-ASCII characters (emoji, symbols)
+/// - Replaces whitespace and non-alphanumeric runs with a single hyphen
+/// - Strips leading/trailing hyphens
+/// - Truncates at `max_length` without breaking mid-word
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(slugify("Hello World", 100), "hello-world");
+/// assert_eq!(slugify("Hello World 😹", 100), "hello-world");
+/// ```
+#[wasm_bindgen]
+pub fn slugify(input: &str, max_length: Option<usize>) -> String {
+    let max_len = max_length.unwrap_or(100);
+
+    if input.is_empty() {
+        return String::new();
+    }
+
+    let lower = input.to_lowercase();
+
+    let mut slug = String::with_capacity(lower.len());
+    let mut prev_hyphen = true; // treat start as if we just had a hyphen (skip leading)
+
+    for ch in lower.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            prev_hyphen = false;
+        } else if ch == ' ' || ch == '-' || ch == '_' {
+            if !prev_hyphen {
+                slug.push('-');
+                prev_hyphen = true;
+            }
+        }
+        // All other chars (non-ASCII, symbols, punctuation) are silently dropped
+    }
+
+    // Remove trailing hyphen
+    if slug.ends_with('-') {
+        slug.pop();
+    }
+
+    // Truncate at max_len without breaking mid-word
+    if slug.len() > max_len {
+        slug = slug[..max_len].to_string();
+        if let Some(pos) = slug.rfind('-') {
+            slug.truncate(pos);
+        }
+    }
+
+    slug
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_reg_exp_basic() {
+        assert_eq!(escape_reg_exp("hello"), "hello");
+        assert_eq!(escape_reg_exp("hello+world"), "hello\\+world");
+        assert_eq!(escape_reg_exp("a.b"), "a\\.b");
+        assert_eq!(escape_reg_exp("a*b"), "a\\*b");
+        assert_eq!(escape_reg_exp("a?b"), "a\\?b");
+        assert_eq!(escape_reg_exp("a^b"), "a\\^b");
+        assert_eq!(escape_reg_exp("a$b"), "a\\$b");
+        assert_eq!(escape_reg_exp("a{b}"), "a\\{b\\}");
+        assert_eq!(escape_reg_exp("a(b)"), "a\\(b\\)");
+        assert_eq!(escape_reg_exp("a|b"), "a\\|b");
+        assert_eq!(escape_reg_exp("a[b]"), "a\\[b\\]");
+        assert_eq!(escape_reg_exp("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn test_escape_reg_exp_empty() {
+        assert_eq!(escape_reg_exp(""), "");
+    }
+
+    #[test]
+    fn test_escape_reg_exp_no_special() {
+        assert_eq!(escape_reg_exp("hello world 123"), "hello world 123");
+    }
+
+    #[test]
+    fn test_slugify_basic() {
+        assert_eq!(slugify("Hello", None), "hello");
+        assert_eq!(slugify("Hello World", None), "hello-world");
+        assert_eq!(slugify(" Hello World", None), "hello-world");
+        assert_eq!(slugify(" Hello World ", None), "hello-world");
+    }
+
+    #[test]
+    fn test_slugify_emoji() {
+        assert_eq!(slugify(" Hello World 😹", None), "hello-world");
+        assert_eq!(slugify("😆 Hello World 😹", None), "hello-world");
+    }
+
+    #[test]
+    fn test_slugify_empty() {
+        assert_eq!(slugify("", None), "");
+        assert_eq!(slugify("", Some(50)), "");
+    }
+
+    #[test]
+    fn test_slugify_max_length() {
+        assert_eq!(slugify("Hello World", Some(5)), "hello");
+        assert_eq!(slugify("Hello World", Some(7)), "hello");
+    }
+
+    #[test]
+    fn test_slugify_unicode() {
+        // Non-ASCII chars are stripped
+        assert_eq!(slugify("café", None), "caf");
+    }
+
+    #[test]
+    fn test_slugify_special_chars() {
+        assert_eq!(slugify("Hello & World!", None), "hello-world");
+        assert_eq!(slugify("a---b", None), "a-b");
+    }
+}

--- a/packages/libs/getSlug.ts
+++ b/packages/libs/getSlug.ts
@@ -6,10 +6,16 @@
  * @param maxLength - Maximum length of slug (will truncate at word boundary)
  * @returns slug
  */
+
+import { _getWasmSlugify } from "./string"
+
 export const getSlug = (name?: string, maxLength = 100): string => {
   if (!name) {
-    return "";
+    return ""
   }
+
+  const wasmSlugify = _getWasmSlugify()
+  if (wasmSlugify) return wasmSlugify(name, maxLength)
 
   let slug = name
     .toLowerCase()

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -17,6 +17,7 @@
     "remark-parse": "^11.0.0",
     "sanitize-html": "^2.13.0",
     "tailwind-merge": "^3.0.0",
+    "@duyet/wasm": "*",
     "unified": "^11.0.0",
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.3"

--- a/packages/libs/string.ts
+++ b/packages/libs/string.ts
@@ -2,6 +2,30 @@
  * String utility functions
  */
 
+// Lazy WASM initialization — shared module for escape_reg_exp + slugify
+let wasmEscapeRegExp: ((input: string) => string) | null = null
+let _wasmSlugify: ((input: string, max?: number | null) => string) | null = null
+
+/**
+ * Initialize WASM string utilities (escape_reg_exp + slugify).
+ * Call once at app startup. Falls back to JS if WASM unavailable.
+ */
+export async function initWasmStringUtils(): Promise<void> {
+  try {
+    const mod = await import("@duyet/wasm/pkg/utils/utils.js")
+    await mod.default()
+    wasmEscapeRegExp = mod.escape_reg_exp
+    _wasmSlugify = mod.slugify
+  } catch {
+    // WASM not available — JS fallback will be used
+  }
+}
+
+/** @internal Returns the WASM slugify function, or null if not initialized */
+export function _getWasmSlugify(): ((input: string, max?: number | null) => string) | null {
+  return _wasmSlugify
+}
+
 /**
  * Escape special characters in a string for use in a regular expression
  * @example
@@ -11,5 +35,6 @@
  * ```
  */
 export function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  if (wasmEscapeRegExp) return wasmEscapeRegExp(str)
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -6,7 +6,8 @@
 // Import directly from the generated module:
 //
 //   import { noop } from "@duyet/wasm/pkg/placeholder/placeholder.js"
-//   import { parse_csv } from "@duyet/wasm/pkg/csv-parser/csv_parser.js"
+//   import { parseCsv } from "@duyet/wasm/pkg/csv-parser/csv_parser.js"
+//   import { escape_reg_exp, slugify } from "@duyet/wasm/pkg/utils/utils.js"
 //
 // Each WASM module must be initialized before use (auto-happens on first import
 // with wasm-pack's --target web output).


### PR DESCRIPTION
## Summary
- Add `crates/utils/` with `escape_reg_exp` and `slugify` WASM functions
- Consolidate duplicate WASM init into single `initWasmStringUtils()`
- 9 Rust tests, 104 JS tests pass

## Test plan
- [x] `cargo test -p duyet-utils` — 9/9 pass
- [x] `cd packages/libs && bun test` — 104/104 pass
- [x] `bun run wasm:build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)