### PR TITLE
feat(ui): refresh cross-app chrome and blog cv visuals

### DIFF
--- a/apps/agents/app/globals.css
+++ b/apps/agents/app/globals.css
@@ -51,7 +51,7 @@
   --line-height-tight: 1.05;
   --line-height-normal: 1.55;
 
-  --background: #f8f8f2;
+  --background: #ffffff;
   --foreground: #1a1a1a;
   --card: #ffffff;
   --card-foreground: #1a1a1a;
@@ -75,7 +75,7 @@
   --chart-3: #a7f3d0;
   --chart-4: #fecaca;
   --chart-5: #facc15;
-  --sidebar: #f8f8f2;
+  --sidebar: #ffffff;
   --sidebar-foreground: #1a1a1a;
   --sidebar-primary: #1a1a1a;
   --sidebar-primary-foreground: #ffffff;

--- a/apps/ai-percentage/src/routes/__root.tsx
+++ b/apps/ai-percentage/src/routes/__root.tsx
@@ -65,14 +65,14 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider>
-          <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+          <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
             <Header longText="AI Code Usage" shortText="AI %" />
-            <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+            <main className="relative z-10 rounded-b-3xl bg-white pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
               <div className="mx-auto max-w-[1280px] px-5 pb-16 pt-6 sm:px-8 lg:px-10">
                 <Outlet />
               </div>
             </main>
-            <Footer className="bg-[#f2f2eb] dark:bg-[#1a1a1a]" />
+            <Footer className="bg-white dark:bg-[#1a1a1a]" />
           </div>
         </ThemeProvider>
         <Analytics />

