### PR TITLE
feat(home): refresh public pages

### DIFF
--- a/apps/home/__tests__/utm.test.ts
+++ b/apps/home/__tests__/utm.test.ts
@@ -34,6 +34,17 @@ describe("addUtmParams", () => {
     expect(result).toContain("utm_source=home");
   });
 
+  it("preserves relative path when host provided", () => {
+    const result = addUtmParams(
+      "/agents",
+      "homepage",
+      "agents_bento",
+      "agents.duyet.net"
+    );
+    expect(result).toContain("https://agents.duyet.net/agents");
+    expect(result).toContain("utm_content=agents_bento");
+  });
+
   it("returns relative path unchanged when no host", () => {
     const result = addUtmParams("/about");
     expect(result).toBe("/about");

--- a/apps/home/app/lib/utm.ts
+++ b/apps/home/app/lib/utm.ts
@@ -9,7 +9,7 @@ export function addUtmParams(
   content?: string,
   host?: string
 ): string {
-  const absUrl = url.startsWith("/") && host ? `https://${host}` : url;
+  const absUrl = url.startsWith("/") && host ? `https://${host}${url}` : url;
   if (absUrl.startsWith("/")) return absUrl;
   const urlObj = new URL(absUrl);
   urlObj.searchParams.set("utm_source", "home");

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@duyet/components": "*",
     "@duyet/libs": "*",
+    "@duyet/urls": "*",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
     "framer-motion": "^12.36.0",

--- a/apps/home/public/screenshots/agentstate-art.svg
+++ b/apps/home/public/screenshots/agentstate-art.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000" role="img" aria-labelledby="title desc">
+  <title id="title">AgentState thumbnail</title>
+  <desc id="desc">A mobile-inspired product card for AgentState with line-art agent workflow tools and a muted status panel.</desc>
+  <defs>
+    <linearGradient id="top" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#234345" />
+      <stop offset="1" stop-color="#8fb3ad" />
+    </linearGradient>
+    <filter id="softShadow" x="-15%" y="-15%" width="130%" height="140%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#1a1a1a" flood-opacity=".18" />
+    </filter>
+    <filter id="cardShadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="18" stdDeviation="26" flood-color="#1a1a1a" flood-opacity=".14" />
+    </filter>
+  </defs>
+
+  <rect width="1600" height="1000" fill="#f8f8f2" />
+  <g filter="url(#softShadow)">
+    <rect x="88" y="-270" width="1424" height="430" rx="56" fill="url(#top)" />
+    <text x="800" y="76" text-anchor="middle" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="600">Today's pulse</text>
+    <text x="150" y="-92" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="50" font-weight="600" opacity=".22">Keep agent memory inspectable</text>
+    <text x="150" y="-18" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="36" opacity=".28">Trace decisions, state changes, and tool outputs before tomorrow's run.</text>
+    <g transform="translate(150 84)" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 58h18c12 0 22-10 22-22V22c0-11 9-20 20-20h18" />
+      <path d="M166 2h22c11 0 20 9 20 20v14c0 12 10 22 22 22h18" />
+      <path d="M328 58l54-48c10-9 25-1 23 12l-10 72c-2 14-19 19-29 9l-22-22-30 30" />
+    </g>
+  </g>
+
+  <g filter="url(#cardShadow)">
+    <rect x="92" y="210" width="1416" height="690" rx="42" fill="#ffffff" stroke="#e3e0d8" stroke-width="2" />
+    <rect x="92" y="210" width="1416" height="405" rx="42" fill="#fffef9" />
+    <path d="M92 574h1416" stroke="#e3e0d8" stroke-width="2" />
+
+    <g transform="translate(198 292)" fill="none" stroke="#1f1f1f" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M0 230c48-34 82-34 132 0s84 34 132 0 84-34 132 0" />
+      <rect x="30" y="96" width="250" height="138" rx="18" />
+      <path d="M72 194c28-74 62-42 90-88s58 10 86-38" />
+      <circle cx="72" cy="194" r="9" fill="#fffef9" />
+      <circle cx="162" cy="106" r="9" fill="#fffef9" />
+      <circle cx="248" cy="68" r="9" fill="#fffef9" />
+
+      <path d="M398 224h156" />
+      <path d="M476 224V86" />
+      <circle cx="476" cy="86" r="70" />
+      <circle cx="476" cy="86" r="36" />
+      <path d="M476 50v36h38" />
+      <path d="M476 16V0" />
+      <path d="M440 0h72" />
+
+      <rect x="660" y="88" width="260" height="146" rx="20" />
+      <path d="M702 178c40-36 74-16 106-44s72 8 112-34" />
+      <path d="M704 124h34M704 150h24M704 202h152" />
+      <circle cx="738" cy="124" r="8" fill="#fffef9" />
+      <circle cx="808" cy="134" r="8" fill="#fffef9" />
+      <circle cx="920" cy="100" r="8" fill="#fffef9" />
+
+      <rect x="1000" y="124" width="220" height="110" rx="18" />
+      <path d="M1034 206l50-48 44 28 72-62" />
+      <circle cx="1064" cy="156" r="12" />
+      <path d="M1168 88l80-74" />
+      <path d="M1208 48l36 36" />
+    </g>
+
+    <rect x="92" y="615" width="1416" height="285" rx="42" fill="#a9b9aa" />
+    <text x="180" y="710" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="600">Agent state you can trust</text>
+    <text x="180" y="784" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="400" opacity=".9">Track memory, retries, approvals, and tool output without losing context between runs.</text>
+    <g transform="translate(180 842)" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M0 48h28c14 0 26-12 26-26V8" />
+      <path d="M132 8h34c14 0 26 12 26 26v14" />
+      <path d="M282 48V10h38c22 0 38 16 38 38v0" />
+      <path d="M448 52l86-76-20 110-38-38-34 34" />
+    </g>
+  </g>
+</svg>

--- a/apps/home/public/screenshots/anyrouter-art.svg
+++ b/apps/home/public/screenshots/anyrouter-art.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">AnyRouter product artwork</title>
+  <desc id="desc">Abstract routing dashboard on a black canvas.</desc>
+  <rect width="1200" height="800" fill="#050505"/>
+  <rect x="110" y="110" width="980" height="580" rx="28" fill="#111"/>
+  <rect x="150" y="150" width="900" height="70" rx="14" fill="#f8f8f2"/>
+  <circle cx="185" cy="185" r="10" fill="#f97316"/>
+  <circle cx="220" cy="185" r="10" fill="#1a1a1a"/>
+  <circle cx="255" cy="185" r="10" fill="#1a1a1a"/>
+  <path d="M220 420h210c80 0 80-150 160-150h150" fill="none" stroke="#f8f8f2" stroke-width="18" stroke-linecap="round"/>
+  <path d="M220 420h210c80 0 80 150 160 150h150" fill="none" stroke="#f97316" stroke-width="18" stroke-linecap="round"/>
+  <path d="M760 270l120 90-120 90" fill="none" stroke="#f8f8f2" stroke-width="18" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M760 450l120 90-120 90" fill="none" stroke="#f97316" stroke-width="18" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="150" y="640" fill="#f8f8f2" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="600">AnyRouter</text>
+  <text x="150" y="690" fill="#f8f8f2" opacity=".62" font-family="Inter, Arial, sans-serif" font-size="24">Model routing and gateway control</text>
+</svg>

--- a/apps/home/public/screenshots/pageview-art.svg
+++ b/apps/home/public/screenshots/pageview-art.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1000" role="img" aria-labelledby="title desc">
+  <title id="title">pageview thumbnail</title>
+  <desc id="desc">A mobile-inspired analytics card with line-art charts and a muted pageview summary panel.</desc>
+  <defs>
+    <linearGradient id="pulse" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#243e42" />
+      <stop offset="1" stop-color="#8aaeb5" />
+    </linearGradient>
+    <filter id="topShadow" x="-15%" y="-20%" width="130%" height="150%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#1a1a1a" flood-opacity=".18" />
+    </filter>
+    <filter id="mainShadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="20" stdDeviation="28" flood-color="#1a1a1a" flood-opacity=".14" />
+    </filter>
+  </defs>
+
+  <rect width="1600" height="1000" fill="#f8f8f2" />
+  <g filter="url(#topShadow)">
+    <rect x="88" y="-280" width="1424" height="438" rx="56" fill="url(#pulse)" />
+    <text x="800" y="76" text-anchor="middle" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="52" font-weight="600">Today's pulse</text>
+    <text x="150" y="-90" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="50" font-weight="600" opacity=".22">Traffic is quiet until it is useful</text>
+    <text x="150" y="-18" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="36" opacity=".28">Watch referrers, posts, and conversion signals without heavy analytics noise.</text>
+    <g transform="translate(150 84)" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M16 84V12M16 84h94M46 84V42M78 84V28M110 84V58" />
+      <path d="M178 78c42-56 74-20 110-70s70 18 112-28" />
+      <path d="M474 80l88-72 18 108-42-36-34 38" />
+    </g>
+  </g>
+
+  <g filter="url(#mainShadow)">
+    <rect x="92" y="212" width="1416" height="688" rx="42" fill="#ffffff" stroke="#e3e0d8" stroke-width="2" />
+    <rect x="92" y="212" width="1416" height="404" rx="42" fill="#fffef9" />
+    <path d="M92 576h1416" stroke="#e3e0d8" stroke-width="2" />
+
+    <g transform="translate(188 284)" fill="none" stroke="#1f1f1f" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M0 238c46-28 84-32 132 0s88 28 136 0" />
+      <path d="M70 226V104c0-24 18-44 42-44h170c24 0 42 20 42 44v122" />
+      <path d="M112 184c30-54 60-20 96-66s72 24 116-42" />
+      <circle cx="112" cy="184" r="8" fill="#fffef9" />
+      <circle cx="208" cy="118" r="8" fill="#fffef9" />
+      <circle cx="324" cy="76" r="8" fill="#fffef9" />
+
+      <rect x="440" y="54" width="274" height="206" rx="22" />
+      <path d="M488 206V98M548 206v-56M608 206v-92M668 206v-34" />
+      <path d="M488 82h176" />
+
+      <rect x="828" y="82" width="292" height="178" rx="22" />
+      <path d="M874 202c38-34 72-16 108-52s72 2 124-54" />
+      <circle cx="874" cy="202" r="8" fill="#fffef9" />
+      <circle cx="982" cy="150" r="8" fill="#fffef9" />
+      <circle cx="1106" cy="96" r="8" fill="#fffef9" />
+      <path d="M874 120h48M874 146h32M874 230h154" />
+
+      <path d="M1168 268c34-64 68-28 102-74s66 4 104-48" />
+      <path d="M1168 268h196" />
+    </g>
+
+    <rect x="92" y="616" width="1416" height="284" rx="42" fill="#b7ad99" />
+    <text x="180" y="710" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="600">Pageviews without the noise</text>
+    <text x="180" y="784" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="400" opacity=".9">See useful traffic, referrers, and content signals in a compact privacy-friendly dashboard.</text>
+    <g transform="translate(180 842)" fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M4 58c40-42 70-20 112-62s78 20 126-28" />
+      <path d="M338 86V8M388 86V36M438 86V22M488 86V58" />
+      <path d="M594 54l74-50 46 88 72-74" />
+    </g>
+  </g>
+</svg>

--- a/apps/home/src/data/projects.ts
+++ b/apps/home/src/data/projects.ts
@@ -1,0 +1,111 @@
+export interface AppItem {
+  name: string;
+  href: string;
+  host: string;
+  utmContent: string;
+  description: string;
+  screenshot?: string;
+  tone?: string;
+}
+
+export const apps: AppItem[] = [
+  {
+    name: "LLM Timeline",
+    href: "/",
+    host: "llm-timeline.duyet.net",
+    utmContent: "llm_timeline_bento",
+    description: "Interactive timeline of 50+ LLM models from 2017-2025",
+    screenshot: "/screenshots/llm-timeline.png",
+    tone: "bg-[#4f6f62]",
+  },
+  {
+    name: "AI Agents",
+    href: "/agents",
+    host: "agents.duyet.net",
+    utmContent: "agents_bento",
+    description: "AI chat interface with Cloudflare Workers AI and streaming",
+    screenshot: "/screenshots/ai-agents.png",
+    tone: "bg-[#536f91]",
+  },
+  {
+    name: "OpenClaw",
+    href: "/claw",
+    host: "claw.duyet.net",
+    utmContent: "claw_bento",
+    description: "OpenClaw Management Dashboard",
+    screenshot: "/screenshots/openclaw.png",
+    tone: "bg-[#7f524e]",
+  },
+  {
+    name: "MCP Tools",
+    href: "/mcp",
+    host: "mcp.duyet.net",
+    utmContent: "mcp_bento",
+    description: "Model Context Protocol tools and integrations",
+    screenshot: "/screenshots/mcp-tools-art.png",
+    tone: "bg-[#5f6257]",
+  },
+  {
+    name: "Rust Tiếng Việt",
+    href: "/rust",
+    host: "rust-tieng-viet.github.io",
+    utmContent: "rust_bento",
+    description: "Rust programming language documentation in Vietnamese",
+    screenshot: "/screenshots/rust-art.png",
+    tone: "bg-[#6a5578]",
+  },
+  {
+    name: "ClickHouse Monitoring",
+    href: "/clickhouse-monitoring",
+    host: "clickhouse.duyet.net",
+    utmContent: "ch_monitor_bento",
+    description: "Real-time monitoring dashboard for ClickHouse clusters",
+    screenshot: "/screenshots/ch-monitor.png",
+    tone: "bg-[#8b633f]",
+  },
+  {
+    name: "Claude Plugins",
+    href: "/claude-plugins",
+    host: "github.com/duyet/claude-plugins",
+    utmContent: "claude_plugins_bento",
+    description: "Official plugins for Claude Code and AI SDK",
+    screenshot: "/screenshots/claude-plugins-art.png",
+    tone: "bg-[#4f6f62]",
+  },
+  {
+    name: "Stamp",
+    href: "/stamp",
+    host: "stamp.duyet.net",
+    utmContent: "stamp_bento",
+    description: "URL shortener with analytics and custom domains",
+    screenshot: "/screenshots/stamp.png",
+    tone: "bg-[#7f524e]",
+  },
+  {
+    name: "AgentState",
+    href: "/agentstate",
+    host: "agentstate.app",
+    utmContent: "agentstate_bento",
+    description: "AI agent state management and debugging tools",
+    screenshot: "/screenshots/agentstate-art.svg",
+    tone: "bg-[#536f91]",
+  },
+  {
+    name: "Agent Demo",
+    href: "/okie",
+    host: "okie.one",
+    utmContent: "okie_bento",
+    description: "A focused demo for testing agent workflows and prompt tools",
+    screenshot: "/screenshots/okie.png",
+    tone: "bg-[#5f6257]",
+  },
+  {
+    name: "pageview",
+    href: "https://pageview.duyet.net",
+    host: "pageview.duyet.net",
+    utmContent: "pageview_bento",
+    description: "Simple, privacy-friendly analytics for websites",
+    screenshot: "/screenshots/pageview-art.svg",
+    tone: "bg-[#7a705d]",
+  },
+];

--- a/apps/home/src/data/projects.ts
+++ b/apps/home/src/data/projects.ts
@@ -1,3 +1,5 @@
+import { duyetUrls } from "@duyet/urls";
+
 export interface AppItem {
   name: string;
   href: string;
@@ -8,11 +10,24 @@ export interface AppItem {
   tone?: string;
 }
 
+const hostOf = (url: string) => new URL(url).host;
+
+const projectUrls = {
+  llmTimeline: "https://llm-timeline.duyet.net",
+  agents: "https://agents.duyet.net",
+  claw: "https://claw.duyet.net",
+  claudePlugins: "https://github.com/duyet/claude-plugins",
+  stamp: "https://stamp.duyet.net",
+  agentState: "https://agentstate.app",
+  okie: "https://okie.one",
+  pageview: "https://pageview.duyet.net",
+};
+
 export const apps: AppItem[] = [
   {
     name: "LLM Timeline",
     href: "/",
-    host: "llm-timeline.duyet.net",
+    host: hostOf(projectUrls.llmTimeline),
     utmContent: "llm_timeline_bento",
     description: "Interactive timeline of 50+ LLM models from 2017-2025",
     screenshot: "/screenshots/llm-timeline.png",
@@ -21,7 +36,7 @@ export const apps: AppItem[] = [
   {
     name: "AI Agents",
     href: "/agents",
-    host: "agents.duyet.net",
+    host: hostOf(projectUrls.agents),
     utmContent: "agents_bento",
     description: "AI chat interface with Cloudflare Workers AI and streaming",
     screenshot: "/screenshots/ai-agents.png",
@@ -30,7 +45,7 @@ export const apps: AppItem[] = [
   {
     name: "OpenClaw",
     href: "/claw",
-    host: "claw.duyet.net",
+    host: hostOf(projectUrls.claw),
     utmContent: "claw_bento",
     description: "OpenClaw Management Dashboard",
     screenshot: "/screenshots/openclaw.png",
@@ -38,8 +53,8 @@ export const apps: AppItem[] = [
   },
   {
     name: "MCP Tools",
-    href: "/mcp",
-    host: "mcp.duyet.net",
+    href: duyetUrls.external.mcp ?? "https://mcp.duyet.net",
+    host: hostOf(duyetUrls.external.mcp ?? "https://mcp.duyet.net"),
     utmContent: "mcp_bento",
     description: "Model Context Protocol tools and integrations",
     screenshot: "/screenshots/mcp-tools-art.png",
@@ -47,8 +62,10 @@ export const apps: AppItem[] = [
   },
   {
     name: "Rust Tiếng Việt",
-    href: "/rust",
-    host: "rust-tieng-viet.github.io",
+    href: duyetUrls.external.rust ?? "https://rust-tieng-viet.github.io",
+    host: hostOf(
+      duyetUrls.external.rust ?? "https://rust-tieng-viet.github.io"
+    ),
     utmContent: "rust_bento",
     description: "Rust programming language documentation in Vietnamese",
     screenshot: "/screenshots/rust-art.png",
@@ -56,8 +73,10 @@ export const apps: AppItem[] = [
   },
   {
     name: "ClickHouse Monitoring",
-    href: "/clickhouse-monitoring",
-    host: "clickhouse.duyet.net",
+    href: duyetUrls.external.clickhouse ?? "https://clickhouse.duyet.net",
+    host: hostOf(
+      duyetUrls.external.clickhouse ?? "https://clickhouse.duyet.net"
+    ),
     utmContent: "ch_monitor_bento",
     description: "Real-time monitoring dashboard for ClickHouse clusters",
     screenshot: "/screenshots/ch-monitor.png",
@@ -65,8 +84,8 @@ export const apps: AppItem[] = [
   },
   {
     name: "Claude Plugins",
-    href: "/claude-plugins",
-    host: "github.com/duyet/claude-plugins",
+    href: projectUrls.claudePlugins,
+    host: hostOf(projectUrls.claudePlugins),
     utmContent: "claude_plugins_bento",
     description: "Official plugins for Claude Code and AI SDK",
     screenshot: "/screenshots/claude-plugins-art.png",
@@ -75,7 +94,7 @@ export const apps: AppItem[] = [
   {
     name: "Stamp",
     href: "/stamp",
-    host: "stamp.duyet.net",
+    host: hostOf(projectUrls.stamp),
     utmContent: "stamp_bento",
     description: "URL shortener with analytics and custom domains",
     screenshot: "/screenshots/stamp.png",
@@ -84,7 +103,7 @@ export const apps: AppItem[] = [
   {
     name: "AgentState",
     href: "/agentstate",
-    host: "agentstate.app",
+    host: hostOf(projectUrls.agentState),
     utmContent: "agentstate_bento",
     description: "AI agent state management and debugging tools",
     screenshot: "/screenshots/agentstate-art.svg",
@@ -93,7 +112,7 @@ export const apps: AppItem[] = [
   {
     name: "Agent Demo",
     href: "/okie",
-    host: "okie.one",
+    host: hostOf(projectUrls.okie),
     utmContent: "okie_bento",
     description: "A focused demo for testing agent workflows and prompt tools",
     screenshot: "/screenshots/okie.png",
@@ -101,8 +120,8 @@ export const apps: AppItem[] = [
   },
   {
     name: "pageview",
-    href: "https://pageview.duyet.net",
-    host: "pageview.duyet.net",
+    href: projectUrls.pageview,
+    host: hostOf(projectUrls.pageview),
     utmContent: "pageview_bento",
     description: "Simple, privacy-friendly analytics for websites",
     screenshot: "/screenshots/pageview-art.svg",

--- a/apps/home/src/globals.css
+++ b/apps/home/src/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @layer base {
   :root {
     --font-inter:
@@ -9,6 +11,11 @@
     --color-primary: #1a1a1a;
     --color-theme: #f8f8f2;
     --color-status: oklch(70.5% 0.213 47.604);
+  }
+
+  html.dark {
+    --color-primary: #f8f8f2;
+    --color-theme: #0d0e0c;
   }
 
   html {
@@ -24,9 +31,10 @@
     text-rendering: optimizeLegibility;
   }
 
-  .dark body {
+  html.dark body {
     background-color: var(--color-theme);
     color: var(--color-primary);
+    color-scheme: dark;
   }
 }
 

--- a/apps/home/src/routeTree.gen.ts
+++ b/apps/home/src/routeTree.gen.ts
@@ -9,10 +9,17 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ProjectsRouteImport } from './routes/projects'
 import { Route as LsRouteImport } from './routes/ls'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as PProjectRouteImport } from './routes/p/$project'
 
+const ProjectsRoute = ProjectsRouteImport.update({
+  id: '/projects',
+  path: '/projects',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LsRoute = LsRouteImport.update({
   id: '/ls',
   path: '/ls',
@@ -28,39 +35,59 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PProjectRoute = PProjectRouteImport.update({
+  id: '/p/$project',
+  path: '/p/$project',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/ls': typeof LsRoute
+  '/projects': typeof ProjectsRoute
+  '/p/$project': typeof PProjectRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/ls': typeof LsRoute
+  '/projects': typeof ProjectsRoute
+  '/p/$project': typeof PProjectRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/ls': typeof LsRoute
+  '/projects': typeof ProjectsRoute
+  '/p/$project': typeof PProjectRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about' | '/ls'
+  fullPaths: '/' | '/about' | '/ls' | '/projects' | '/p/$project'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about' | '/ls'
-  id: '__root__' | '/' | '/about' | '/ls'
+  to: '/' | '/about' | '/ls' | '/projects' | '/p/$project'
+  id: '__root__' | '/' | '/about' | '/ls' | '/projects' | '/p/$project'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
   LsRoute: typeof LsRoute
+  ProjectsRoute: typeof ProjectsRoute
+  PProjectRoute: typeof PProjectRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/projects': {
+      id: '/projects'
+      path: '/projects'
+      fullPath: '/projects'
+      preLoaderRoute: typeof ProjectsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/ls': {
       id: '/ls'
       path: '/ls'
@@ -82,6 +109,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/p/$project': {
+      id: '/p/$project'
+      path: '/p/$project'
+      fullPath: '/p/$project'
+      preLoaderRoute: typeof PProjectRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -89,6 +123,8 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
   LsRoute: LsRoute,
+  ProjectsRoute: ProjectsRoute,
+  PProjectRoute: PProjectRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -1,6 +1,18 @@
-import Header from "@duyet/components/Header";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+  Github as GithubIcon,
+  LinkedIn as LinkedInIcon,
+} from "@duyet/components/Icons";
+import {
+  ArrowRight,
+  BookOpen,
+  FileUser,
+  Radio,
+} from "lucide-react";
+import { Suspense } from "react";
 import { addUtmParams } from "../../app/lib/utm";
+import { BuildDate } from "../components/BuildDate";
+import { FooterInteractive } from "../components/FooterInteractive";
 
 const experienceYears = "8+ years";
 
@@ -85,344 +97,339 @@ export const Route = createFileRoute("/about")({
   }),
 });
 
-// Claude-style SVG Icons - minimal, geometric, soft
-const ResumeIcon = () => (
-  <svg
-    aria-hidden="true"
-    width="80"
-    height="80"
-    viewBox="0 0 80 80"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <rect
-      x="24"
-      y="16"
-      width="32"
-      height="48"
-      rx="6"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      fill="none"
-    />
-    <circle
-      cx="40"
-      cy="30"
-      r="6"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      fill="none"
-    />
-    <path
-      d="M31 46C31 42 34 40 40 40C46 40 49 42 49 46"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="32"
-      y1="54"
-      x2="48"
-      y2="54"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-  </svg>
-);
+const links = [
+  {
+    title: "Resume",
+    description:
+      "Experience building scalable data infrastructure, AI applications, and production systems.",
+    url: addUtmParams("https://cv.duyet.net", "about_page", "resume_card"),
+    icon: FileUser,
+    tone: "bg-[#bfdbfe] dark:bg-[#1f3a5f]",
+  },
+  {
+    title: "GitHub",
+    description:
+      "Open source work across Python, Rust, TypeScript, analytics, and developer tooling.",
+    url: addUtmParams("https://github.com/duyet", "about_page", "github_card"),
+    icon: GithubIcon,
+    tone: "bg-[#a7f3d0] dark:bg-[#164634]",
+  },
+  {
+    title: "LinkedIn",
+    description:
+      "Professional history, roles, and career context in data and platform engineering.",
+    url: addUtmParams(
+      "https://linkedin.com/in/duyet",
+      "about_page",
+      "linkedin_card"
+    ),
+    icon: LinkedInIcon,
+    tone: "bg-[#fecaca] dark:bg-[#4f1f1f]",
+  },
+  {
+    title: "Blog",
+    description:
+      "Technical writing on data engineering, distributed systems, AI agents, and open source.",
+    url: addUtmParams("https://blog.duyet.net", "about_page", "blog_card"),
+    icon: BookOpen,
+    tone: "bg-white dark:bg-[#1a1a1a]",
+  },
+];
 
-const GithubIcon = () => (
-  <svg
-    aria-hidden="true"
-    width="80"
-    height="80"
-    viewBox="0 0 80 80"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <circle
-      cx="40"
-      cy="38"
-      r="18"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      fill="none"
-    />
-    <circle cx="33" cy="35" r="2.5" fill="currentColor" />
-    <circle cx="47" cy="35" r="2.5" fill="currentColor" />
-    <path
-      d="M32 48C32 48 34 52 40 52C46 52 48 48 48 48"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M28 44V50C28 52 26 54 24 54"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-    <path
-      d="M52 44V50C52 52 54 54 56 54"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-  </svg>
-);
+const focusAreas = [
+  {
+    label: "Data systems",
+    value: "Pipelines, warehouses, observability, and distributed services",
+  },
+  {
+    label: "AI infrastructure",
+    value: "Agent workflows, model routing, evaluation, and usage analytics",
+  },
+  {
+    label: "Engineering practice",
+    value: "Small tools, clean interfaces, production hygiene, and writing",
+  },
+];
 
-const LinkedInIcon = () => (
-  <svg
-    aria-hidden="true"
-    width="80"
-    height="80"
-    viewBox="0 0 80 80"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <rect
-      x="22"
-      y="22"
-      width="36"
-      height="36"
-      rx="8"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      fill="none"
-    />
-    <circle cx="32" cy="34" r="3" fill="currentColor" />
-    <rect x="28" y="40" width="8" height="14" rx="1.5" fill="currentColor" />
-    <rect x="40" y="40" width="8" height="14" rx="1.5" fill="currentColor" />
-    <path
-      d="M44 40V38C44 36 45 34 48 34C51 34 52 36 52 38V54"
-      stroke="currentColor"
-      strokeWidth="3"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      fill="none"
-    />
-  </svg>
-);
-
-const BlogIcon = () => (
-  <svg
-    aria-hidden="true"
-    width="80"
-    height="80"
-    viewBox="0 0 80 80"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <rect
-      x="24"
-      y="20"
-      width="32"
-      height="40"
-      rx="6"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      fill="none"
-    />
-    <line
-      x1="32"
-      y1="32"
-      x2="48"
-      y2="32"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="32"
-      y1="40"
-      x2="48"
-      y2="40"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-    <line
-      x1="32"
-      y1="48"
-      x2="42"
-      y2="48"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-    />
-  </svg>
-);
-
-interface LinkItem {
-  icon: () => React.JSX.Element;
-  title: string;
-  description: string;
-  url: string;
-  color: string;
-}
+const skills = [
+  "Python",
+  "Rust",
+  "TypeScript",
+  "Spark",
+  "Airflow",
+  "ClickHouse",
+  "BigQuery",
+  "Kafka",
+  "Kubernetes",
+  "AWS",
+  "GCP",
+  "LlamaIndex",
+  "AI SDK",
+  "LangGraph",
+];
 
 function AboutPage() {
-  const BLOG_URL =
-    import.meta.env.VITE_DUYET_BLOG_URL || "https://blog.duyet.net";
-
-  const links: LinkItem[] = [
-    {
-      icon: ResumeIcon,
-      title: "Resume",
-      description:
-        "Experience building scalable data infrastructure and leading engineering teams.",
-      url: addUtmParams("https://cv.duyet.net", "about_page", "resume_card"),
-      color: "bg-orange-100/50",
-    },
-    {
-      icon: GithubIcon,
-      title: "GitHub",
-      description:
-        "Open source contributions and personal projects in Python, Rust, and TypeScript.",
-      url: addUtmParams(
-        "https://github.com/duyet",
-        "about_page",
-        "github_card"
-      ),
-      color: "bg-purple-100/50",
-    },
-    {
-      icon: LinkedInIcon,
-      title: "LinkedIn",
-      description:
-        "Professional network and career highlights in data engineering.",
-      url: addUtmParams(
-        "https://linkedin.com/in/duyet",
-        "about_page",
-        "linkedin_card"
-      ),
-      color: "bg-blue-100/50",
-    },
-    {
-      icon: BlogIcon,
-      title: "Blog",
-      description:
-        "Technical writings on data engineering, distributed systems, and open source.",
-      url: addUtmParams(BLOG_URL, "about_page", "blog_card"),
-      color: "bg-amber-100/60",
-    },
-  ];
-
-  const skills = [
-    {
-      name: "Python",
-      link: addUtmParams(
-        "https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=python",
-        "about_page",
-        "skill_python"
-      ),
-    },
-    {
-      name: "Rust",
-      link: addUtmParams(
-        "https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=rust",
-        "about_page",
-        "skill_rust"
-      ),
-    },
-    {
-      name: "Javascript",
-      link: addUtmParams(
-        "https://github.com/duyet?utf8=%E2%9C%93&tab=repositories&q=&type=public&language=javascript",
-        "about_page",
-        "skill_javascript"
-      ),
-    },
-    { name: "Spark" },
-    {
-      name: "Airflow",
-      link: addUtmParams(
-        `${BLOG_URL}/tag/airflow/`,
-        "about_page",
-        "skill_airflow"
-      ),
-    },
-    { name: "AWS" },
-    { name: "GCP" },
-  ];
-
   return (
-    <>
-      <Header shortText="Duyệt" />
-      <div className="min-h-screen bg-neutral-50">
-        <div className="mx-auto max-w-6xl px-4 py-16 sm:py-24">
-          {/* Header */}
-          <div className="mb-12 text-center">
-            <h1 className="mb-6 font-serif text-5xl font-normal text-neutral-900 sm:text-6xl">
-              About
-            </h1>
-            <p className="mx-auto max-w-3xl text-lg leading-relaxed text-neutral-700">
-              Data & AI Engineer with {experienceYears} of experience. I am
-              confident in my knowledge of Data Engineering, AI/ML concepts,
-              best practices and state-of-the-art data and Cloud technologies.
-            </p>
-          </div>
+    <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+      <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur dark:bg-[#0d0e0c]/95">
+        <div className="mx-auto flex max-w-[1280px] items-center justify-between px-5 py-4 sm:px-8 lg:px-10 lg:py-5">
+          <Link
+            to="/"
+            className="flex items-center gap-3 text-xl font-semibold tracking-tight"
+          >
+            <DuyetMark />
+            Duyet Le
+          </Link>
 
-          {/* Links Grid */}
-          <div className="mb-16 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-            {links.map((link) => {
-              const Icon = link.icon;
+          <nav className="hidden items-center gap-7 text-sm font-medium md:flex">
+            <a href="https://blog.duyet.net">Blog</a>
+            <Link to="/projects">Projects</Link>
+            <a href="https://cv.duyet.net">Experience</a>
+            <a href="https://insights.duyet.net">Insights</a>
+            <Link to="/about">About</Link>
+          </nav>
+
+          <a
+            href={addUtmParams(
+              "https://status.duyet.net",
+              "about",
+              "header_status"
+            )}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex min-w-24 items-center justify-end gap-2 text-sm font-medium"
+          >
+            <span className="h-3 w-3 rounded-full bg-orange-500" />
+            <span>Status</span>
+          </a>
+        </div>
+      </header>
+
+      <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-20 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+        <section className="mx-auto max-w-[1280px] px-5 py-14 sm:px-8 md:py-18 lg:px-10 lg:py-24 xl:py-28">
+          <p className="mb-4 text-sm font-medium text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60">
+            About
+          </p>
+          <div className="grid gap-10 lg:grid-cols-[minmax(0,0.95fr)_minmax(320px,0.55fr)] lg:items-end">
+            <div className="max-w-[820px] space-y-6">
+              <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
+                I build data and AI systems that stay useful in production.
+              </h1>
+              <p className="max-w-[620px] text-lg font-medium leading-snug tracking-tight text-[#1a1a1a]/80 dark:text-[#f8f8f2]/80 lg:text-xl">
+                Data & AI Engineer with {experienceYears} of experience across
+                modern data infrastructure, AI/ML platforms, distributed
+                systems, and cloud-native engineering.
+              </p>
+            </div>
+
+            <div className="space-y-4 text-base font-medium leading-7 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+              <p>
+                I care about systems that are easy to operate, easy to explain,
+                and boring in the places where reliability matters.
+              </p>
+              <p>
+                Most of my work sits where data products, AI tools, and
+                engineering platforms meet.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
+          <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-4 lg:gap-6 xl:gap-8">
+            {links.map((item) => {
+              const Icon = item.icon;
               return (
                 <a
-                  key={link.title}
-                  href={link.url}
-                  target={link.url.startsWith("http") ? "_blank" : undefined}
-                  rel={
-                    link.url.startsWith("http")
-                      ? "noopener noreferrer"
-                      : undefined
-                  }
-                  className={`group flex flex-col p-10 ${link.color} rounded-3xl transition-transform duration-200 hover:scale-[1.02]`}
+                  key={item.title}
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`group flex min-h-[220px] flex-col rounded-xl p-5 transition-transform hover:-translate-y-0.5 lg:min-h-[240px] lg:p-6 ${item.tone}`}
                 >
-                  <div className="mb-8 text-neutral-800">
-                    <Icon />
+                  <div className="flex items-start justify-between gap-6">
+                    <h2 className="text-base font-medium lg:text-lg">
+                      {item.title}
+                    </h2>
+                    <Icon className="h-7 w-7 shrink-0 lg:h-8 lg:w-8" />
                   </div>
-                  <p className="mb-3 text-xl font-medium text-neutral-900">
-                    {link.title}
-                  </p>
-                  <p className="text-sm leading-relaxed text-neutral-700">
-                    {link.description}
+                  <p className="mt-auto max-w-[560px] text-lg font-medium leading-tight tracking-tight md:text-xl">
+                    {item.description}
                   </p>
                 </a>
               );
             })}
           </div>
+        </section>
 
-          {/* Skills Section */}
-          <div className="rounded-3xl bg-stone-100/70 p-8 sm:p-12">
-            <h2 className="mb-6 font-serif text-3xl font-normal text-neutral-900">
-              Skills & Stacks
-            </h2>
-            <div className="flex flex-wrap gap-3">
-              {skills.map(({ name, link }) =>
-                link ? (
-                  <a
-                    key={name}
-                    href={link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-block rounded-full bg-neutral-50 px-5 py-2 text-sm font-medium text-neutral-800 transition-colors hover:bg-neutral-100 hover:text-neutral-900"
-                  >
-                    {name}
-                  </a>
-                ) : (
-                  <span
-                    key={name}
-                    className="inline-block rounded-full bg-neutral-50 px-5 py-2 text-sm font-medium text-neutral-800 transition-colors hover:bg-neutral-100"
-                  >
-                    {name}
-                  </span>
-                )
+        <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
+          <div className="grid gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
+            <div>
+              <p className="mb-3 text-sm font-medium text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60">
+                Work
+              </p>
+              <h2 className="text-balance text-3xl font-semibold tracking-tight md:text-4xl">
+                Practical engineering, written down clearly.
+              </h2>
+            </div>
+
+            <div className="divide-y divide-[#1a1a1a]/12 border-y border-[#1a1a1a]/12 dark:divide-white/12 dark:border-white/12">
+              {focusAreas.map((item) => (
+                <div
+                  key={item.label}
+                  className="grid gap-3 py-6 md:grid-cols-[180px_1fr] md:gap-8"
+                >
+                  <p className="text-sm font-semibold uppercase tracking-normal text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+                    {item.label}
+                  </p>
+                  <p className="text-xl font-medium leading-tight tracking-tight">
+                    {item.value}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
+          <div className="flex flex-col justify-between gap-5 md:flex-row md:items-end">
+            <div>
+              <p className="mb-3 text-sm font-medium text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60">
+                Stack
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
+                Tools I reach for.
+              </h2>
+            </div>
+            <a
+              href={addUtmParams(
+                "https://github.com/duyet",
+                "about_page",
+                "skills_github"
               )}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-base font-medium"
+            >
+              Repositories
+              <ArrowRight className="h-5 w-5" />
+            </a>
+          </div>
+
+          <div className="mt-10 flex flex-wrap gap-x-5 gap-y-4 text-2xl font-semibold tracking-tight text-[#1a1a1a]/90 dark:text-[#f8f8f2]/90 md:text-3xl">
+            {skills.map((skill) => (
+              <span key={skill}>{skill}</span>
+            ))}
+          </div>
+        </section>
+
+        <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
+          <div className="grid gap-5 rounded-xl bg-white p-6 dark:bg-[#1a1a1a] md:grid-cols-[1fr_auto] md:items-center lg:p-8">
+            <div className="flex items-start gap-4">
+              <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-[#f8f8f2] dark:text-[#0d0e0c]">
+                <Radio className="h-5 w-5" />
+              </span>
+              <div>
+                <h2 className="text-xl font-semibold tracking-tight">
+                  Follow the work
+                </h2>
+                <p className="mt-1 text-base font-medium text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+                  Blog posts, project notes, analytics, and small tools across
+                  the Duyet network.
+                </p>
+              </div>
+            </div>
+            <a
+              href={addUtmParams(
+                "https://blog.duyet.net",
+                "about_page",
+                "follow_blog"
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white"
+            >
+              Read blog
+              <ArrowRight className="h-5 w-5" />
+            </a>
+          </div>
+        </section>
+      </main>
+
+      <footer className="sticky bottom-0 bg-white px-5 pb-12 pt-24 dark:bg-[#1a1a1a] sm:px-8 lg:px-10 lg:pb-16 lg:pt-28 xl:pb-20">
+        <div className="mx-auto max-w-[1280px]">
+          <h2 className="max-w-[820px] text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
+            Build useful systems, then explain them clearly.
+          </h2>
+          <div className="my-12 flex flex-wrap items-center gap-4 md:my-16">
+            <a
+              href={addUtmParams(
+                "https://github.com/duyet",
+                "about_page",
+                "footer_github"
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white lg:px-8 lg:text-lg"
+            >
+              GitHub
+            </a>
+            <a
+              href={addUtmParams(
+                "https://linkedin.com/in/duyet",
+                "about_page",
+                "footer_linkedin"
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg border border-[#1a1a1a]/15 px-6 py-4 text-base font-medium transition-colors hover:border-[#1a1a1a] dark:border-white/15 dark:hover:border-white lg:px-8 lg:text-lg"
+            >
+              LinkedIn
+            </a>
+          </div>
+
+          <hr className="border-[#1a1a1a]/15 dark:border-white/15" />
+
+          <div className="grid gap-6 pt-10 text-base font-medium md:grid-cols-2 md:pt-16">
+            <div className="flex flex-wrap items-center gap-6">
+              <span>© Duyet Le</span>
+              <a href="/llms.txt" className="underline underline-offset-2">
+                llms.txt
+              </a>
+              <Suspense fallback={<div className="h-10 w-10" />}>
+                <FooterInteractive />
+              </Suspense>
+            </div>
+            <div className="flex flex-wrap items-center gap-6 md:justify-end">
+              <BuildDate />
+              <a
+                href={addUtmParams(
+                  "https://status.duyet.net",
+                  "about_page",
+                  "footer_status"
+                )}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2"
+              >
+                <span className="h-3 w-3 rounded-full bg-orange-500" />
+                <span>All Systems Operational</span>
+              </a>
             </div>
           </div>
         </div>
-      </div>
-    </>
+      </footer>
+    </div>
+  );
+}
+
+function DuyetMark() {
+  return (
+    <span className="grid h-5 w-5 grid-cols-2 gap-0.5" aria-hidden="true">
+      <span className="bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="translate-y-1 bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="-translate-y-1 bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+    </span>
   );
 }

--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -3,24 +3,20 @@ import {
   Github as GithubIcon,
   LinkedIn as LinkedInIcon,
 } from "@duyet/components/Icons";
-import {
-  ArrowRight,
-  BookOpen,
-  FileUser,
-  Radio,
-} from "lucide-react";
+import { ArrowRight, BookOpen, FileUser, Radio } from "lucide-react";
 import { Suspense } from "react";
 import { addUtmParams } from "../../app/lib/utm";
 import { BuildDate } from "../components/BuildDate";
 import { FooterInteractive } from "../components/FooterInteractive";
 
 const experienceYears = "8+ years";
+const contentLastModified = "2026-05-02";
 
 const profilePageJsonLd = JSON.stringify({
   "@context": "https://schema.org",
   "@type": "ProfilePage",
   dateCreated: "2020-01-01",
-  dateModified: new Date().toISOString().split("T")[0],
+  dateModified: contentLastModified,
   mainEntity: {
     "@type": "Person",
     name: "Duyet Le",
@@ -182,10 +178,30 @@ function AboutPage() {
           </Link>
 
           <nav className="hidden items-center gap-7 text-sm font-medium md:flex">
-            <a href="https://blog.duyet.net">Blog</a>
+            <a
+              href={addUtmParams(
+                "https://blog.duyet.net",
+                "about",
+                "header_blog"
+              )}
+            >
+              Blog
+            </a>
             <Link to="/projects">Projects</Link>
-            <a href="https://cv.duyet.net">Experience</a>
-            <a href="https://insights.duyet.net">Insights</a>
+            <a
+              href={addUtmParams("https://cv.duyet.net", "about", "header_cv")}
+            >
+              Experience
+            </a>
+            <a
+              href={addUtmParams(
+                "https://insights.duyet.net",
+                "about",
+                "header_insights"
+              )}
+            >
+              Insights
+            </a>
             <Link to="/about">About</Link>
           </nav>
 

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -81,10 +81,34 @@ function HomePage() {
             </Link>
 
             <nav className="hidden items-center gap-7 text-sm font-medium md:flex">
-              <a href="https://blog.duyet.net">Blog</a>
+              <a
+                href={addUtmParams(
+                  "https://blog.duyet.net",
+                  "homepage",
+                  "header_blog"
+                )}
+              >
+                Blog
+              </a>
               <Link to="/projects">Projects</Link>
-              <a href="https://cv.duyet.net">Experience</a>
-              <a href="https://insights.duyet.net">Insights</a>
+              <a
+                href={addUtmParams(
+                  "https://cv.duyet.net",
+                  "homepage",
+                  "header_cv"
+                )}
+              >
+                Experience
+              </a>
+              <a
+                href={addUtmParams(
+                  "https://insights.duyet.net",
+                  "homepage",
+                  "header_insights"
+                )}
+              >
+                Insights
+              </a>
               <Link to="/about">About</Link>
             </nav>
 
@@ -149,7 +173,6 @@ function HomePage() {
                 <CapabilityCard key={item.title} {...item} />
               ))}
             </div>
-
           </section>
 
           <section
@@ -309,10 +332,10 @@ function ProjectCard({
       </div>
       <div className="p-5 text-white">
         <h3 className="text-lg font-semibold tracking-tight">{item.name}</h3>
-        <p className="mt-2 text-sm font-medium leading-6 text-white/82">
+        <p className="mt-2 text-sm font-medium leading-6 text-white/80">
           {item.description}
         </p>
-        <p className="mt-5 truncate text-sm font-medium text-white/62">
+        <p className="mt-5 truncate text-sm font-medium text-white/60">
           {item.host}
         </p>
       </div>
@@ -410,6 +433,8 @@ function AppLink({
       <a
         href={href}
         className={className}
+        target="_blank"
+        rel="noopener noreferrer"
         data-shortcut-id={shortcutId}
         data-shortcut-number={shortcutNumber}
       >

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -2,12 +2,12 @@ import { cn } from "@duyet/libs/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   ArrowRight,
-  BarChart,
-  BookOpen,
-  FileText,
+  ChartNoAxesCombined,
+  Newspaper,
+  UserRound,
+  FileUser,
   Link as LinkIcon,
   Server,
-  Workflow,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { Suspense } from "react";
@@ -15,127 +15,31 @@ import { addUtmParams } from "../../app/lib/utm";
 import { BuildDate } from "../components/BuildDate";
 import { FooterInteractive } from "../components/FooterInteractive";
 import { KeyboardFeatures } from "../components/KeyboardFeatures";
+import { apps, type AppItem } from "../data/projects";
 
 export const Route = createFileRoute("/")({
   component: HomePage,
 });
 
-interface AppItem {
-  name: string;
-  href: string;
-  host: string;
-  utmContent: string;
-  description: string;
-  screenshot?: string;
-}
-
-const apps: AppItem[] = [
-  {
-    name: "LLM Timeline",
-    href: "/",
-    host: "llm-timeline.duyet.net",
-    utmContent: "llm_timeline_bento",
-    description: "Interactive timeline of 50+ LLM models from 2017-2025",
-    screenshot: "/screenshots/llm-timeline.png",
-  },
-  {
-    name: "AI Agents",
-    href: "/agents",
-    host: "agents.duyet.net",
-    utmContent: "agents_bento",
-    description: "AI chat interface with Cloudflare Workers AI and streaming",
-    screenshot: "/screenshots/ai-agents.png",
-  },
-  {
-    name: "OpenClaw",
-    href: "/claw",
-    host: "claw.duyet.net",
-    utmContent: "claw_bento",
-    description: "OpenClaw Management Dashboard",
-    screenshot: "/screenshots/openclaw.png",
-  },
-  {
-    name: "MCP Tools",
-    href: "/mcp",
-    host: "mcp.duyet.net",
-    utmContent: "mcp_bento",
-    description: "Model Context Protocol tools and integrations",
-    screenshot: "/screenshots/mcp-tools-art.png",
-  },
-  {
-    name: "Rust Tiếng Việt",
-    href: "/rust",
-    host: "rust-tieng-viet.github.io",
-    utmContent: "rust_bento",
-    description: "Rust programming language documentation in Vietnamese",
-    screenshot: "/screenshots/rust-art.png",
-  },
-  {
-    name: "ClickHouse Monitoring",
-    href: "/clickhouse-monitoring",
-    host: "clickhouse.duyet.net",
-    utmContent: "ch_monitor_bento",
-    description: "Real-time monitoring dashboard for ClickHouse clusters",
-    screenshot: "/screenshots/ch-monitor.png",
-  },
-  {
-    name: "Claude Plugins",
-    href: "/claude-plugins",
-    host: "github.com/duyet/claude-plugins",
-    utmContent: "claude_plugins_bento",
-    description: "Official plugins for Claude Code and AI SDK",
-  },
-  {
-    name: "Stamp",
-    href: "/stamp",
-    host: "stamp.duyet.net",
-    utmContent: "stamp_bento",
-    description: "URL shortener with analytics and custom domains",
-    screenshot: "/screenshots/stamp.png",
-  },
-  {
-    name: "AgentState",
-    href: "/agentstate",
-    host: "agentstate.app",
-    utmContent: "agentstate_bento",
-    description: "AI agent state management and debugging tools",
-  },
-  {
-    name: "okie.one",
-    href: "/okie",
-    host: "okie.one",
-    utmContent: "okie_bento",
-    description: "Vietnamese community platform for developers",
-    screenshot: "/screenshots/okie.png",
-  },
-  {
-    name: "pageview",
-    href: "https://pageview.duyet.net",
-    host: "pageview.duyet.net",
-    utmContent: "pageview_bento",
-    description: "Simple, privacy-friendly analytics for websites",
-  },
-];
-
 const capabilities = [
   {
-    title: "Write",
+    title: "Blog",
     description:
       "Deep dives into data engineering architecture, distributed systems, AI agents, and lessons learned from scaling open source.",
     href: addUtmParams("https://blog.duyet.net", "homepage", "blog_card"),
-    icon: BookOpen,
-    className: "bg-white",
+    icon: Newspaper,
+    className: "bg-white dark:bg-[#1a1a1a]",
   },
   {
-    title: "Build",
+    title: "Resume",
     description:
       "Scalable data infrastructure, intelligent applications, and production systems that stay fast as usage grows.",
     href: addUtmParams("https://cv.duyet.net", "homepage", "resume_card"),
-    icon: Workflow,
-    className: "bg-[#bfdbfe]",
+    icon: FileUser,
+    className: "bg-[#bfdbfe] dark:bg-[#1f3a5f]",
   },
   {
-    title: "Measure",
+    title: "Insights",
     description:
       "Live analytics for coding activity, site traffic, token usage, and operational systems across the Duyet network.",
     href: addUtmParams(
@@ -143,16 +47,16 @@ const capabilities = [
       "homepage",
       "insights_card"
     ),
-    icon: BarChart,
-    className: "bg-[#a7f3d0]",
+    icon: ChartNoAxesCombined,
+    className: "bg-[#a7f3d0] dark:bg-[#164634]",
   },
   {
-    title: "Document",
+    title: "About",
     description:
       "Clear project surfaces for Rust, ClickHouse, MCP tools, AI agents, and the small systems that make them useful.",
     href: "/about",
-    icon: FileText,
-    className: "bg-[#fecaca]",
+    icon: UserRound,
+    className: "bg-[#fecaca] dark:bg-[#4f1f1f]",
   },
 ];
 
@@ -166,8 +70,8 @@ function HomePage() {
         <KeyboardFeatures />
       </Suspense>
 
-      <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a]">
-        <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur">
+      <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+        <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur dark:bg-[#0d0e0c]/95">
           <div className="mx-auto flex max-w-[1280px] items-center justify-between px-5 py-4 sm:px-8 lg:px-10 lg:py-5">
             <Link to="/" className="flex items-center gap-3">
               <DuyetMark />
@@ -178,6 +82,7 @@ function HomePage() {
 
             <nav className="hidden items-center gap-7 text-sm font-medium md:flex">
               <a href="https://blog.duyet.net">Blog</a>
+              <Link to="/projects">Projects</Link>
               <a href="https://cv.duyet.net">Experience</a>
               <a href="https://insights.duyet.net">Insights</a>
               <Link to="/about">About</Link>
@@ -199,7 +104,7 @@ function HomePage() {
           </div>
         </header>
 
-        <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 2xl:rounded-b-[4rem]">
+        <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
           <section className="mx-auto max-w-[1280px] px-5 py-14 sm:px-8 md:py-18 lg:px-10 lg:py-24 xl:py-28">
             <div className="max-w-[860px] space-y-6">
               <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
@@ -225,18 +130,18 @@ function HomePage() {
             </div>
 
             <div className="my-10 flex justify-center lg:my-14">
-              <a
-                href="#apps"
-                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] lg:px-8 lg:text-lg"
+              <Link
+                to="/projects"
+                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white lg:px-8 lg:text-lg"
               >
-                View more apps
-              </a>
+                View more projects
+              </Link>
             </div>
           </section>
 
           <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
             <h2 className="text-2xl font-semibold tracking-tight md:text-3xl xl:text-4xl">
-              What I do
+              Explore the work
             </h2>
 
             <div className="mt-10 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-4 lg:gap-6 xl:gap-8">
@@ -245,14 +150,6 @@ function HomePage() {
               ))}
             </div>
 
-            <div className="my-10 flex justify-center lg:my-14">
-              <Link
-                to="/about"
-                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] lg:px-8 lg:text-lg"
-              >
-                More about Duyet
-              </Link>
-            </div>
           </section>
 
           <section
@@ -263,7 +160,7 @@ function HomePage() {
               <h2 className="text-2xl font-semibold tracking-tight md:text-3xl xl:text-4xl">
                 Apps
               </h2>
-              <p className="text-base font-medium text-[#1a1a1a]/70">
+              <p className="text-base font-medium text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
                 Managed by @duyetbot AI Agent
               </p>
             </div>
@@ -278,27 +175,29 @@ function HomePage() {
               ))}
             </div>
 
-            <div className="mt-5 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6 xl:gap-8">
-              {compactApps.map((item) => (
-                <CompactAppCard key={item.name} item={item} />
-              ))}
-            </div>
+            {compactApps.length > 0 && (
+              <div className="mt-5 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6 xl:gap-8">
+                {compactApps.map((item) => (
+                  <CompactAppCard key={item.name} item={item} />
+                ))}
+              </div>
+            )}
           </section>
 
           <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
             <Link
               to="/ls"
-              className="group grid gap-5 rounded-xl bg-white p-6 transition-colors hover:bg-[#f2f2eb] md:grid-cols-[1fr_auto] md:items-center lg:p-8"
+              className="group grid gap-5 rounded-xl bg-white p-6 transition-colors hover:bg-[#f2f2eb] dark:bg-[#1a1a1a] dark:hover:bg-[#242420] md:grid-cols-[1fr_auto] md:items-center lg:p-8"
             >
               <div className="flex items-start gap-4">
-                <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-[#1a1a1a] text-white">
+                <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-[#f8f8f2] dark:text-[#0d0e0c]">
                   <LinkIcon className="h-5 w-5" />
                 </span>
                 <div>
                   <h3 className="text-xl font-semibold tracking-tight">
                     duyet.net/ls
                   </h3>
-                  <p className="mt-1 text-base font-medium text-[#1a1a1a]/70">
+                  <p className="mt-1 text-base font-medium text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
                     All short URLs and redirects
                   </p>
                 </div>
@@ -308,7 +207,7 @@ function HomePage() {
           </section>
         </main>
 
-        <footer className="sticky bottom-0 bg-white px-5 pb-12 pt-24 sm:px-8 lg:px-10 lg:pb-16 lg:pt-28 xl:pb-20">
+        <footer className="sticky bottom-0 bg-white px-5 pb-12 pt-24 dark:bg-[#1a1a1a] sm:px-8 lg:px-10 lg:pb-16 lg:pt-28 xl:pb-20">
           <div className="mx-auto max-w-[1280px]">
             <h2 className="max-w-[820px] text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
               Build useful systems, then explain them clearly.
@@ -322,7 +221,7 @@ function HomePage() {
                 )}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] lg:px-8 lg:text-lg"
+                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white lg:px-8 lg:text-lg"
               >
                 GitHub
               </a>
@@ -334,13 +233,13 @@ function HomePage() {
                 )}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-lg border border-[#1a1a1a]/15 px-6 py-4 text-base font-medium transition-colors hover:border-[#1a1a1a] lg:px-8 lg:text-lg"
+                className="rounded-lg border border-[#1a1a1a]/15 px-6 py-4 text-base font-medium transition-colors hover:border-[#1a1a1a] dark:border-white/15 dark:hover:border-white lg:px-8 lg:text-lg"
               >
                 LinkedIn
               </a>
             </div>
 
-            <hr className="border-[#1a1a1a]/15" />
+            <hr className="border-[#1a1a1a]/15 dark:border-white/15" />
 
             <div className="grid gap-6 pt-10 text-base font-medium md:grid-cols-2 md:pt-16">
               <div className="flex flex-wrap items-center gap-6">
@@ -379,10 +278,10 @@ function HomePage() {
 function DuyetMark() {
   return (
     <span className="grid h-5 w-5 grid-cols-2 gap-0.5" aria-hidden="true">
-      <span className="bg-[#1a1a1a]" />
-      <span className="translate-y-1 bg-[#1a1a1a]" />
-      <span className="-translate-y-1 bg-[#1a1a1a]" />
-      <span className="bg-[#1a1a1a]" />
+      <span className="bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="translate-y-1 bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="-translate-y-1 bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
     </span>
   );
 }
@@ -397,20 +296,24 @@ function ProjectCard({
   return (
     <AppLink
       item={item}
-      className="group relative overflow-hidden rounded-xl bg-[#1a1a1a]"
+      className={`group overflow-hidden rounded-xl border border-[#1a1a1a]/10 ${item.tone ?? "bg-[#1a1a1a]"} transition-transform hover:-translate-y-0.5 dark:border-white/10`}
       shortcutNumber={shortcutNumber}
     >
-      <div className="absolute inset-0 z-10 h-1/2 bg-gradient-to-b from-black/65 to-transparent" />
-      <img
-        src={item.screenshot}
-        alt={item.name}
-        loading="lazy"
-        className="aspect-[16/10] h-full w-full rounded-xl object-cover object-top transition-transform duration-500 group-hover:scale-[1.025]"
-      />
-      <div className="absolute left-6 top-6 z-20 text-white lg:left-8 lg:top-8">
+      <div className="overflow-hidden bg-[#1a1a1a]">
+        <img
+          src={item.screenshot}
+          alt={item.name}
+          loading="lazy"
+          className="aspect-[16/10] w-full object-cover object-top transition-transform duration-500 group-hover:scale-[1.025]"
+        />
+      </div>
+      <div className="p-5 text-white">
         <h3 className="text-lg font-semibold tracking-tight">{item.name}</h3>
-        <p className="mt-1 text-xs font-medium text-white/80">
+        <p className="mt-2 text-sm font-medium leading-6 text-white/82">
           {item.description}
+        </p>
+        <p className="mt-5 truncate text-sm font-medium text-white/62">
+          {item.host}
         </p>
       </div>
     </AppLink>
@@ -427,7 +330,7 @@ function CapabilityCard({
   title: string;
   description: string;
   href: string;
-  icon: typeof BookOpen;
+  icon: typeof Newspaper;
   className: string;
 }) {
   const isExternal = href.startsWith("http");
@@ -472,16 +375,16 @@ function CompactAppCard({ item }: { item: AppItem }) {
   return (
     <AppLink
       item={item}
-      className="group flex min-h-36 flex-col rounded-xl bg-white p-5 transition-colors hover:bg-[#f2f2eb] lg:p-6"
+      className="group flex min-h-36 flex-col rounded-xl bg-white p-5 transition-colors hover:bg-[#f2f2eb] dark:bg-[#1a1a1a] dark:hover:bg-[#242420] lg:p-6"
     >
-      <div className="mb-8 flex h-10 w-10 items-center justify-center rounded-lg bg-[#1a1a1a] text-white">
+      <div className="mb-8 flex h-10 w-10 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-[#f8f8f2] dark:text-[#0d0e0c]">
         <Server className="h-5 w-5" />
       </div>
       <h3 className="text-lg font-semibold tracking-tight">{item.name}</h3>
-      <p className="mt-2 text-sm font-medium leading-snug text-[#1a1a1a]/70">
+      <p className="mt-2 text-sm font-medium leading-snug text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
         {item.description}
       </p>
-      <p className="mt-auto pt-6 text-sm font-medium text-[#1a1a1a]/55">
+      <p className="mt-auto pt-6 text-sm font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
         {item.host}
       </p>
     </AppLink>
@@ -506,8 +409,6 @@ function AppLink({
     return (
       <a
         href={href}
-        target="_blank"
-        rel="noopener noreferrer"
         className={className}
         data-shortcut-id={shortcutId}
         data-shortcut-number={shortcutNumber}

--- a/apps/home/src/routes/p/$project.tsx
+++ b/apps/home/src/routes/p/$project.tsx
@@ -1,0 +1,244 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { ArrowLeft, ExternalLink } from "lucide-react";
+import { addUtmParams } from "../../../app/lib/utm";
+
+type Product = {
+  slug: string;
+  name: string;
+  eyebrow: string;
+  summary: string;
+  image: string;
+  url: string;
+  year: string;
+  role: string;
+  industry: string;
+  overview: string;
+  highlights: string[];
+};
+
+const products: Product[] = [
+  {
+    slug: "anyrouter",
+    name: "AnyRouter",
+    eyebrow: "AI gateway product",
+    summary: "A practical gateway for routing model traffic across providers.",
+    image: "/screenshots/anyrouter-art.svg",
+    url: "https://github.com/duyet/anyrouter",
+    year: "2026",
+    role: "Design, engineering, docs",
+    industry: "AI infrastructure",
+    overview:
+      "AnyRouter turns provider choice, model routing, and integration docs into a single focused surface for developers building AI products.",
+    highlights: [
+      "Provider-agnostic API patterns for LLM applications.",
+      "Developer-facing docs designed for copy-paste integration.",
+      "Operational pages for models, usage, and gateway behavior.",
+    ],
+  },
+  {
+    slug: "chm",
+    name: "ClickHouse Monitoring",
+    eyebrow: "Operational dashboard",
+    summary: "A ClickHouse cluster monitoring surface for fast daily triage.",
+    image: "/screenshots/ch-monitor.png",
+    url: "https://clickhouse.duyet.net",
+    year: "2026",
+    role: "Product design, frontend, observability",
+    industry: "Data infrastructure",
+    overview:
+      "The monitoring app keeps cluster health, query activity, and operational signals in a compact interface built for repeated use.",
+    highlights: [
+      "Dense but readable dashboards for ClickHouse operations.",
+      "Focused query and cluster views without marketing-page chrome.",
+      "Responsive layouts that keep metrics scannable on smaller screens.",
+    ],
+  },
+  {
+    slug: "stamp",
+    name: "Stamp",
+    eyebrow: "Link and image utility",
+    summary: "A small product surface for links, generated visuals, and usage.",
+    image: "/screenshots/stamp.png",
+    url: "https://stamp.duyet.net",
+    year: "2026",
+    role: "Design, full-stack engineering",
+    industry: "Developer tools",
+    overview:
+      "Stamp combines a compact public tool with operational details behind the scenes, keeping the product easy to understand and fast to use.",
+    highlights: [
+      "Simple public workflows with restrained controls.",
+      "Usage and credit surfaces designed for clarity.",
+      "Cloudflare-first deployment and configuration.",
+    ],
+  },
+];
+
+export const Route = createFileRoute("/p/$project")({
+  loader: ({ params }) => {
+    const product = products.find((item) => item.slug === params.project);
+    if (!product) throw notFound();
+    return { product };
+  },
+  component: ProductPage,
+});
+
+function ProductPage() {
+  const { product } = Route.useLoaderData() as { product: Product };
+  const related = products.filter((item) => item.slug !== product.slug);
+
+  return (
+    <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a]">
+      <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur">
+        <div className="mx-auto flex max-w-[1340px] items-center justify-between px-5 py-3 sm:px-8 md:py-5 lg:px-10">
+          <Link
+            to="/"
+            className="flex items-center gap-2 text-xl font-semibold tracking-tight"
+          >
+            Duyet
+          </Link>
+          <nav className="hidden items-center gap-8 text-sm font-medium md:flex">
+            <Link to="/">Home</Link>
+            <a href="https://blog.duyet.net">Blog</a>
+            <a href="https://cv.duyet.net">CV</a>
+          </nav>
+          <span className="flex min-w-24 items-center justify-end gap-2 text-sm font-medium">
+            <span className="h-3 w-3 rounded-full bg-orange-500" />
+            Product
+          </span>
+        </div>
+      </header>
+
+      <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 2xl:rounded-b-[4rem]">
+        <section className="mx-auto max-w-[1340px] px-5 py-12 sm:px-8 md:py-16 lg:px-10 lg:py-24 xl:py-28">
+          <Link
+            to="/"
+            className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-[#1a1a1a]/70 hover:text-[#1a1a1a]"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back home
+          </Link>
+          <div className="space-y-4 md:space-y-6 lg:space-y-8">
+            <p className="text-sm font-medium text-[#1a1a1a]/70">
+              {product.eyebrow}
+            </p>
+            <h1 className="text-5xl font-semibold tracking-tight sm:text-6xl lg:text-7xl xl:text-8xl">
+              {product.name}
+            </h1>
+            <p className="max-w-[580px] text-lg leading-7 lg:text-xl">
+              {product.summary}
+            </p>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-[1340px] px-5 sm:px-8 lg:px-10">
+          <img
+            src={product.image}
+            alt={`${product.name} product screenshot`}
+            className="aspect-[4/3] w-full rounded-lg bg-[#050505] object-cover sm:aspect-[6/4] lg:aspect-[5/3] xl:rounded-xl"
+          />
+        </section>
+
+        <section className="mx-auto mt-16 max-w-[1340px] px-5 sm:px-8 md:mt-20 lg:mt-24 lg:px-10">
+          <div className="space-y-4 lg:space-y-6">
+            <h2 className="text-lg lg:text-xl">About {product.name}</h2>
+            <p className="max-w-[1180px] text-2xl font-semibold tracking-tight sm:text-3xl md:text-4xl xl:text-5xl">
+              {product.overview}
+            </p>
+          </div>
+
+          <div className="my-12 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:mt-16 lg:gap-6 xl:mt-20 xl:gap-8">
+            <Meta label="Product" value={product.name} />
+            <Meta label="Industry" value={product.industry} />
+            <Meta label="Role" value={product.role} />
+            <Meta label="Year" value={product.year} />
+          </div>
+
+          <div className="space-y-4 lg:space-y-6">
+            <h2 className="text-lg lg:text-xl">Highlights</h2>
+            <div className="grid gap-4 md:grid-cols-3 lg:gap-6 xl:gap-8">
+              {product.highlights.map((highlight) => (
+                <div
+                  key={highlight}
+                  className="rounded-lg border border-[#1a1a1a]/10 bg-white p-5"
+                >
+                  <p className="text-base font-semibold leading-snug md:text-lg">
+                    {highlight}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="my-12 flex justify-center lg:my-16">
+            <a
+              href={addUtmParams(
+                product.url,
+                "homepage",
+                `${product.slug}_product_page`
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] md:text-lg"
+            >
+              Visit project
+              <ExternalLink className="h-5 w-5" />
+            </a>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-20 max-w-[1340px] px-5 sm:px-8 lg:mt-28 lg:px-10 xl:mt-32">
+          <h2 className="text-3xl font-semibold tracking-tight md:text-4xl xl:text-5xl">
+            More projects
+          </h2>
+          <div className="mt-10 grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6 xl:mt-16 xl:gap-8">
+            {related.map((item) => (
+              <Link
+                key={item.slug}
+                to="/p/$project"
+                params={{ project: item.slug }}
+                className="group relative overflow-hidden rounded-lg bg-[#050505]"
+              >
+                <img
+                  src={item.image}
+                  alt=""
+                  className="aspect-[4/3] w-full object-cover opacity-75 transition-transform duration-500 group-hover:scale-[1.025] sm:aspect-[6/4]"
+                />
+                <div className="absolute inset-0 bg-gradient-to-b from-black/70 to-transparent" />
+                <div className="absolute left-6 top-6 z-10 text-white lg:left-8 lg:top-8">
+                  <p className="text-xl font-medium">{item.name}</p>
+                  <p className="text-sm opacity-80">{item.eyebrow}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <nav className="mx-auto mb-4 mt-10 w-max rounded-full bg-white px-6 py-4 text-sm font-medium shadow-lg ring-1 ring-black/5 md:hidden">
+        <ul className="flex items-center justify-center gap-5">
+          <li>
+            <Link to="/">Home</Link>
+          </li>
+          <li>
+            <a href="https://blog.duyet.net">Blog</a>
+          </li>
+          <li>
+            <a href="https://cv.duyet.net">CV</a>
+          </li>
+          <li>
+            <Link to="/about">About</Link>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-t border-[#1a1a1a]/15 pt-3">
+      <h3 className="text-sm text-[#1a1a1a]/60 lg:text-base">{label}</h3>
+      <p className="mt-1 text-base font-semibold lg:text-lg">{value}</p>
+    </div>
+  );
+}

--- a/apps/home/src/routes/p/$project.tsx
+++ b/apps/home/src/routes/p/$project.tsx
@@ -74,6 +74,23 @@ const products: Product[] = [
 ];
 
 export const Route = createFileRoute("/p/$project")({
+  head: ({ params, loaderData }) => {
+    const product =
+      (loaderData as { product?: Product } | undefined)?.product ??
+      products.find((item) => item.slug === params.project);
+
+    return {
+      meta: [
+        { title: `${product?.name ?? "Project"} | Duyet Le` },
+        {
+          name: "description",
+          content:
+            product?.summary ??
+            "A Duyet Le project surface for data, AI, and developer tools.",
+        },
+      ],
+    };
+  },
   loader: ({ params }) => {
     const product = products.find((item) => item.slug === params.project);
     if (!product) throw notFound();
@@ -87,8 +104,8 @@ function ProductPage() {
   const related = products.filter((item) => item.slug !== product.slug);
 
   return (
-    <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a]">
-      <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur">
+    <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+      <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur dark:bg-[#0d0e0c]/95">
         <div className="mx-auto flex max-w-[1340px] items-center justify-between px-5 py-3 sm:px-8 md:py-5 lg:px-10">
           <Link
             to="/"
@@ -98,8 +115,24 @@ function ProductPage() {
           </Link>
           <nav className="hidden items-center gap-8 text-sm font-medium md:flex">
             <Link to="/">Home</Link>
-            <a href="https://blog.duyet.net">Blog</a>
-            <a href="https://cv.duyet.net">CV</a>
+            <a
+              href={addUtmParams(
+                "https://blog.duyet.net",
+                "product_page",
+                "header_blog"
+              )}
+            >
+              Blog
+            </a>
+            <a
+              href={addUtmParams(
+                "https://cv.duyet.net",
+                "product_page",
+                "header_cv"
+              )}
+            >
+              CV
+            </a>
           </nav>
           <span className="flex min-w-24 items-center justify-end gap-2 text-sm font-medium">
             <span className="h-3 w-3 rounded-full bg-orange-500" />
@@ -108,17 +141,17 @@ function ProductPage() {
         </div>
       </header>
 
-      <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 2xl:rounded-b-[4rem]">
+      <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
         <section className="mx-auto max-w-[1340px] px-5 py-12 sm:px-8 md:py-16 lg:px-10 lg:py-24 xl:py-28">
           <Link
             to="/"
-            className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-[#1a1a1a]/70 hover:text-[#1a1a1a]"
+            className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-[#1a1a1a]/70 hover:text-[#1a1a1a] dark:text-[#f8f8f2]/70 dark:hover:text-[#f8f8f2]"
           >
             <ArrowLeft className="h-4 w-4" />
             Back home
           </Link>
           <div className="space-y-4 md:space-y-6 lg:space-y-8">
-            <p className="text-sm font-medium text-[#1a1a1a]/70">
+            <p className="text-sm font-medium text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
               {product.eyebrow}
             </p>
             <h1 className="text-5xl font-semibold tracking-tight sm:text-6xl lg:text-7xl xl:text-8xl">
@@ -159,7 +192,7 @@ function ProductPage() {
               {product.highlights.map((highlight) => (
                 <div
                   key={highlight}
-                  className="rounded-lg border border-[#1a1a1a]/10 bg-white p-5"
+                  className="rounded-lg border border-[#1a1a1a]/10 bg-white p-5 dark:border-white/10 dark:bg-[#1a1a1a]"
                 >
                   <p className="text-base font-semibold leading-snug md:text-lg">
                     {highlight}
@@ -178,7 +211,7 @@ function ProductPage() {
               )}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] md:text-lg"
+              className="inline-flex items-center gap-2 rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white md:text-lg"
             >
               Visit project
               <ExternalLink className="h-5 w-5" />
@@ -214,16 +247,32 @@ function ProductPage() {
         </section>
       </main>
 
-      <nav className="mx-auto mb-4 mt-10 w-max rounded-full bg-white px-6 py-4 text-sm font-medium shadow-lg ring-1 ring-black/5 md:hidden">
+      <nav className="mx-auto mb-4 mt-10 w-max rounded-full bg-white px-6 py-4 text-sm font-medium shadow-lg ring-1 ring-black/5 dark:bg-[#1a1a1a] dark:ring-white/10 md:hidden">
         <ul className="flex items-center justify-center gap-5">
           <li>
             <Link to="/">Home</Link>
           </li>
           <li>
-            <a href="https://blog.duyet.net">Blog</a>
+            <a
+              href={addUtmParams(
+                "https://blog.duyet.net",
+                "product_page",
+                "mobile_blog"
+              )}
+            >
+              Blog
+            </a>
           </li>
           <li>
-            <a href="https://cv.duyet.net">CV</a>
+            <a
+              href={addUtmParams(
+                "https://cv.duyet.net",
+                "product_page",
+                "mobile_cv"
+              )}
+            >
+              CV
+            </a>
           </li>
           <li>
             <Link to="/about">About</Link>
@@ -236,8 +285,10 @@ function ProductPage() {
 
 function Meta({ label, value }: { label: string; value: string }) {
   return (
-    <div className="border-t border-[#1a1a1a]/15 pt-3">
-      <h3 className="text-sm text-[#1a1a1a]/60 lg:text-base">{label}</h3>
+    <div className="border-t border-[#1a1a1a]/15 pt-3 dark:border-white/15">
+      <h3 className="text-sm text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60 lg:text-base">
+        {label}
+      </h3>
       <p className="mt-1 text-base font-semibold lg:text-lg">{value}</p>
     </div>
   );

--- a/apps/home/src/routes/projects.tsx
+++ b/apps/home/src/routes/projects.tsx
@@ -23,14 +23,41 @@ function ProjectsPage() {
     <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
       <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur dark:bg-[#0d0e0c]/95">
         <div className="mx-auto flex max-w-[1280px] items-center justify-between px-5 py-4 sm:px-8 lg:px-10 lg:py-5">
-          <Link to="/" className="flex items-center gap-3 text-xl font-semibold tracking-tight">
+          <Link
+            to="/"
+            className="flex items-center gap-3 text-xl font-semibold tracking-tight"
+          >
             <DuyetMark />
             Duyet Le
           </Link>
           <nav className="hidden items-center gap-7 text-sm font-medium md:flex">
-            <a href="https://blog.duyet.net">Blog</a>
-            <a href="https://cv.duyet.net">Experience</a>
-            <a href="https://insights.duyet.net">Insights</a>
+            <a
+              href={addUtmParams(
+                "https://blog.duyet.net",
+                "projects",
+                "header_blog"
+              )}
+            >
+              Blog
+            </a>
+            <a
+              href={addUtmParams(
+                "https://cv.duyet.net",
+                "projects",
+                "header_cv"
+              )}
+            >
+              Experience
+            </a>
+            <a
+              href={addUtmParams(
+                "https://insights.duyet.net",
+                "projects",
+                "header_insights"
+              )}
+            >
+              Insights
+            </a>
             <Link to="/about">About</Link>
           </nav>
           <a
@@ -74,7 +101,11 @@ function ProjectsPage() {
         <section className="mt-12 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6 xl:mt-16 xl:gap-8">
           {apps.map((item, index) =>
             item.screenshot ? (
-              <ProjectCard key={item.name} item={item} shortcutNumber={index + 1} />
+              <ProjectCard
+                key={item.name}
+                item={item}
+                shortcutNumber={index + 1}
+              />
             ) : (
               <CompactProjectCard
                 key={item.name}
@@ -112,10 +143,10 @@ function ProjectCard({
       </div>
       <div className="p-5 text-white">
         <h2 className="text-lg font-semibold tracking-tight">{item.name}</h2>
-        <p className="mt-2 text-sm font-medium leading-6 text-white/82">
+        <p className="mt-2 text-sm font-medium leading-6 text-white/80">
           {item.description}
         </p>
-        <p className="mt-5 truncate text-sm font-medium text-white/62">
+        <p className="mt-5 truncate text-sm font-medium text-white/60">
           {item.host}
         </p>
       </div>
@@ -167,6 +198,8 @@ function ProjectLink({
       <a
         href={href}
         className={className}
+        target="_blank"
+        rel="noopener noreferrer"
         data-shortcut-id={shortcutId}
         data-shortcut-number={shortcutNumber}
       >

--- a/apps/home/src/routes/projects.tsx
+++ b/apps/home/src/routes/projects.tsx
@@ -1,0 +1,199 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import type { ReactNode } from "react";
+import { addUtmParams } from "../../app/lib/utm";
+import { apps, type AppItem } from "../data/projects";
+
+export const Route = createFileRoute("/projects")({
+  component: ProjectsPage,
+  head: () => ({
+    meta: [
+      { title: "Projects | Duyet Le" },
+      {
+        name: "description",
+        content:
+          "A complete list of Duyet Le projects, apps, dashboards, AI tools, and open source work.",
+      },
+    ],
+  }),
+});
+
+function ProjectsPage() {
+  return (
+    <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+      <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur dark:bg-[#0d0e0c]/95">
+        <div className="mx-auto flex max-w-[1280px] items-center justify-between px-5 py-4 sm:px-8 lg:px-10 lg:py-5">
+          <Link to="/" className="flex items-center gap-3 text-xl font-semibold tracking-tight">
+            <DuyetMark />
+            Duyet Le
+          </Link>
+          <nav className="hidden items-center gap-7 text-sm font-medium md:flex">
+            <a href="https://blog.duyet.net">Blog</a>
+            <a href="https://cv.duyet.net">Experience</a>
+            <a href="https://insights.duyet.net">Insights</a>
+            <Link to="/about">About</Link>
+          </nav>
+          <a
+            href={addUtmParams(
+              "https://status.duyet.net",
+              "projects",
+              "header_status"
+            )}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex min-w-24 items-center justify-end gap-2 text-sm font-medium"
+          >
+            <span className="h-3 w-3 rounded-full bg-orange-500" />
+            <span>Status</span>
+          </a>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-[1280px] px-5 pb-20 pt-10 sm:px-8 md:pt-16 lg:px-10">
+        <Link
+          to="/"
+          className="mb-10 inline-flex items-center gap-2 text-sm font-medium text-[#1a1a1a]/65 transition-colors hover:text-[#1a1a1a] dark:text-[#f8f8f2]/65 dark:hover:text-[#f8f8f2]"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back home
+        </Link>
+
+        <section className="max-w-3xl">
+          <p className="mb-3 text-sm font-medium text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60">
+            Projects
+          </p>
+          <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
+            Apps, tools, dashboards, and open source systems.
+          </h1>
+          <p className="mt-5 max-w-2xl text-base font-medium leading-7 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+            A complete list of public project surfaces across data engineering,
+            AI infrastructure, analytics, developer tooling, and writing.
+          </p>
+        </section>
+
+        <section className="mt-12 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6 xl:mt-16 xl:gap-8">
+          {apps.map((item, index) =>
+            item.screenshot ? (
+              <ProjectCard key={item.name} item={item} shortcutNumber={index + 1} />
+            ) : (
+              <CompactProjectCard
+                key={item.name}
+                item={item}
+                shortcutNumber={index + 1}
+              />
+            )
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function ProjectCard({
+  item,
+  shortcutNumber,
+}: {
+  item: AppItem;
+  shortcutNumber?: number;
+}) {
+  return (
+    <ProjectLink
+      item={item}
+      className={`group overflow-hidden rounded-xl border border-[#1a1a1a]/10 ${item.tone ?? "bg-[#1a1a1a]"} transition-transform hover:-translate-y-0.5 dark:border-white/10`}
+      shortcutNumber={shortcutNumber}
+    >
+      <div className="overflow-hidden bg-[#1a1a1a]">
+        <img
+          src={item.screenshot}
+          alt={item.name}
+          loading="lazy"
+          className="aspect-[16/10] w-full object-cover object-top transition-transform duration-500 group-hover:scale-[1.025]"
+        />
+      </div>
+      <div className="p-5 text-white">
+        <h2 className="text-lg font-semibold tracking-tight">{item.name}</h2>
+        <p className="mt-2 text-sm font-medium leading-6 text-white/82">
+          {item.description}
+        </p>
+        <p className="mt-5 truncate text-sm font-medium text-white/62">
+          {item.host}
+        </p>
+      </div>
+    </ProjectLink>
+  );
+}
+
+function CompactProjectCard({
+  item,
+  shortcutNumber,
+}: {
+  item: AppItem;
+  shortcutNumber?: number;
+}) {
+  return (
+    <ProjectLink
+      item={item}
+      className="group flex min-h-44 flex-col rounded-xl border border-[#1a1a1a]/10 bg-white p-5 transition-colors hover:bg-[#f2f2eb] dark:border-white/10 dark:bg-[#1a1a1a] dark:hover:bg-[#242420]"
+      shortcutNumber={shortcutNumber}
+    >
+      <h2 className="text-lg font-semibold tracking-tight">{item.name}</h2>
+      <p className="mt-2 text-sm font-medium leading-6 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+        {item.description}
+      </p>
+      <div className="mt-auto flex items-center justify-between gap-4 pt-8 text-sm font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+        <span className="truncate">{item.host}</span>
+        <ArrowRight className="h-5 w-5 shrink-0 transition-transform group-hover:translate-x-1" />
+      </div>
+    </ProjectLink>
+  );
+}
+
+function ProjectLink({
+  item,
+  className,
+  shortcutNumber,
+  children,
+}: {
+  item: AppItem;
+  className?: string;
+  shortcutNumber?: number;
+  children: ReactNode;
+}) {
+  const href = addUtmParams(item.href, "projects", item.utmContent, item.host);
+  const shortcutId = item.name.toLowerCase().replace(/\s+/g, "-");
+
+  if (href.startsWith("http")) {
+    return (
+      <a
+        href={href}
+        className={className}
+        data-shortcut-id={shortcutId}
+        data-shortcut-number={shortcutNumber}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      to={href}
+      className={className}
+      data-shortcut-id={shortcutId}
+      data-shortcut-number={shortcutNumber}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function DuyetMark() {
+  return (
+    <span className="grid h-5 w-5 grid-cols-2 gap-0.5" aria-hidden="true">
+      <span className="bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="translate-y-1 bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="-translate-y-1 bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+      <span className="bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
+    </span>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -267,6 +267,7 @@
       "dependencies": {
         "@duyet/components": "*",
         "@duyet/libs": "*",
+        "@duyet/urls": "*",
         "@tanstack/react-router": "^1.0.0",
         "@tanstack/react-start": "^1.0.0",
         "framer-motion": "^12.36.0",


### PR DESCRIPTION
## Summary
- refresh the home about page with the new editorial visual system
- keep the projects listing and product detail routes used by the refreshed home surface
- add generated project thumbnails used by the new card grid

## Verification
- cd apps/home && bun run check-types
- cd apps/home && bun run build
- GitHub Actions deploy preview for home succeeded on the source commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated Projects page showcasing all available apps and tools
  * Added individual project detail pages with screenshots, metadata, and external links
  * Introduced new navigation links to Projects section

* **Style**
  * Redesigned About page layout with improved sections and visual hierarchy
  * Enhanced dark mode styling and color scheme application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->