### PR TITLE
fix(llm-timeline): build native cli before sync

### DIFF
--- a/apps/llm-timeline/package.json
+++ b/apps/llm-timeline/package.json
@@ -19,8 +19,8 @@
     "llms-txt": "bun scripts/generate-llms-txt.ts",
     "sitemap": "bun scripts/generate-sitemap.ts",
     "prebuild": "bun scripts/generate-rss.ts && bun scripts/generate-llms-txt.ts && bun scripts/generate-data-json.ts",
-    "sync": "bun scripts/sync-data.ts",
-    "sync:dry": "bun scripts/sync-data.ts --dry-run --verbose"
+    "sync": "bun run --cwd \"$PWD/../..\" rust:build && bun scripts/sync-data.ts",
+    "sync:dry": "bun run --cwd \"$PWD/../..\" rust:build && bun scripts/sync-data.ts --dry-run --verbose"
   },
   "dependencies": {
     "@duyet/components": "*",


### PR DESCRIPTION
## Summary
- build the native Rust CLI before llm-timeline sync commands run
- keep sync and sync:dry on the same data-sync entrypoints after the binary exists

## Evidence
- Recent commit 76d2fdcdb00f switched llm-timeline CSV/dedup sync code to @duyet/libs/native-cli.
- In a clean worktree without target/release/duyet-cli, importing parseCsv failed with: duyet-cli binary not found at target/release/duyet-cli.

## Verification
- PASS: bun run rust:build
- PASS: bun -e 'import { parseCsv } from ./apps/llm-timeline/lib/csv.ts; console.log(JSON.stringify(parseCsv(a,b\n1,2)))' in the original worktree after rust:build
- PASS: git diff --check
- BLOCKED: local Bun install/check-types/lint in the original worktree hit tempdir/integrity issues for optional native packages; latest master GitHub Test/typecheck and Lint workflows were green before this patch.