### PR TITLE
fix(cv): restore serif font token

### DIFF
--- a/apps/cv/app/globals.css
+++ b/apps/cv/app/globals.css
@@ -23,6 +23,7 @@
 }
 
 :root {
+  --font-serif: "Libre Baskerville", Georgia, serif;
   --background: #ffffff;
   --foreground: #1f1f1f;
   --card: #ffffff;


### PR DESCRIPTION
## Summary
- restore the `--font-serif` CSS token removed in commit `115468d3` while CV components still reference `var(--font-serif)`

## Evidence
- `115468d3` removed the token from `apps/cv/app/globals.css`
- current CV headings still use `font-[family-name:var(--font-serif)]` in `apps/cv/components/profile.tsx`, `experience.tsx`, `education.tsx`, and `section.tsx`

## Verification
- `bun run check-types` in `apps/cv`
- `bun run build` in `apps/cv`

## Summary by Sourcery

Bug Fixes:
- Reintroduce the --font-serif CSS variable so existing CV headings and components referencing it render with the intended serif font stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed print mode heading font display to use proper serif styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->