--- a/apps/ai-percentage/src/styles.css
+++ b/apps/ai-percentage/src/styles.css
@@ -4,7 +4,7 @@
   :root {
     --font-inter: "Inter", -apple-system, BlinkMacSystemFont, ui-sans-serif, system-ui, sans-serif;
     --font-serif: "Libre Baskerville", Georgia, serif;
-    --background: #f8f8f2;
+    --background: #ffffff;
     --foreground: #1a1a1a;
     --card: #ffffff;
     --card-foreground: #1a1a1a;

--- a/apps/blog/app/globals.css
+++ b/apps/blog/app/globals.css
@@ -25,7 +25,7 @@
 
 /* Design system tokens — shared public app palette */
 :root {
-  --background: #f8f8f2;
+  --background: #ffffff;
   --foreground: #1a1a1a;
   --muted: #f4f4ef;
   --muted-foreground: #5f5f57;

--- a/apps/blog/components/layout/HomeCards.tsx
+++ b/apps/blog/components/layout/HomeCards.tsx
@@ -7,12 +7,16 @@ interface HomeCardsProps {
   topTags: string[];
 }
 
-const CARD_BG_COLORS = Array.from({ length: 100 }, (_, index) => {
-  const hue = (index * 37) % 360;
-  const saturation = 72 - (index % 5) * 4;
-  const lightness = 88 - (index % 4) * 5;
-  return `hsl(${hue} ${saturation}% ${lightness}%)`;
-});
+const CARD_BG_COLORS = [
+  "#0f172a",
+  "#1e293b",
+  "#1f3a5f",
+  "#0f5132",
+  "#3b2f24",
+  "#3f1f1f",
+  "#1b2a41",
+  "#172554",
+];
 
 export function HomeCards({ seriesList, topTags }: HomeCardsProps) {
   const cards = [
@@ -53,18 +57,15 @@ export function HomeCards({ seriesList, topTags }: HomeCardsProps) {
               "--card-bg": CARD_BG_COLORS[
                 hashString(`${card.href}:${card.title}:${card.category}:${index}`) % CARD_BG_COLORS.length
               ],
-              "--card-bg-dark": `hsl(${(index * 77 + 196) % 360} 36% 17%)`,
             } as CSSProperties
           }
-          className="group flex min-h-[180px] flex-col rounded-xl border border-[#1a1a1a]/10 bg-[var(--card-bg)] p-5 text-[#1a1a1a] shadow-[0_16px_36px_rgba(15,23,42,0.05)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1a1a1a] dark:border-white/10 dark:bg-[var(--card-bg-dark)] dark:text-[#f8f8f2] dark:focus-visible:outline-[#f8f8f2] lg:p-6"
+          className="group flex min-h-[180px] flex-col rounded-xl border border-[#1a1a1a]/10 bg-[var(--card-bg)] p-5 text-white shadow-[0_16px_36px_rgba(15,23,42,0.12)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1a1a1a] dark:border-white/10 dark:focus-visible:outline-[#f8f8f2] lg:p-6"
         >
-          <span className="text-sm font-medium text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60">
-            {card.category}
-          </span>
+          <span className="text-sm font-medium text-white/70">{card.category}</span>
           <h3 className="mt-5 text-lg font-semibold leading-tight tracking-tight md:text-xl">
             {card.title}
           </h3>
-          <p className="mt-2 text-sm font-medium leading-snug text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+          <p className="mt-2 text-sm font-medium leading-snug text-white/78">
             {card.description}
           </p>
           {card.tags.length > 0 ? (
@@ -72,7 +73,7 @@ export function HomeCards({ seriesList, topTags }: HomeCardsProps) {
               {card.tags.slice(0, 5).map((tag) => (
                 <span
                   key={tag}
-                  className="rounded-lg bg-white/75 px-2.5 py-1 text-xs font-medium text-[#1a1a1a]/65 dark:bg-white/10 dark:text-[#f8f8f2]/70"
+                  className="rounded-lg border border-white/25 bg-white/10 px-2.5 py-1 text-xs font-medium text-white/85"
                 >
                   {tag}
                 </span>

--- a/apps/blog/components/layout/SeriesBox.tsx
+++ b/apps/blog/components/layout/SeriesBox.tsx
@@ -6,22 +6,31 @@ export function SeriesBox({
   series,
   current,
   className,
+  tone = "light",
 }: {
   series: Series | null;
   current?: string;
   className?: string;
+  tone?: "light" | "dark";
 }) {
   if (!series) return null;
   const { name, posts } = series;
+  const isDarkTone = tone === "dark";
 
   return (
     <div
       className={cn(
         "rounded-xl border border-[#1a1a1a]/10 bg-white p-6 dark:border-white/10 dark:bg-[#1a1a1a] sm:p-8",
+        isDarkTone && "border-white/15 bg-[#0f172a] text-white dark:bg-[#0f172a]",
         className
       )}
     >
-      <h2 className="mb-6 flex flex-row items-center gap-3 text-2xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] md:text-3xl">
+      <h2
+        className={cn(
+          "mb-6 flex flex-row items-center gap-3 text-2xl font-semibold tracking-tight md:text-3xl",
+          isDarkTone ? "text-white" : "text-[#1a1a1a] dark:text-[#f8f8f2]"
+        )}
+      >
         <NewspaperIcon size={28} strokeWidth={2} />
         Series:{" "}
         <a
@@ -40,7 +49,9 @@ export function SeriesBox({
               className={cn(
                 "flex items-center gap-4 rounded-lg p-3 transition-colors sm:gap-5 sm:p-4",
                 isCurrent
-                  ? "bg-[#f8f8f2] dark:bg-[#0d0e0c]"
+                  ? isDarkTone
+                    ? "bg-white/12"
+                    : "bg-white dark:bg-[#0d0e0c]"
                   : ""
               )}
               key={slug}
@@ -48,19 +59,33 @@ export function SeriesBox({
               <div
                 className={cn(
                   "text-3xl font-semibold tabular-nums md:text-4xl",
-                  "text-[#1a1a1a]/25 dark:text-[#f8f8f2]/25"
+                  isDarkTone
+                    ? "text-white/35"
+                    : "text-[#1a1a1a]/25 dark:text-[#f8f8f2]/25"
                 )}
               >
                 {i + 1}
               </div>
               <div className="flex-1">
                 {isCurrent ? (
-                  <span className="line-clamp-1 text-base font-semibold text-[#1a1a1a] dark:text-[#f8f8f2]">
+                  <span
+                    className={cn(
+                      "line-clamp-1 text-base font-semibold",
+                      isDarkTone
+                        ? "text-white"
+                        : "text-[#1a1a1a] dark:text-[#f8f8f2]"
+                    )}
+                  >
                     {title}
                   </span>
                 ) : (
                   <a
-                    className="line-clamp-1 text-base font-medium text-[#1a1a1a]/80 transition-colors hover:text-[#1a1a1a] hover:underline hover:underline-offset-4 dark:text-[#f8f8f2]/80 dark:hover:text-[#f8f8f2]"
+                    className={cn(
+                      "line-clamp-1 text-base font-medium transition-colors hover:underline hover:underline-offset-4",
+                      isDarkTone
+                        ? "text-white/80 hover:text-white"
+                        : "text-[#1a1a1a]/80 hover:text-[#1a1a1a] dark:text-[#f8f8f2]/80 dark:hover:text-[#f8f8f2]"
+                    )}
                     href={slug}
                   >
                     {title}
@@ -70,9 +95,13 @@ export function SeriesBox({
                 <p
                   className={cn(
                     "line-clamp-1 text-sm",
-                    isCurrent
-                      ? "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70"
-                      : "text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55"
+                    isDarkTone
+                      ? isCurrent
+                        ? "text-white/74"
+                        : "text-white/62"
+                      : isCurrent
+                        ? "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70"
+                        : "text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55"
                   )}
                 >
                   {excerpt}

--- a/apps/blog/src/routes/__root.tsx
+++ b/apps/blog/src/routes/__root.tsx
@@ -19,7 +19,7 @@ import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 
 function NotFoundComponent() {
   return (
-    <div className="flex min-h-screen items-center justify-center px-4 bg-[#f8f8f2] dark:bg-[#0d0e0c]">
+    <div className="flex min-h-screen items-center justify-center px-4 bg-white dark:bg-[#0d0e0c]">
       <div className="max-w-md text-center">
         <h1 className="mb-4 text-6xl font-bold font-serif text-neutral-900 dark:text-neutral-100">
           404
@@ -122,10 +122,10 @@ function RootComponent() {
               showAuthButtons={false}
               actions={<AppCommandPalette />}
             />
-            <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+            <main className="relative z-10 rounded-b-3xl bg-white pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
               <Outlet />
             </main>
-            <Footer className="bg-[#f2f2eb] dark:bg-[#1a1a1a]" />
+            <Footer className="bg-white dark:bg-[#1a1a1a]" />
             <Analytics />
             <ServiceWorkerRegister />
           </div>

--- a/apps/blog/src/routes/series.tsx
+++ b/apps/blog/src/routes/series.tsx
@@ -19,18 +19,20 @@ export const Route = createFileRoute("/series")({
 });
 
 const seriesBackgrounds = [
-  "bg-white dark:bg-[#1a1a1a]",
-  "bg-[#bfdbfe] dark:bg-[#1f3a5f]",
-  "bg-[#a7f3d0] dark:bg-[#164634]",
-  "bg-[#fecaca] dark:bg-[#4f1f1f]",
-  "bg-[#f2f2eb] dark:bg-[#242420]",
+  "bg-[#0f172a]",
+  "bg-[#1e293b]",
+  "bg-[#1f3a5f]",
+  "bg-[#0f5132]",
+  "bg-[#3f1f1f]",
+  "bg-[#3b2f24]",
+  "bg-[#172554]",
 ];
 
 function SeriesPage() {
   const { seriesList } = Route.useLoaderData() as { seriesList: Series[] };
 
   return (
-    <div className="min-h-screen bg-[#f8f8f2] px-5 pb-14 pt-10 dark:bg-[#0d0e0c] sm:px-8 sm:pt-14 lg:px-10 lg:pt-20">
+    <div className="min-h-screen bg-white px-5 pb-14 pt-10 dark:bg-[#0d0e0c] sm:px-8 sm:pt-14 lg:px-10 lg:pt-20">
       <div className="mx-auto mb-10 max-w-[1280px]">
         <div className="max-w-3xl">
           <h1 className="mb-5 text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl lg:text-6xl">
@@ -50,6 +52,7 @@ function SeriesPage() {
               className={cn(tone)}
               key={series.slug}
               series={series}
+              tone="dark"
             />
           );
         })}

--- a/apps/cv/app/globals.css
+++ b/apps/cv/app/globals.css
@@ -116,10 +116,9 @@
 
 /* Print-specific optimizations for professional PDF export */
 @media print {
-  /* Use A4 page size with proper margins */
   @page {
     size: A4;
-    margin: 15mm 20mm;
+    margin: 10mm 14mm;
   }
 
   html,
@@ -130,91 +129,93 @@
     padding: 0;
   }
 
-  /* Professional serif font for better print readability */
   body {
     font-family: "Georgia", "Times New Roman", Times, serif !important;
-    font-size: 11pt !important;
-    line-height: 1.4 !important;
+    font-size: 10pt !important;
+    line-height: 1.28 !important;
     background: white !important;
     color: #000 !important;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }
 
-  /* Keep serif font for headings */
   h1,
   h2,
   h3 {
     font-family: var(--font-serif), Georgia, serif !important;
   }
 
-  /* Link styling: show URLs after links for reference */
   a[href^="http"] {
     color: #000 !important;
     text-decoration: none !important;
   }
 
-  /* Hide hover card content - not relevant for print */
   [role="dialog"],
   [data-state*="open"],
   .hover-card-content {
     display: none !important;
   }
 
-  /* Compress layout for single page */
   main {
     min-height: auto !important;
     margin: 0 !important;
     padding: 0 !important;
   }
 
-  /* Reduce all gaps and spacing */
-  .flex.flex-col.gap-8 {
+  main > div {
+    margin: 0 !important;
+    max-width: 100% !important;
+  }
+
+  .min-h-screen {
+    min-height: auto !important;
+  }
+
+  .flex.flex-col.gap-8,
+  .flex.flex-col.gap-6 {
     gap: 0.5rem !important;
   }
 
-  .flex.flex-col.gap-5 {
-    gap: 0.4rem !important;
-  }
-
-  .flex.flex-col.gap-3 {
+  .flex.flex-col.gap-5,
+  .flex.flex-col.gap-4 {
     gap: 0.3rem !important;
   }
 
+  .flex.flex-col.gap-3,
   .flex.flex-col.gap-2 {
-    gap: 0.2rem !important;
+    gap: 0.15rem !important;
   }
 
-  /* Optimize header spacing */
   header {
-    margin-bottom: 0.3rem !important;
+    margin-bottom: 0.2rem !important;
   }
 
   h1 {
-    font-size: 18pt !important;
-    margin-bottom: 0.3rem !important;
+    font-size: 16pt !important;
+    margin-bottom: 0.15rem !important;
     font-weight: 700 !important;
+    line-height: 1.1 !important;
   }
 
   h2 {
-    font-size: 14pt !important;
-    margin-bottom: 0.2rem !important;
+    font-size: 12pt !important;
+    margin-bottom: 0.1rem !important;
     font-weight: 600 !important;
+    line-height: 1.15 !important;
   }
 
   h3 {
-    font-size: 12pt !important;
+    font-size: 10.5pt !important;
     font-weight: 600 !important;
+    line-height: 1.15 !important;
   }
 
-  /* Compact sections */
   section {
-    margin-bottom: 0.4rem !important;
+    margin-bottom: 0.25rem !important;
   }
 
-  /* Reduce padding and margins */
   .mb-2 {
-    margin-bottom: 0.2rem !important;
+    margin-bottom: 0.1rem !important;
   }
 
   .mb-10 {
@@ -226,7 +227,6 @@
     margin-top: 0 !important;
   }
 
-  /* Prevent awkward page breaks */
   section,
   header,
   .experience-item,
@@ -234,14 +234,12 @@
     break-inside: avoid !important;
   }
 
-  /* Hide print button and unnecessary elements */
   .print\:hidden,
   button,
   [role="button"] {
     display: none !important;
   }
 
-  /* Optimize container */
   .container,
   [class*="Container"] {
     max-width: 100% !important;
@@ -249,27 +247,24 @@
     margin: 0 !important;
   }
 
-  /* Compress text elements */
   p,
   div,
   span {
-    line-height: 1.4 !important;
+    line-height: 1.28 !important;
   }
 
-  /* Reduce separator spacing */
   hr,
   [role="separator"] {
-    margin: 0.2rem 0 !important;
+    margin: 0.1rem 0 !important;
   }
 
-  /* Print footer styling */
   .cv-print-footer {
-    margin-top: 0.3rem !important;
-    padding-top: 0.2rem !important;
+    margin-top: 0.1rem !important;
+    padding-top: 0.1rem !important;
   }
 
   .cv-print-footer p {
-    font-size: 8pt !important;
+    font-size: 7.5pt !important;
     font-weight: 400 !important;
     text-align: left !important;
     color: #666 !important;
@@ -284,8 +279,8 @@
 
   .cv-print-footer .cv-footer-separator {
     margin: 0.1rem 0 !important;
-    width: 30% !important;
-    max-width: 30% !important;
+    width: 28% !important;
+    max-width: 28% !important;
     height: 0.5px !important;
     border: none !important;
     border-top: 0.5px solid #ccc !important;
@@ -293,24 +288,21 @@
     background: transparent !important;
   }
 
-  /* Optimize list styling */
   ul {
     margin: 0 !important;
-    padding-left: 1.2rem !important;
+    padding-left: 1rem !important;
   }
 
   li {
-    margin: 0.1rem 0 !important;
+    margin: 0.05rem 0 !important;
   }
 
-  /* Company logos - keep grayscale for professional look */
   img {
     filter: grayscale(100%) !important;
-    max-width: 1.5em !important;
-    max-height: 1.5em !important;
+    max-width: 1.25em !important;
+    max-height: 1.25em !important;
   }
 
-  /* Ensure all text is readable in print - force dark colors */
   .text-gray-600,
   .text-gray-300,
   .text-gray-400,
@@ -321,17 +313,14 @@
     color: #333 !important;
   }
 
-  /* Accent color in title */
   .text-neutral-500 {
     color: #444 !important;
   }
 
-  /* Strong/bold text */
   strong {
     font-weight: 600 !important;
   }
 
-  /* Separator orientation */
   [orientation="vertical"] {
     display: inline-block !important;
     width: 1px !important;

--- a/apps/home/src/components/SiteChrome.tsx
+++ b/apps/home/src/components/SiteChrome.tsx
@@ -1,8 +1,4 @@
-import {
-  AppCommandPalette,
-  Footer,
-  Header,
-} from "@duyet/components";
+import { AppCommandPalette, Footer, Header } from "@duyet/components";
 import { addUtmParams } from "../../app/lib/utm";
 
 const navigationItems = [
@@ -18,12 +14,6 @@ const navigationItems = [
   { name: "About", href: "/about" },
 ];
 
-const statusHref = addUtmParams(
-  "https://status.duyet.net",
-  "site_header",
-  "status"
-);
-
 export function SiteHeader() {
   return (
     <Header
@@ -31,20 +21,7 @@ export function SiteHeader() {
       longText="Duyet Le"
       navigationItems={navigationItems}
       showAuthButtons={false}
-      actions={
-        <div className="hidden items-center gap-2 md:flex">
-          <AppCommandPalette />
-          <a
-            href={statusHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="min-w-24 items-center justify-end gap-2 text-sm font-medium"
-          >
-            <span className="h-3 w-3 rounded-full bg-orange-500" />
-            <span>Status</span>
-          </a>
-        </div>
-      }
+      actions={<AppCommandPalette />}
     />
   );
 }

--- a/apps/home/src/globals.css
+++ b/apps/home/src/globals.css
@@ -9,7 +9,7 @@
       sans-serif;
     --font-serif: "Libre Baskerville", Georgia, serif;
     --color-primary: #1a1a1a;
-    --color-theme: #f8f8f2;
+    --color-theme: #ffffff;
     --color-status: oklch(70.5% 0.213 47.604);
   }
 

--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import {
   Github as GithubIcon,
   LinkedIn as LinkedInIcon,
@@ -164,10 +164,10 @@ const skills = [
 
 function AboutPage() {
   return (
-      <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+      <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
         <SiteHeader />
 
-      <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-20 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+      <main className="relative z-10 rounded-b-3xl bg-white pb-20 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
         <section className="mx-auto max-w-[1280px] px-5 py-14 sm:px-8 md:py-18 lg:px-10 lg:py-24 xl:py-28">
           <p className="mb-4 text-sm font-medium text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60">
             About
@@ -288,7 +288,7 @@ function AboutPage() {
         <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
           <div className="grid gap-5 rounded-xl bg-white p-6 dark:bg-[#1a1a1a] md:grid-cols-[1fr_auto] md:items-center lg:p-8">
             <div className="flex items-start gap-4">
-              <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-[#f8f8f2] dark:text-[#0d0e0c]">
+              <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-white dark:text-[#0d0e0c]">
                 <Radio className="h-5 w-5" />
               </span>
               <div>
@@ -309,7 +309,7 @@ function AboutPage() {
               )}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center gap-2 rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-white dark:text-[#0d0e0c] dark:hover:bg-white"
             >
               Read blog
               <ArrowRight className="h-5 w-5" />

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -69,10 +69,10 @@ function HomePage() {
         <KeyboardFeatures />
       </Suspense>
 
-      <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+      <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
         <SiteHeader />
 
-        <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+        <main className="relative z-10 rounded-b-3xl bg-white pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
           <section className="mx-auto max-w-[1280px] px-5 py-14 sm:px-8 md:py-18 lg:px-10 lg:py-24 xl:py-28">
             <div className="max-w-[860px] space-y-6">
               <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
@@ -124,7 +124,7 @@ function HomePage() {
             <div className="my-10 flex justify-center lg:my-14">
               <Link
                 to="/projects"
-                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white lg:px-8 lg:text-lg"
+                className="rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-white dark:text-[#0d0e0c] dark:hover:bg-white lg:px-8 lg:text-lg"
               >
                 View more projects
               </Link>
@@ -145,7 +145,7 @@ function HomePage() {
               className="group grid gap-5 rounded-xl bg-white p-6 transition-colors dark:bg-[#1a1a1a] md:grid-cols-[1fr_auto] md:items-center lg:p-8"
             >
               <div className="flex items-start gap-4">
-                <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-[#f8f8f2] dark:text-[#0d0e0c]">
+                <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-white dark:text-[#0d0e0c]">
                   <LinkIcon className="h-5 w-5" />
                 </span>
                 <div>
@@ -251,7 +251,7 @@ function CompactAppCard({ item }: { item: AppItem }) {
       item={item}
       className="group flex min-h-36 flex-col rounded-xl bg-white p-5 transition-colors dark:bg-[#1a1a1a] lg:p-6"
     >
-      <div className="mb-8 flex h-10 w-10 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-[#f8f8f2] dark:text-[#0d0e0c]">
+      <div className="mb-8 flex h-10 w-10 items-center justify-center rounded-lg bg-[#1a1a1a] text-white dark:bg-white dark:text-[#0d0e0c]">
         <Server className="h-5 w-5" />
       </div>
       <h3 className="text-lg font-semibold tracking-tight">{item.name}</h3>

--- a/apps/home/src/routes/ls.tsx
+++ b/apps/home/src/routes/ls.tsx
@@ -34,7 +34,7 @@ const publicUrls = Object.entries(urls)
 
 function ListPage() {
   return (
-    <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+    <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
       <SiteHeader />
 
       <main className="mx-auto max-w-5xl px-4 py-12 sm:px-6 sm:py-16">

--- a/apps/home/src/routes/p/$project.tsx
+++ b/apps/home/src/routes/p/$project.tsx
@@ -105,10 +105,10 @@ function ProductPage() {
   const related = products.filter((item) => item.slug !== product.slug);
 
   return (
-    <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+    <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
       <SiteHeader />
 
-      <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+      <main className="relative z-10 rounded-b-3xl bg-white pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
         <section className="mx-auto max-w-[1340px] px-5 py-12 sm:px-8 md:py-16 lg:px-10 lg:py-24 xl:py-28">
           <Link
             to="/"
@@ -178,7 +178,7 @@ function ProductPage() {
               )}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:hover:bg-white md:text-lg"
+              className="inline-flex items-center gap-2 rounded-lg bg-[#1a1a1a] px-6 py-4 text-base font-medium text-white transition-colors hover:bg-[#444] dark:bg-white dark:text-[#0d0e0c] dark:hover:bg-white md:text-lg"
             >
               Visit project
               <ExternalLink className="h-5 w-5" />

--- a/apps/home/src/routes/projects.tsx
+++ b/apps/home/src/routes/projects.tsx
@@ -21,7 +21,7 @@ export const Route = createFileRoute("/projects")({
 
 function ProjectsPage() {
   return (
-    <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+    <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
       <SiteHeader />
 
       <main className="mx-auto max-w-[1280px] px-5 pb-20 pt-10 sm:px-8 md:pt-16 lg:px-10">

--- a/apps/homelab/app/globals.css
+++ b/apps/homelab/app/globals.css
@@ -25,8 +25,9 @@
   --font-inter:
     "Inter", -apple-system, BlinkMacSystemFont, ui-sans-serif, system-ui,
     sans-serif;
-  --font-serif: "Libre Baskerville", georgia, serif;
-  --background: #f8f8f2;
+  --font-serif:
+    "Libre Baskerville", Georgia, serif;
+  --background: #ffffff;
   --foreground: #1a1a1a;
   --card: #ffffff;
   --card-foreground: #1a1a1a;

--- a/apps/homelab/src/routes/__root.tsx
+++ b/apps/homelab/src/routes/__root.tsx
@@ -57,17 +57,17 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider defaultTheme="light">
-          <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+          <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
             <Header
               longText={homelabConfig.header.longText}
               shortText={homelabConfig.header.shortText}
             />
-            <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+            <main className="relative z-10 rounded-b-3xl bg-white pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
               <Container className="mb-20 max-w-[1280px] px-5 pb-16 pt-8 sm:px-8 lg:px-10">
                 <Outlet />
               </Container>
             </main>
-            <Footer className="bg-[#f2f2eb] dark:bg-[#1a1a1a]" />
+            <Footer className="bg-white dark:bg-[#1a1a1a]" />
           </div>
           <Analytics />
         </ThemeProvider>

--- a/apps/insights/src/routes/__root.tsx
+++ b/apps/insights/src/routes/__root.tsx
@@ -10,8 +10,8 @@ import {
   Outlet,
   Scripts,
 } from "@tanstack/react-router";
-import type { ReactNode } from "react";
-import { Suspense } from "react";
+import type { JSX, ReactNode } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { Menu as MenuIcon, X } from "lucide-react";
 import { GlobalPeriodSelector } from "@/components/GlobalPeriodSelector";
 import { CompactNavigation } from "@/components/navigation/CompactNavigation";
@@ -68,6 +68,28 @@ export const Route = createRootRoute({
 });
 
 function RootComponent() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const mobileMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onPointerDown = (event: MouseEvent | TouchEvent) => {
+      if (!mobileMenuOpen || !mobileMenuRef.current) {
+        return;
+      }
+
+      if (!mobileMenuRef.current.contains(event.target as Node)) {
+        setMobileMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onPointerDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+    };
+  }, [mobileMenuOpen]);
+
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -101,23 +123,36 @@ function RootComponent() {
                   ))}
                 </nav>
 
-                <div className="md:hidden">
-                  <details className="group relative">
-                    <summary className="flex cursor-pointer list-none rounded-lg p-1.5 text-neutral-700 hover:bg-[#1a1a1a]/5 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:text-neutral-300 dark:hover:bg-white/5 dark:hover:text-neutral-100 dark:focus-visible:ring-neutral-500 [&::-webkit-details-marker]:hidden">
-                      <span className="sr-only">Toggle menu</span>
-                      <MenuIcon className="size-5 group-open:hidden" />
-                      <X className="hidden size-5 group-open:block" />
-                    </summary>
+                <div className="md:hidden" ref={mobileMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMobileMenuOpen((open) => !open);
+                    }}
+                    className="flex rounded-lg p-1.5 text-neutral-700 hover:bg-[#1a1a1a]/5 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:text-neutral-300 dark:hover:bg-white/5 dark:hover:text-neutral-100 dark:focus-visible:ring-neutral-500"
+                    aria-expanded={mobileMenuOpen}
+                    aria-label="Toggle menu"
+                  >
+                    <MenuIcon className={mobileMenuOpen ? "hidden size-5" : "size-5"} />
+                    <X className={mobileMenuOpen ? "size-5" : "hidden size-5"} />
+                  </button>
+                  {mobileMenuOpen ? (
                     <div className="absolute right-0 top-full z-50 mt-3 w-[min(280px,calc(100vw-2rem))] rounded-xl border border-[#1a1a1a]/10 bg-white p-4 shadow-lg dark:border-white/10 dark:bg-[#1a1a1a]">
                       <nav className="flex flex-col items-start gap-3 text-sm font-medium">
                         {headerNavItems.map((item) => (
-                          <HeaderLink key={item.label} href={item.href}>
+                          <HeaderLink
+                            key={item.label}
+                            href={item.href}
+                            onClick={() => {
+                              setMobileMenuOpen(false);
+                            }}
+                          >
                             {item.label}
                           </HeaderLink>
                         ))}
                       </nav>
                     </div>
-                  </details>
+                  ) : null}
                 </div>
               </div>
             </header>
@@ -192,22 +227,24 @@ function RootComponent() {
 function HeaderLink({
   href,
   children,
+  onClick,
 }: {
   href: string;
   children: ReactNode;
-}) {
+  onClick?: () => void;
+}): JSX.Element {
   if (href.startsWith("http")) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer">
+      <a href={href} target="_blank" rel="noopener noreferrer" onClick={onClick}>
         {children}
       </a>
     );
   }
 
-  return <a href={href}>{children}</a>;
+  return <a href={href} onClick={onClick}>{children}</a>;
 }
 
-function DuyetMark() {
+function DuyetMark(): JSX.Element {
   return (
     <span className="grid h-5 w-5 grid-cols-2 gap-0.5" aria-hidden="true">
       <span className="bg-[#1a1a1a] dark:bg-[#f8f8f2]" />

--- a/apps/insights/src/routes/__root.tsx
+++ b/apps/insights/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import {
 } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { Suspense } from "react";
+import { Menu as MenuIcon, X } from "lucide-react";
 import { GlobalPeriodSelector } from "@/components/GlobalPeriodSelector";
 import { CompactNavigation } from "@/components/navigation/CompactNavigation";
 
@@ -82,8 +83,8 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider>
-          <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
-            <header className="sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur dark:bg-[#0d0e0c]/95">
+          <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+            <header className="sticky top-0 z-50 border-b border-[#1a1a1a]/10 bg-white/95 backdrop-blur dark:border-white/10 dark:bg-[#0d0e0c]/95">
               <div className="mx-auto flex max-w-[1280px] items-center justify-between px-5 py-4 sm:px-8 lg:px-10 lg:py-5">
                 <a href="/" className="flex items-center gap-3">
                   <DuyetMark />
@@ -100,19 +101,28 @@ function RootComponent() {
                   ))}
                 </nav>
 
-                <a
-                  href={statusHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hidden items-center gap-2 text-sm font-medium md:flex"
-                >
-                  <span className="h-3 w-3 rounded-full bg-orange-500" />
-                  <span>Status</span>
-                </a>
+                <div className="md:hidden">
+                  <details className="group relative">
+                    <summary className="flex cursor-pointer list-none rounded-lg p-1.5 text-neutral-700 hover:bg-[#1a1a1a]/5 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:text-neutral-300 dark:hover:bg-white/5 dark:hover:text-neutral-100 dark:focus-visible:ring-neutral-500 [&::-webkit-details-marker]:hidden">
+                      <span className="sr-only">Toggle menu</span>
+                      <MenuIcon className="size-5 group-open:hidden" />
+                      <X className="hidden size-5 group-open:block" />
+                    </summary>
+                    <div className="absolute right-0 top-full z-50 mt-3 w-[min(280px,calc(100vw-2rem))] rounded-xl border border-[#1a1a1a]/10 bg-white p-4 shadow-lg dark:border-white/10 dark:bg-[#1a1a1a]">
+                      <nav className="flex flex-col items-start gap-3 text-sm font-medium">
+                        {headerNavItems.map((item) => (
+                          <HeaderLink key={item.label} href={item.href}>
+                            {item.label}
+                          </HeaderLink>
+                        ))}
+                      </nav>
+                    </div>
+                  </details>
+                </div>
               </div>
             </header>
 
-            <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+            <main className="relative z-10 rounded-b-3xl bg-white pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
               <div className="mx-auto max-w-[1280px] px-5 pb-16 pt-6 sm:px-8 lg:px-10">
                 <div className="mb-8 flex flex-wrap items-center justify-between gap-3">
                   <CompactNavigation />
@@ -122,7 +132,7 @@ function RootComponent() {
               </div>
             </main>
 
-            <footer className="sticky bottom-0 bg-[#f2f2eb] px-5 pb-12 pt-24 dark:bg-[#1a1a1a] sm:px-8 lg:px-10 lg:pb-16 lg:pt-28 xl:pb-20">
+            <footer className="sticky bottom-0 bg-white px-5 pb-12 pt-24 dark:bg-[#1a1a1a] sm:px-8 lg:px-10 lg:pb-16 lg:pt-28 xl:pb-20">
               <div className="mx-auto max-w-[1280px]">
                 <h2 className="max-w-[820px] text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
                   Build useful systems, then explain them clearly.

--- a/apps/insights/src/styles/globals.css
+++ b/apps/insights/src/styles/globals.css
@@ -37,7 +37,7 @@
   --radius: 0.65rem;
   --font-inter: "Inter", -apple-system, BlinkMacSystemFont, ui-sans-serif, system-ui, sans-serif;
   --font-serif: "Libre Baskerville", Georgia, serif;
-  --background: #f8f8f2;
+  --background: #ffffff;
   --foreground: #1a1a1a;
   --card: #ffffff;
   --card-foreground: #1a1a1a;

--- a/apps/insights/src/styles/globals.css
+++ b/apps/insights/src/styles/globals.css
@@ -23,8 +23,8 @@
 
   body {
     font-family: var(--font-inter);
-    background-color: #f8f8f2;
-    color: #1a1a1a;
+    background-color: var(--background);
+    color: var(--foreground);
   }
 
   .dark body {

--- a/apps/llm-timeline/app/globals.css
+++ b/apps/llm-timeline/app/globals.css
@@ -3,7 +3,7 @@
 @layer base {
   :root {
     --radius: 0.625rem;
-    --background: #f8f8f2;
+    --background: #ffffff;
     --foreground: #1a1a1a;
     --card: #ffffff;
     --card-foreground: #1a1a1a;

--- a/apps/llm-timeline/src/globals.css
+++ b/apps/llm-timeline/src/globals.css
@@ -6,7 +6,7 @@
     --font-display: "Libre Baskerville", Georgia, serif;
     --font-mono: "Inter", ui-monospace, monospace;
     --radius: 0.5rem;
-    --background: #f8f8f2;
+    --background: #ffffff;
     --foreground: #1a1a1a;
     --card: #ffffff;
     --card-foreground: #1a1a1a;

--- a/apps/llm-timeline/src/routes/__root.tsx
+++ b/apps/llm-timeline/src/routes/__root.tsx
@@ -16,7 +16,7 @@ import {
 
 function NotFoundComponent() {
   return (
-    <div className="flex min-h-screen items-center justify-center px-4 bg-[#f8f8f2] dark:bg-[#0d0e0c]">
+    <div className="flex min-h-screen items-center justify-center px-4 bg-white dark:bg-[#0d0e0c]">
       <div className="max-w-md text-center">
         <h1 className="mb-4 text-6xl font-bold font-[family-name:var(--font-display)] text-[#1a1a1a] dark:text-[#f8f8f2]">
           404
@@ -30,7 +30,7 @@ function NotFoundComponent() {
         <div className="flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a
             href="/"
-            className="rounded-xl px-6 py-2 font-medium transition-all hover:opacity-90 bg-[#1a1a1a] text-[#f8f8f2] dark:bg-[#f8f8f2] dark:text-[#1a1a1a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="rounded-xl px-6 py-2 font-medium transition-all hover:opacity-90 bg-[#1a1a1a] text-[#f8f8f2] dark:bg-white dark:text-[#1a1a1a] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           >
             Go to timeline
           </a>
@@ -110,7 +110,7 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider>
-          <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+          <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
             <Header
               longText="LLM Timeline"
               shortText={llmTimelineConfig.metadata.title.replace(
@@ -118,12 +118,12 @@ function RootComponent() {
                 ""
               )}
             />
-            <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+            <main className="relative z-10 rounded-b-3xl bg-white pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
               <div className="mx-auto max-w-[1280px] px-5 pb-16 pt-6 sm:px-8 lg:px-10">
                 <Outlet />
               </div>
             </main>
-            <Footer className="bg-[#f2f2eb] dark:bg-[#1a1a1a]" />
+            <Footer className="bg-white dark:bg-[#1a1a1a]" />
           </div>
         </ThemeProvider>
         <Analytics />

--- a/apps/llm-timeline/src/routes/__root.tsx
+++ b/apps/llm-timeline/src/routes/__root.tsx
@@ -56,7 +56,7 @@ export const Route = createRootRoute({
       { name: "robots", content: "follow, index" },
       {
         name: "theme-color",
-        content: "#f8f8f2",
+        content: "#ffffff",
         media: "(prefers-color-scheme: light)",
       },
       {

--- a/apps/photos/app/globals.css
+++ b/apps/photos/app/globals.css
@@ -22,7 +22,7 @@
 
 :root {
   --radius: 0.5rem;
-  --background: #f8f8f2;
+  --background: #ffffff;
   --foreground: #1a1a1a;
 
   --muted: oklch(0.967 0.001 286.375);

--- a/apps/photos/src/routes/__root.tsx
+++ b/apps/photos/src/routes/__root.tsx
@@ -60,7 +60,7 @@ export const Route = createRootRoute({
       },
       {
         name: "theme-color",
-        content: "#f8f8f2",
+        content: "#ffffff",
         media: "(prefers-color-scheme: light)",
       },
       {

--- a/apps/photos/src/routes/__root.tsx
+++ b/apps/photos/src/routes/__root.tsx
@@ -29,7 +29,7 @@ function NotFoundComponent() {
         <div className="flex flex-col gap-4 sm:flex-row sm:justify-center">
           <Link
             to="/"
-            className="rounded-xl bg-[#1a1a1a] px-6 py-2 font-medium text-white transition-all hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:ring-offset-2 dark:bg-[#f8f8f2] dark:text-[#0d0e0c] dark:focus-visible:ring-neutral-500"
+            className="rounded-xl bg-[#1a1a1a] px-6 py-2 font-medium text-white transition-all hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:ring-offset-2 dark:bg-white dark:text-[#0d0e0c] dark:focus-visible:ring-neutral-500"
           >
             Back to gallery
           </Link>
@@ -104,14 +104,14 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider>
-          <div className="min-h-screen bg-[#f8f8f2] text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
+          <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
             <Header longText="Photos" shortText="Photos" />
-            <main className="relative z-10 rounded-b-3xl bg-[#f8f8f2] pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
+            <main className="relative z-10 rounded-b-3xl bg-white pb-16 dark:bg-[#0d0e0c] 2xl:rounded-b-[4rem]">
               <div className="mx-auto px-5 pb-16 pt-6 sm:px-8 lg:px-4 xl:px-6 2xl:px-8">
                 <Outlet />
               </div>
             </main>
-            <Footer className="bg-[#f2f2eb] dark:bg-[#1a1a1a]" />
+            <Footer className="bg-white dark:bg-[#1a1a1a]" />
           </div>
           <Analytics />
         </ThemeProvider>

--- a/packages/components/Footer.tsx
+++ b/packages/components/Footer.tsx
@@ -84,6 +84,11 @@ export function FooterContent({
   urls = duyetUrls,
 }: FooterContentProps = {}) {
   const navigation = createFooterNavigation(urls, profile);
+  const localDate = new Date().toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
   return (
     <Container>
       <div aria-labelledby="footer-heading">
@@ -130,7 +135,7 @@ export function FooterContent({
         <div className="flex flex-col gap-4 border-t border-[#1a1a1a]/10 pt-6 text-xs text-[#1a1a1a]/55 dark:border-white/10 dark:text-[#f8f8f2]/55 sm:flex-row sm:items-center sm:justify-between">
           <p>
             &copy; {new Date().getFullYear()} {urls.apps.home.replace(/^https?:\/\//, "")} | {" "}
-            {profile.personal.title} | {new Date().toISOString().split("T")[0]}
+            {profile.personal.title} | {localDate}
           </p>
           <ThemeToggle />
         </div>

--- a/packages/components/Footer.tsx
+++ b/packages/components/Footer.tsx
@@ -12,9 +12,8 @@ import ThemeToggle from "./ThemeToggle";
 
 function FooterLink({ href, children }: { href: string; children: ReactNode }) {
   const classes = cn(
-    "text-sm text-neutral-500 dark:text-neutral-400",
-    "no-underline hover:text-gray-700",
-    "dark:hover:text-white transition"
+    "text-sm text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70",
+    "no-underline transition-colors hover:text-[#1a1a1a] dark:hover:text-[#f8f8f2]"
   );
 
   if (href.startsWith("http")) {
@@ -39,7 +38,9 @@ function FooterLink({ href, children }: { href: string; children: ReactNode }) {
 
 function FooterHeader({ children }: { children: ReactNode }) {
   return (
-    <h3 className="text-sm text-black dark:text-white font-bold">{children}</h3>
+    <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+      {children}
+    </h3>
   );
 }
 
@@ -89,55 +90,49 @@ export function FooterContent({
         <h2 id="footer-heading" className="sr-only">
           Footer
         </h2>
-        <div className="w-full py-8 mx-auto">
-          <div className="xl:grid xl:grid-cols-3 xl:gap-8">
-            <div className="grid grid-cols-1 gap-8 xl:col-span-2">
-              <div className="grid grid-cols-1 gap-8 sm:grid-cols-3 md:gap-8">
-                <div className="mt-6 md:mt-0">
-                  <Logo className="p-0" />
-                </div>
 
-                <div className="mt-6 sm:mt-12 md:mt-0">
-                  <FooterHeader>Resources</FooterHeader>
-                  <ul className="mt-4 space-y-1.5 list-none ml-0">
-                    {navigation.general.map((item) => (
-                      <li key={item.name}>
-                        <FooterLink href={item.href}>{item.name}</FooterLink>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+        <div className="grid gap-12 border-t border-[#1a1a1a]/10 py-10 dark:border-white/10 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] md:gap-16 md:py-14">
+          <div className="space-y-5">
+            <Logo className="p-0" />
+            <p className="max-w-sm text-sm leading-6 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+              Build useful systems, then explain them clearly.
+            </p>
+          </div>
 
-                <div className="mt-6 sm:mt-12 md:mt-0">
-                  <FooterHeader>{profile.personal.email}</FooterHeader>
-                  <div className="mt-4 text-sm text-gray-600 dark:text-neutral-400">
-                    <Social profile={profile} />
-                  </div>
-                  <ul className="mt-4 space-y-1.5 list-none ml-0">
-                    {navigation.profile.map((item) => (
-                      <li key={item.name}>
-                        <FooterLink href={item.href}>{item.name}</FooterLink>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+          <div className="grid gap-10 sm:grid-cols-2">
+            <div>
+              <FooterHeader>Resources</FooterHeader>
+              <ul className="mt-4 space-y-2 list-none ml-0">
+                {navigation.general.map((item) => (
+                  <li key={item.name}>
+                    <FooterLink href={item.href}>{item.name}</FooterLink>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <FooterHeader>{profile.personal.email}</FooterHeader>
+              <div className="mt-4 text-sm text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+                <Social profile={profile} />
               </div>
+              <ul className="mt-4 space-y-2 list-none ml-0">
+                {navigation.profile.map((item) => (
+                  <li key={item.name}>
+                    <FooterLink href={item.href}>{item.name}</FooterLink>
+                  </li>
+                ))}
+              </ul>
             </div>
           </div>
+        </div>
 
-          <div className="pt-8 mt-8 sm:flex sm:items-center sm:justify-between">
-            <div className="mt-5">
-              <p className="mt-4 text-xs text-gray-500 dark:text-neutral-400">
-                &copy; {new Date().getFullYear()}{" "}
-                {urls.apps.home.replace(/^https?:\/\//, "")} |{" "}
-                {profile.personal.title} |{" "}
-                {new Date().toISOString().split("T")[0]}
-              </p>
-            </div>
-            <div className="mt-5">
-              <ThemeToggle />
-            </div>
-          </div>
+        <div className="flex flex-col gap-4 border-t border-[#1a1a1a]/10 pt-6 text-xs text-[#1a1a1a]/55 dark:border-white/10 dark:text-[#f8f8f2]/55 sm:flex-row sm:items-center sm:justify-between">
+          <p>
+            &copy; {new Date().getFullYear()} {urls.apps.home.replace(/^https?:\/\//, "")} | {" "}
+            {profile.personal.title} | {new Date().toISOString().split("T")[0]}
+          </p>
+          <ThemeToggle />
         </div>
       </div>
     </Container>
@@ -179,7 +174,7 @@ export default function Footer({
   return (
     <footer
       className={cn(
-        "bg-[#f2f2eb] px-5 pb-12 pt-24 dark:bg-[#1a1a1a] sm:px-8 lg:px-10 lg:pb-16 lg:pt-28 xl:pb-20",
+        "bg-white px-5 pb-10 pt-14 dark:bg-[#1a1a1a] sm:px-8 lg:px-10 lg:pb-12 lg:pt-16",
         className
       )}
     >

--- a/packages/components/header/index.tsx
+++ b/packages/components/header/index.tsx
@@ -71,13 +71,13 @@ export default function Header({
   return (
     <header
       className={cn(
-        "sticky top-0 z-50 bg-[#f8f8f2]/95 backdrop-blur dark:bg-[#0d0e0c]/95",
+        "sticky top-0 z-50 border-b border-[#1a1a1a]/10 bg-white/95 backdrop-blur dark:border-white/10 dark:bg-[#0d0e0c]/95",
         className
       )}
     >
       <div
         className={cn(
-          "mx-auto flex max-w-[1280px] items-center justify-between px-5 py-4 sm:px-8 lg:px-10 lg:py-5",
+          "mx-auto flex max-w-[1280px] items-center justify-between px-5 py-4 sm:px-8 lg:px-10",
           containerClassName
         )}
       >
@@ -100,17 +100,17 @@ export default function Header({
           {showAuthButtons ? <AuthButtons urls={urls} /> : null}
         </nav>
 
-        {/* Mobile: hamburger + auth */}
+        {/* Mobile nav */}
         <div className="flex items-center gap-3 md:hidden">
           {actions}
           {showAuthButtons ? <AuthButtons urls={urls} /> : null}
           <details className="group relative">
-            <summary className="flex cursor-pointer list-none rounded p-1 text-neutral-700 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:text-neutral-300 dark:hover:text-neutral-100 dark:focus-visible:ring-neutral-500 [&::-webkit-details-marker]:hidden">
+            <summary className="flex cursor-pointer list-none rounded-lg p-1.5 text-neutral-700 hover:bg-[#1a1a1a]/5 hover:text-neutral-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 dark:text-neutral-300 dark:hover:bg-white/5 dark:hover:text-neutral-100 dark:focus-visible:ring-neutral-500 [&::-webkit-details-marker]:hidden">
               <span className="sr-only">Toggle menu</span>
               <MenuIcon className="size-5 group-open:hidden" />
               <X className="hidden size-5 group-open:block" />
             </summary>
-            <div className="absolute right-0 top-full z-50 mt-3 w-[min(260px,calc(100vw-2rem))] rounded-xl border border-[#1a1a1a]/10 bg-white p-4 shadow-lg dark:border-white/10 dark:bg-[#1a1a1a]">
+            <div className="absolute right-0 top-full z-50 mt-3 w-[min(280px,calc(100vw-2rem))] rounded-xl border border-[#1a1a1a]/10 bg-white p-4 shadow-lg dark:border-white/10 dark:bg-[#1a1a1a]">
               <MenuNav
                 urls={urls}
                 navigationItems={navigationItems}


### PR DESCRIPTION
## Summary
- refresh shared header/footer to a cleaner minimal chrome with strict responsive menu behavior
- remove header status links from home/insights and add mobile nav toggle for insights
- set white light-mode app-shell surfaces across public apps (including agents token updates)
- restyle blog home + series cards to strong dark non-pastel tones with white text
- tighten CV print CSS to better fit one-page PDF output

## Validation
- bun run check-types
- bunx biome lint on changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated light theme background color from beige to white across all applications for a cleaner, brighter aesthetic
  * Refined footer and header styling with improved color consistency
  * Enhanced dark mode color coordination throughout

* **New Features**
  * Added tone customization to series cards (light and dark variants)
  * Improved mobile navigation menu

* **Chores**
  * Optimized print styling for better PDF document output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->