### PR TITLE
feat(home): add mobile navigation picker

### DIFF
--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -1,21 +1,37 @@
+import {
+  Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@duyet/components";
 import { cn } from "@duyet/libs/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   ArrowRight,
   ChartNoAxesCombined,
-  Newspaper,
-  UserRound,
   FileUser,
   Link as LinkIcon,
+  MenuIcon,
+  Newspaper,
   Server,
+  UserRound,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { addUtmParams } from "../../app/lib/utm";
 import { BuildDate } from "../components/BuildDate";
 import { FooterInteractive } from "../components/FooterInteractive";
 import { KeyboardFeatures } from "../components/KeyboardFeatures";
-import { apps, type AppItem } from "../data/projects";
+import { type AppItem, apps } from "../data/projects";
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -60,6 +76,33 @@ const capabilities = [
   },
 ];
 
+const navItems = [
+  {
+    label: "Blog",
+    href: addUtmParams("https://blog.duyet.net", "homepage", "header_blog"),
+  },
+  { label: "Projects", href: "/projects" },
+  {
+    label: "Experience",
+    href: addUtmParams("https://cv.duyet.net", "homepage", "header_cv"),
+  },
+  {
+    label: "Insights",
+    href: addUtmParams(
+      "https://insights.duyet.net",
+      "homepage",
+      "header_insights"
+    ),
+  },
+  { label: "About", href: "/about" },
+];
+
+const statusHref = addUtmParams(
+  "https://status.duyet.net",
+  "homepage",
+  "header_status"
+);
+
 function HomePage() {
   const visualApps = apps.filter((item) => item.screenshot);
   const compactApps = apps.filter((item) => !item.screenshot);
@@ -81,50 +124,24 @@ function HomePage() {
             </Link>
 
             <nav className="hidden items-center gap-7 text-sm font-medium md:flex">
-              <a
-                href={addUtmParams(
-                  "https://blog.duyet.net",
-                  "homepage",
-                  "header_blog"
-                )}
-              >
-                Blog
-              </a>
-              <Link to="/projects">Projects</Link>
-              <a
-                href={addUtmParams(
-                  "https://cv.duyet.net",
-                  "homepage",
-                  "header_cv"
-                )}
-              >
-                Experience
-              </a>
-              <a
-                href={addUtmParams(
-                  "https://insights.duyet.net",
-                  "homepage",
-                  "header_insights"
-                )}
-              >
-                Insights
-              </a>
-              <Link to="/about">About</Link>
+              {navItems.map((item) => (
+                <HeaderLink key={item.label} href={item.href}>
+                  {item.label}
+                </HeaderLink>
+              ))}
             </nav>
 
             <a
-              href={addUtmParams(
-                "https://status.duyet.net",
-                "homepage",
-                "header_status"
-              )}
+              href={statusHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex min-w-24 items-center justify-end gap-2 text-sm font-medium"
+              className="hidden min-w-24 items-center justify-end gap-2 text-sm font-medium md:flex"
             >
               <span className="h-3 w-3 rounded-full bg-orange-500" />
               <span>Status</span>
             </a>
+
+            <MobileMenu />
           </div>
         </header>
 
@@ -143,27 +160,6 @@ function HomePage() {
           </section>
 
           <section className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
-            <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6 xl:gap-8">
-              {visualApps.slice(0, 6).map((item, index) => (
-                <ProjectCard
-                  key={item.name}
-                  item={item}
-                  shortcutNumber={index + 1}
-                />
-              ))}
-            </div>
-
-            <div className="my-10 flex justify-center lg:my-14">
-              <Link
-                to="/projects"
-                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white lg:px-8 lg:text-lg"
-              >
-                View more projects
-              </Link>
-            </div>
-          </section>
-
-          <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
             <h2 className="text-2xl font-semibold tracking-tight md:text-3xl xl:text-4xl">
               Explore the work
             </h2>
@@ -177,7 +173,7 @@ function HomePage() {
 
           <section
             id="apps"
-            className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40"
+            className="mx-auto mt-16 max-w-[1280px] px-5 sm:px-8 lg:mt-20 lg:px-10 xl:mt-24"
           >
             <div className="flex flex-col justify-between gap-3 md:flex-row md:items-end">
               <h2 className="text-2xl font-semibold tracking-tight md:text-3xl xl:text-4xl">
@@ -189,13 +185,22 @@ function HomePage() {
             </div>
 
             <div className="mt-10 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6 xl:gap-8">
-              {visualApps.slice(6).map((item, index) => (
+              {visualApps.map((item, index) => (
                 <ProjectCard
                   key={item.name}
                   item={item}
-                  shortcutNumber={index < 4 ? index + 7 : undefined}
+                  shortcutNumber={index < 10 ? index + 1 : undefined}
                 />
               ))}
+            </div>
+
+            <div className="my-10 flex justify-center lg:my-14">
+              <Link
+                to="/projects"
+                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white lg:px-8 lg:text-lg"
+              >
+                View more projects
+              </Link>
             </div>
 
             {compactApps.length > 0 && (
@@ -298,6 +303,78 @@ function HomePage() {
   );
 }
 
+function HeaderLink({ href, children }: { href: string; children: ReactNode }) {
+  if (href.startsWith("http")) {
+    return <a href={href}>{children}</a>;
+  }
+
+  return <Link to={href}>{children}</Link>;
+}
+
+function MobileMenu() {
+  const [open, setOpen] = useState(false);
+  const items = [
+    ...navItems,
+    {
+      label: "Status",
+      href: statusHref,
+      external: true,
+    },
+  ];
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="md:hidden"
+          aria-label="Open menu"
+        >
+          <MenuIcon data-icon="inline-start" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent
+        side="top"
+        className="mx-auto mt-3 w-[calc(100%-2rem)] max-w-sm rounded-xl border border-[#1a1a1a]/10 p-0 dark:border-white/10"
+      >
+        <SheetHeader className="px-4 pt-4 text-left">
+          <SheetTitle className="text-base">Menu</SheetTitle>
+          <SheetDescription className="sr-only">
+            Search and open Duyet site navigation links.
+          </SheetDescription>
+        </SheetHeader>
+        <Command className="bg-transparent">
+          <CommandInput placeholder="Search pages..." />
+          <CommandList>
+            <CommandEmpty>No page found.</CommandEmpty>
+            <CommandGroup heading="Navigation">
+              {items.map((item) => (
+                <CommandItem
+                  key={item.label}
+                  value={item.label}
+                  onSelect={() => {
+                    setOpen(false);
+                    window.location.href = item.href;
+                  }}
+                >
+                  <span>{item.label}</span>
+                  {"external" in item && item.external ? (
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      External
+                    </span>
+                  ) : null}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
 function DuyetMark() {
   return (
     <span className="grid h-5 w-5 grid-cols-2 gap-0.5" aria-hidden="true">
@@ -319,7 +396,7 @@ function ProjectCard({
   return (
     <AppLink
       item={item}
-      className={`group overflow-hidden rounded-xl border border-[#1a1a1a]/10 ${item.tone ?? "bg-[#1a1a1a]"} transition-transform hover:-translate-y-0.5 dark:border-white/10`}
+      className={`group overflow-hidden rounded-xl ${item.tone ?? "bg-[#1a1a1a]"} transition-transform hover:-translate-y-0.5`}
       shortcutNumber={shortcutNumber}
     >
       <div className="overflow-hidden bg-[#1a1a1a]">

--- a/bun.lock
+++ b/bun.lock
@@ -429,6 +429,7 @@
         "@tremor/react": "^3.18.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lucide-react": "^1.0.0",
         "next-themes": "^0.4.0",
         "react": "19.2.5",

--- a/packages/components/index.tsx
+++ b/packages/components/index.tsx
@@ -39,6 +39,7 @@ export * from "./ui/accordion";
 export * from "./ui/badge";
 export * from "./ui/button";
 export * from "./ui/card";
+export * from "./ui/command";
 export * from "./ui/dialog";
 export * from "./ui/dropdown-menu";
 export * from "./ui/hover-card";

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,6 +35,7 @@
     "@tremor/react": "^3.18.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^1.0.0",
     "next-themes": "^0.4.0",
     "react": "19.2.5",

--- a/packages/components/ui/command.tsx
+++ b/packages/components/ui/command.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { cn } from "@duyet/libs/utils";
+import { Command as CommandPrimitive } from "cmdk";
+import { SearchIcon } from "lucide-react";
+import type * as React from "react";
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-12 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] overflow-y-auto overflow-x-hidden",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-3 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+};


### PR DESCRIPTION
## Summary
- Move Explore the work directly below the Data & AI Engineering hero
- Move the app/project list below Explore the work and remove project card borders
- Hide the top Status link on mobile and add a shadcn/Radix command-style mobile navigation picker

## Verification
- bunx biome check apps/home/src/routes/index.tsx packages/components/ui/command.tsx packages/components/index.tsx packages/components/package.json
- bun run check-types (apps/home)
- bun run build (apps/home)
- Browser check at 385x731: no horizontal overflow, mobile Status hidden, menu opens, menu includes Status