### PR TITLE
chore(agents): remove unused chat code

### DIFF
--- a/apps/agents/components/chat/message-components.tsx
+++ b/apps/agents/components/chat/message-components.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage } from "ai";
 import { Check, Copy, X } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   ChainOfThought,
   ChainOfThoughtContent,

--- a/apps/agents/components/chat/workspace.tsx
+++ b/apps/agents/components/chat/workspace.tsx
@@ -30,13 +30,11 @@ import {
   useMergeRefs,
 } from "@/lib/hooks";
 import { useClerkAuthToken } from "@/lib/hooks/use-clerk-auth";
-import type { ChatMode } from "@/lib/types";
 
 export function ChatWorkspace() {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const lastInputRef = useRef<string>("");
-  const activeConversationIdRef = useRef<string | null>(null);
   const getAuthToken = useClerkAuthToken();
   const [leftRailOpen, setLeftRailOpen] = useState(false);
   const [rightRailOpen, setRightRailOpen] = useState(false);

--- a/apps/agents/dev.js
+++ b/apps/agents/dev.js
@@ -1,6 +1,7 @@
-import { spawn } from "child_process";
+import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import http from "node:http";
+import process from "node:process";
 import httpProxy from "http-proxy";
 
 // Configuration


### PR DESCRIPTION
## Summary
- Remove unused chat imports and a never-read conversation ref from the recently changed agents chat UI.
- Use the explicit `node:` builtin import in the recently changed agents dev proxy.

## Findings fixed

### Warning
- `apps/agents/components/chat/workspace.tsx:33` imported `ChatMode` but never referenced it after the mobile workspace refresh. Evidence: `rg -n "ChatMode" apps/agents/components/chat/workspace.tsx` only matched the import before this patch.
- `apps/agents/components/chat/workspace.tsx:39` declared `activeConversationIdRef` but never read it. Evidence: `rg -n "activeConversationIdRef" apps/agents/components/chat/workspace.tsx` only matched the declaration before this patch.
- `apps/agents/components/chat/message-components.tsx:3` imported `useState` but did not use it. Evidence: focused Biome lint reported `lint/correctness/noUnusedImports` on the recent file.

### Info
- `apps/agents/dev.js:1` imported a Node builtin without the `node:` protocol. Evidence: focused Biome lint reported `lint/style/useNodejsImportProtocol` on the recent file.

## Dead code evidence
- Confident: the removed `activeConversationIdRef` declaration had zero non-test references in the codebase.
- Confident: the removed `ChatMode` import was not used in `workspace.tsx`; the `ChatMode` type itself remains exported and used elsewhere.
- Confident: the removed `useState` import binding was not used in `message-components.tsx`; no runtime code changed.

## Verification
- `bunx biome lint apps/agents/dev.js apps/agents/components/chat/message-components.tsx apps/agents/components/chat/workspace.tsx`
- `bun run check-types` in `apps/agents`
- `git diff --check`

## Summary by Sourcery

Clean up unused chat-related code in the agents app and align a dev script with Node.js import protocol conventions.

Enhancements:
- Remove unused chat workspace type import and inactive conversation ref from the agents chat UI.
- Remove an unused React state import from chat message components to satisfy lint rules.

Chores:
- Update the agents dev script to use the explicit Node.js builtin import protocol.