### PR TITLE
docs: sync root agent workflow commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Read [docs/ai/internal-knowledge.md](docs/ai/internal-knowledge.md) before chang
 
 Use semantic commit messages. Keep changes surgical and verify with the narrowest useful command for the touched app or package.
 For root quality checks, use `bun run lint`, `bun run check-types`, and `bun run test`.
-For Rust/WASM workflows, use the documented root commands (`bun run rust:build`, `bun run wasm:build`, `bun run wasm:test`, `bun run bench:wasm`) only when the touched change requires them.
+For deploy/config workflows, use root scripts (`bun run config`, `bun run deploy`, `bun run cf:deploy`, `bun run cf:deploy:prod`) when needed.
+For Rust/WASM workflows, use the documented root commands (`bun run rust:build`, `bun run wasm:build`, `bun run wasm:test`, `bun run wasm:clippy`, `bun run bench:wasm`) only when the touched change requires them.
 
 Put durable repository knowledge in `docs/ai/internal-knowledge.md` instead of expanding this file.


### PR DESCRIPTION
## Summary\n- add missing root deploy/config workflow commands to root agent instructions\n- add  to Rust/WASM command list\n- keep AGENTS/CLAUDE sync via existing symlink\n\n## Verification\n- docs-only change; verified commands against root  and

## Summary by Sourcery

Update CLAUDE agent workflow documentation to cover additional root scripts and commands for deploy/config and Rust/WASM workflows.

Documentation:
- Document root deploy and config workflow scripts for the CLAUDE agent.
- Expand Rust/WASM workflow guidance to include the wasm:clippy command in the documented root commands list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for deployment and configuration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->