### PR TITLE
feat(deps): add @tanstack/react-query

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@radix-ui/react-icons": "^1.3.2",
         "@tailwindcss/postcss": "^4.2.1",
         "@tailwindcss/typography": "^0.5.16",
+        "@tanstack/react-query": "^5.100.7",
         "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.4.27",
         "highlight.js": "^11.11.1",
@@ -1278,6 +1279,10 @@
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
     "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.7", "", {}, "sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.7", "", { "dependencies": { "@tanstack/query-core": "5.100.7" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ=="],
 
     "@tanstack/react-router": ["@tanstack/react-router@1.168.1", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.2", "@tanstack/router-core": "1.168.1", "isbot": "^5.1.22", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-DsQzbfwcr2Xugqs4G8yShUO9hVQ/tbWhIiLNJSxmZZOgaZCB3JP+ngN1EJBYZz+JBQdvyVHfiEsPXy0P1h3yVA=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@tailwindcss/postcss": "^4.2.1",
     "@tailwindcss/typography": "^0.5.16",
+    "@tanstack/react-query": "^5.100.7",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.4.27",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
## Summary
- Add `@tanstack/react-query ^5` as root dependency
- Foundation for replacing SWR in agents and ai-percentage apps
- Shared `QueryProvider` available in `packages/components`

## Follow-up needed
- Replace `useSWR` in `apps/agents/hooks/` with `useQuery`/`useMutation`
- Replace `useSWR` in `apps/ai-percentage/components/` with `useQuery`
- Remove `swr` from root deps after migration complete

## Test plan
- [x] `bun install` succeeds
- [x] No type errors from new dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Add @tanstack/react-query ^5 as a root dependency in package.json and refresh bun.lock to capture the new package.