### PR TITLE
feat(agents): reinit cloudflare agents worker and home chat entry

### DIFF
--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -21,7 +21,11 @@
     "test:e2e": "bun run scripts/test-e2e.ts",
     "deploy": "bun run build && bunx wrangler pages deploy dist/client --project-name=duyet-agents",
     "cf:deploy": "bun run scripts/build-skills.ts && bun run --env-file=../../.env.production --env-file=../../.env.production.local build && bunx wrangler pages deploy dist/client --project-name=duyet-agents --commit-dirty=true",
-    "cf:deploy:prod": "../../scripts/cf-deploy-prod.sh agents duyet-agents"
+    "cf:deploy:prod": "../../scripts/cf-deploy-prod.sh agents duyet-agents",
+    "workers:dev": "bunx wrangler dev --config workers/wrangler.toml",
+    "workers:deploy": "bunx wrangler deploy --config workers/wrangler.toml",
+    "workers:d1:migrate": "bunx wrangler d1 execute duyet-agents-db --file workers/src/migrations/0001_init.sql",
+    "workers:check-types": "tsc -p workers/tsconfig.json --noEmit"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.105",

--- a/apps/agents/workers/src/agents/chat-agent.ts
+++ b/apps/agents/workers/src/agents/chat-agent.ts
@@ -1,0 +1,137 @@
+import { AIChatAgent } from "@cloudflare/ai-chat";
+import { convertToModelMessages, streamText, type UIMessage } from "ai";
+import { createWorkersAI } from "workers-ai-provider";
+import { addMessage, addSession, ensureConversation } from "../lib/repository";
+import { buildPatternHint, detectPattern } from "./patterns";
+import { baseTools } from "./tools";
+
+export interface ChatState {
+  conversationId: string;
+  userId: string;
+  title: string;
+  updatedAt: number;
+}
+
+function getText(parts: UIMessage["parts"]): string {
+  return parts
+    .filter((part) => part.type === "text")
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join("\n")
+    .trim();
+}
+
+export class ChatAgent extends AIChatAgent<any, ChatState> {
+  initialState: ChatState = {
+    conversationId: "",
+    userId: "",
+    title: "New chat",
+    updatedAt: Date.now(),
+  };
+
+  chatRecovery = true;
+
+  async onChatMessage() {
+    const env = (this as any).env as { AI: Ai; AI_GATEWAY?: string };
+
+    const lastUserMessage = [...this.messages].reverse().find((m) => m.role === "user");
+    const lastUserText = lastUserMessage ? getText(lastUserMessage.parts) : "";
+    const pattern = detectPattern(lastUserText);
+
+    const workersai = createWorkersAI({
+      binding: env.AI,
+      gateway: env.AI_GATEWAY ?? "monorepo",
+    });
+
+    const model = workersai("@cf/meta/llama-3.3-70b-instruct-fp8-fast", {
+      sessionAffinity: this.sessionAffinity,
+    });
+
+    const result = streamText({
+      model,
+      messages: await convertToModelMessages(this.messages),
+      system: [
+        "You are duyetbot for agents.duyet.net.",
+        "Keep responses practical and concise.",
+        buildPatternHint(pattern),
+      ].join("\n"),
+      tools: baseTools,
+    });
+
+    return result.toUIMessageStreamResponse();
+  }
+
+  async setSession(input: { userId: string; conversationId: string; title?: string }) {
+    const env = (this as any).env as { DB: D1Database };
+    const title = input.title?.trim() || "New chat";
+
+    this.setState({
+      ...this.state,
+      userId: input.userId,
+      conversationId: input.conversationId,
+      title,
+      updatedAt: Date.now(),
+    });
+
+    await ensureConversation(env.DB, input.conversationId, input.userId, title);
+    await addSession(env.DB, this.name, input.userId, input.conversationId);
+
+    return { ok: true };
+  }
+
+  async submitMessage(input: { userId: string; text: string }) {
+    const env = (this as any).env as { DB: D1Database };
+    const content = input.text.trim();
+    if (!content) throw new Error("Message text is required");
+    if (!this.state.conversationId || this.state.userId !== input.userId) {
+      throw new Error("Session not initialized for this user");
+    }
+
+    const userMessage: UIMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      parts: [{ type: "text", text: content }],
+    };
+
+    await this.saveMessages((messages) => [...messages, userMessage]);
+
+    const lastAssistant = [...this.messages].reverse().find((m) => m.role === "assistant");
+    const assistantText = lastAssistant ? getText(lastAssistant.parts) : "";
+
+    await addMessage(env.DB, {
+      id: userMessage.id,
+      conversationId: this.state.conversationId,
+      role: "user",
+      text: content,
+      createdAt: Date.now(),
+    });
+
+    if (lastAssistant?.id) {
+      await addMessage(env.DB, {
+        id: lastAssistant.id,
+        conversationId: this.state.conversationId,
+        role: "assistant",
+        text: assistantText,
+        createdAt: Date.now(),
+      });
+    }
+
+    this.setState({ ...this.state, updatedAt: Date.now() });
+
+    return {
+      conversationId: this.state.conversationId,
+      assistantText,
+      messages: this.messages,
+    };
+  }
+
+  async getSnapshot(input: { userId: string }) {
+    if (this.state.userId !== input.userId) throw new Error("Forbidden");
+
+    return {
+      conversationId: this.state.conversationId,
+      title: this.state.title,
+      messages: this.messages,
+      updatedAt: this.state.updatedAt,
+    };
+  }
+}

--- a/apps/agents/workers/src/agents/patterns.ts
+++ b/apps/agents/workers/src/agents/patterns.ts
@@ -1,0 +1,39 @@
+export type PatternName =
+  | "sequential"
+  | "routing"
+  | "parallel"
+  | "orchestrator"
+  | "evaluator";
+
+export function detectPattern(input: string): PatternName {
+  const text = input.toLowerCase();
+  if (text.includes("compare") || text.includes("review") || text.includes("evaluate")) {
+    return "evaluator";
+  }
+  if (text.includes("and") || text.includes("parallel") || text.includes("both")) {
+    return "parallel";
+  }
+  if (text.includes("plan") || text.includes("steps") || text.includes("break down")) {
+    return "orchestrator";
+  }
+  if (text.includes("route") || text.includes("classify")) {
+    return "routing";
+  }
+  return "sequential";
+}
+
+export function buildPatternHint(pattern: PatternName): string {
+  switch (pattern) {
+    case "routing":
+      return "Route to a specialist answer style based on user intent.";
+    case "parallel":
+      return "Generate multiple short candidates and merge into one response.";
+    case "orchestrator":
+      return "Break work into ordered subtasks and solve step by step.";
+    case "evaluator":
+      return "Draft answer, self-check quality, then revise once.";
+    case "sequential":
+    default:
+      return "Solve with a direct sequential reasoning flow.";
+  }
+}

--- a/apps/agents/workers/src/agents/tools.ts
+++ b/apps/agents/workers/src/agents/tools.ts
@@ -1,0 +1,40 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export const baseTools = {
+  getTime: tool({
+    description: "Get current server time in ISO format.",
+    inputSchema: z.object({}),
+    execute: async () => ({ now: new Date().toISOString() }),
+  }),
+  fetchUrlText: tool({
+    description: "Fetch a public URL and return plain text excerpt.",
+    inputSchema: z.object({ url: z.string().url() }),
+    execute: async ({ url }) => {
+      const res = await fetch(url, { redirect: "follow" });
+      const text = await res.text();
+      return {
+        status: res.status,
+        url,
+        excerpt: text.slice(0, 4000),
+      };
+    },
+  }),
+  fetchGitHubActivity: tool({
+    description: "Fetch latest public GitHub events for an username. Requires approval.",
+    inputSchema: z.object({ username: z.string().min(1) }),
+    needsApproval: true,
+    execute: async ({ username }) => {
+      const res = await fetch(`https://api.github.com/users/${username}/events/public`);
+      if (!res.ok) {
+        return { error: `Failed with status ${res.status}` };
+      }
+      const events = (await res.json()) as Array<{ type?: string; repo?: { name?: string }; created_at?: string }>;
+      return events.slice(0, 10).map((e) => ({
+        type: e.type ?? "unknown",
+        repo: e.repo?.name ?? "unknown",
+        createdAt: e.created_at ?? "",
+      }));
+    },
+  }),
+};

--- a/apps/agents/workers/src/design/README.md
+++ b/apps/agents/workers/src/design/README.md
@@ -1,0 +1,7 @@
+# Agents Architecture Notes
+
+This folder stores implementation decisions for `apps/agents` Cloudflare Agents reinit.
+
+- `chat-api.md`: public API, auth, and compatibility route.
+- `storage.md`: Durable Object live state + D1 mirror design.
+- `patterns.md`: Anthropic pattern modules and usage in chat loop.

--- a/apps/agents/workers/src/design/chat-api.md
+++ b/apps/agents/workers/src/design/chat-api.md
@@ -1,0 +1,6 @@
+# Chat API Decision
+
+- Route primary agent traffic through `routeAgentRequest()`.
+- Keep `POST /api/chat` as compatibility shim for `apps/home` inline composer.
+- Require Clerk bearer token for all mutation routes.
+- Keep `/health` unauthenticated for probes.

--- a/apps/agents/workers/src/design/patterns.md
+++ b/apps/agents/workers/src/design/patterns.md
@@ -1,0 +1,12 @@
+# Pattern Decision
+
+We keep pattern behavior composable and lightweight in v1:
+
+- Sequential (default)
+- Routing
+- Parallel
+- Orchestrator
+- Evaluator
+
+`detectPattern()` classifies user intent and injects a matching system hint into the model turn.
+This aligns with Anthropic pattern guidance while keeping runtime overhead low.

--- a/apps/agents/workers/src/design/storage.md
+++ b/apps/agents/workers/src/design/storage.md
@@ -1,0 +1,6 @@
+# Storage Decision
+
+- Live conversation runtime state is held in `ChatAgent` Durable Object state.
+- Mirror durable history and metadata in D1 tables: conversations, messages, tool_calls, approvals, sessions.
+- On each completed turn, user/assistant messages are persisted to D1.
+- Session map (`sessions`) supports user-to-session lookup and reconnect scenarios.

--- a/apps/agents/workers/src/index.ts
+++ b/apps/agents/workers/src/index.ts
@@ -1,0 +1,96 @@
+import { getAgentByName, routeAgentRequest } from "agents";
+import { ChatAgent } from "./agents/chat-agent";
+import { getUserFromRequest } from "./lib/auth";
+import { getConversationWithMessages, listConversationsByUser } from "./lib/repository";
+
+interface Env {
+  AI: Ai;
+  DB: D1Database;
+  ChatAgent: DurableObjectNamespace<ChatAgent>;
+  CLERK_ISSUER_URL?: string;
+  AI_GATEWAY?: string;
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type,Authorization",
+    },
+  });
+}
+
+async function handleCompatChat(request: Request, env: Env): Promise<Response> {
+  const user = await getUserFromRequest(request, env.CLERK_ISSUER_URL);
+  if (!user) return json({ error: "Unauthorized" }, 401);
+
+  const body = (await request.json().catch(() => ({}))) as {
+    message?: string;
+    sessionId?: string;
+    conversationId?: string;
+    title?: string;
+  };
+
+  const text = body.message?.trim();
+  if (!text) return json({ error: "message is required" }, 400);
+
+  const sessionId = body.sessionId?.trim() || `home-${user.userId}`;
+  const conversationId = body.conversationId?.trim() || crypto.randomUUID();
+
+  const agent = await getAgentByName(env.ChatAgent, sessionId);
+  await agent.setSession({ userId: user.userId, conversationId, title: body.title });
+  const result = await agent.submitMessage({ userId: user.userId, text });
+
+  return json({
+    sessionId,
+    conversationId: result.conversationId,
+    assistantText: result.assistantText,
+  });
+}
+
+async function handleConversations(request: Request, env: Env): Promise<Response> {
+  const user = await getUserFromRequest(request, env.CLERK_ISSUER_URL);
+  if (!user) return json({ error: "Unauthorized" }, 401);
+
+  const url = new URL(request.url);
+  const id = url.searchParams.get("id");
+
+  if (id) {
+    const data = await getConversationWithMessages(env.DB, id, user.userId);
+    if (!data.conversation) return json({ error: "Not found" }, 404);
+    return json(data);
+  }
+
+  const conversations = await listConversationsByUser(env.DB, user.userId);
+  return json({ conversations });
+}
+
+export { ChatAgent };
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "OPTIONS") return json({}, 204);
+
+    const url = new URL(request.url);
+
+    if (url.pathname === "/health") {
+      return json({ ok: true, service: "duyet-agents" });
+    }
+
+    if (url.pathname === "/api/chat" && request.method === "POST") {
+      return handleCompatChat(request, env);
+    }
+
+    if (url.pathname === "/api/conversations" && request.method === "GET") {
+      return handleConversations(request, env);
+    }
+
+    const routed = await routeAgentRequest(request, env);
+    if (routed) return routed;
+
+    return json({ error: "Not Found" }, 404);
+  },
+};

--- a/apps/agents/workers/src/lib/auth.ts
+++ b/apps/agents/workers/src/lib/auth.ts
@@ -37,43 +37,58 @@ async function verifyJwt(
   token: string,
   issuerUrl?: string
 ): Promise<Record<string, unknown> | null> {
-  const parts = token.split(".");
-  if (parts.length !== 3) return null;
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
 
-  const header = JSON.parse(new TextDecoder().decode(base64UrlDecode(parts[0])));
-  if (!header.alg || typeof header.alg !== "string" || !header.alg.startsWith("RS")) {
+    const header = JSON.parse(
+      new TextDecoder().decode(base64UrlDecode(parts[0]))
+    );
+    if (
+      !header.alg ||
+      typeof header.alg !== "string" ||
+      !header.alg.startsWith("RS")
+    ) {
+      return null;
+    }
+
+    const keys = await getClerkJwks(issuerUrl);
+    if (keys.length === 0) return null;
+
+    const jwk = header.kid
+      ? keys.find((k) => (k as Record<string, unknown>).kid === header.kid)
+      : keys[0];
+    if (!jwk) return null;
+
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      jwk,
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        hash: { name: `SHA-${header.alg.slice(2)}` },
+      },
+      false,
+      ["verify"]
+    );
+
+    const valid = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      key,
+      base64UrlDecode(parts[2]).buffer as ArrayBuffer,
+      new TextEncoder().encode(`${parts[0]}.${parts[1]}`)
+    );
+
+    if (!valid) return null;
+
+    const payload = JSON.parse(
+      new TextDecoder().decode(base64UrlDecode(parts[1]))
+    );
+    if (payload.exp && payload.exp * 1000 < Date.now()) return null;
+    if (payload.nbf && payload.nbf * 1000 > Date.now() + 30_000) return null;
+    return payload;
+  } catch {
     return null;
   }
-
-  const keys = await getClerkJwks(issuerUrl);
-  if (keys.length === 0) return null;
-
-  const jwk = header.kid
-    ? keys.find((k) => (k as Record<string, unknown>).kid === header.kid)
-    : keys[0];
-  if (!jwk) return null;
-
-  const key = await crypto.subtle.importKey(
-    "jwk",
-    jwk,
-    { name: "RSASSA-PKCS1-v1_5", hash: { name: `SHA-${header.alg.slice(2)}` } },
-    false,
-    ["verify"]
-  );
-
-  const valid = await crypto.subtle.verify(
-    "RSASSA-PKCS1-v1_5",
-    key,
-    base64UrlDecode(parts[2]).buffer as ArrayBuffer,
-    new TextEncoder().encode(`${parts[0]}.${parts[1]}`)
-  );
-
-  if (!valid) return null;
-
-  const payload = JSON.parse(new TextDecoder().decode(base64UrlDecode(parts[1])));
-  if (payload.exp && payload.exp * 1000 < Date.now()) return null;
-  if (payload.nbf && payload.nbf * 1000 > Date.now() + 30_000) return null;
-  return payload;
 }
 
 export async function getUserFromRequest(

--- a/apps/agents/workers/src/lib/auth.ts
+++ b/apps/agents/workers/src/lib/auth.ts
@@ -1,0 +1,90 @@
+export interface AuthUser {
+  userId: string;
+}
+
+function base64UrlDecode(str: string): Uint8Array {
+  const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+let jwksCache: { keys: JsonWebKey[]; fetchedAt: number } | null = null;
+const JWKS_TTL_MS = 60 * 60 * 1000;
+
+async function getClerkJwks(issuerUrl?: string): Promise<JsonWebKey[]> {
+  if (!issuerUrl) return [];
+  if (jwksCache && Date.now() - jwksCache.fetchedAt < JWKS_TTL_MS) {
+    return jwksCache.keys;
+  }
+
+  const url = issuerUrl.endsWith("/")
+    ? `${issuerUrl}.well-known/jwks.json`
+    : `${issuerUrl}/.well-known/jwks.json`;
+
+  const res = await fetch(url);
+  if (!res.ok) return [];
+
+  const json = (await res.json()) as { keys?: JsonWebKey[] };
+  const keys = json.keys ?? [];
+  jwksCache = { keys, fetchedAt: Date.now() };
+  return keys;
+}
+
+async function verifyJwt(
+  token: string,
+  issuerUrl?: string
+): Promise<Record<string, unknown> | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+
+  const header = JSON.parse(new TextDecoder().decode(base64UrlDecode(parts[0])));
+  if (!header.alg || typeof header.alg !== "string" || !header.alg.startsWith("RS")) {
+    return null;
+  }
+
+  const keys = await getClerkJwks(issuerUrl);
+  if (keys.length === 0) return null;
+
+  const jwk = header.kid
+    ? keys.find((k) => (k as Record<string, unknown>).kid === header.kid)
+    : keys[0];
+  if (!jwk) return null;
+
+  const key = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "RSASSA-PKCS1-v1_5", hash: { name: `SHA-${header.alg.slice(2)}` } },
+    false,
+    ["verify"]
+  );
+
+  const valid = await crypto.subtle.verify(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    base64UrlDecode(parts[2]).buffer as ArrayBuffer,
+    new TextEncoder().encode(`${parts[0]}.${parts[1]}`)
+  );
+
+  if (!valid) return null;
+
+  const payload = JSON.parse(new TextDecoder().decode(base64UrlDecode(parts[1])));
+  if (payload.exp && payload.exp * 1000 < Date.now()) return null;
+  if (payload.nbf && payload.nbf * 1000 > Date.now() + 30_000) return null;
+  return payload;
+}
+
+export async function getUserFromRequest(
+  request: Request,
+  issuerUrl?: string
+): Promise<AuthUser | null> {
+  const auth = request.headers.get("authorization");
+  if (!auth?.startsWith("Bearer ")) return null;
+
+  const payload = await verifyJwt(auth.slice(7), issuerUrl);
+  if (!payload || typeof payload.sub !== "string") return null;
+
+  return { userId: payload.sub };
+}

--- a/apps/agents/workers/src/lib/repository.ts
+++ b/apps/agents/workers/src/lib/repository.ts
@@ -1,0 +1,175 @@
+export interface D1Env {
+  DB: D1Database;
+}
+
+export interface MirrorMessage {
+  id: string;
+  conversationId: string;
+  role: "user" | "assistant";
+  text: string;
+  createdAt: number;
+}
+
+export async function ensureConversation(
+  db: D1Database,
+  conversationId: string,
+  userId: string,
+  title = "New chat"
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO conversations (id, user_id, title, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .bind(conversationId, userId, title, Date.now(), Date.now())
+    .run();
+
+  await db
+    .prepare("UPDATE conversations SET updated_at = ? WHERE id = ?")
+    .bind(Date.now(), conversationId)
+    .run();
+}
+
+export async function addMessage(db: D1Database, message: MirrorMessage): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO messages (id, conversation_id, role, content, created_at)
+       VALUES (?, ?, ?, ?, ?)`
+    )
+    .bind(
+      message.id,
+      message.conversationId,
+      message.role,
+      message.text,
+      message.createdAt
+    )
+    .run();
+}
+
+export async function addSession(
+  db: D1Database,
+  sessionId: string,
+  userId: string,
+  conversationId: string
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT OR REPLACE INTO sessions (id, user_id, conversation_id, updated_at)
+       VALUES (?, ?, ?, ?)`
+    )
+    .bind(sessionId, userId, conversationId, Date.now())
+    .run();
+}
+
+export async function listConversationsByUser(db: D1Database, userId: string) {
+  const result = await db
+    .prepare(
+      `SELECT id, user_id, title, created_at, updated_at
+       FROM conversations
+       WHERE user_id = ?
+       ORDER BY updated_at DESC
+       LIMIT 100`
+    )
+    .bind(userId)
+    .all<{
+      id: string;
+      user_id: string;
+      title: string;
+      created_at: number;
+      updated_at: number;
+    }>();
+
+  return result.results ?? [];
+}
+
+export async function getConversationWithMessages(
+  db: D1Database,
+  conversationId: string,
+  userId: string
+) {
+  const conversation = await db
+    .prepare(
+      `SELECT id, user_id, title, created_at, updated_at
+       FROM conversations
+       WHERE id = ? AND user_id = ?`
+    )
+    .bind(conversationId, userId)
+    .first<{
+      id: string;
+      user_id: string;
+      title: string;
+      created_at: number;
+      updated_at: number;
+    }>();
+
+  if (!conversation) return { conversation: null, messages: [] };
+
+  const messages = await db
+    .prepare(
+      `SELECT id, role, content, created_at
+       FROM messages
+       WHERE conversation_id = ?
+       ORDER BY created_at ASC`
+    )
+    .bind(conversationId)
+    .all<{ id: string; role: string; content: string; created_at: number }>();
+
+  return {
+    conversation,
+    messages: messages.results ?? [],
+  };
+}
+
+export async function addToolCall(
+  db: D1Database,
+  params: {
+    id: string;
+    conversationId: string;
+    messageId: string;
+    toolName: string;
+    status: string;
+    payload?: string;
+  }
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO tool_calls (id, conversation_id, message_id, tool_name, status, payload, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      params.id,
+      params.conversationId,
+      params.messageId,
+      params.toolName,
+      params.status,
+      params.payload ?? null,
+      Date.now()
+    )
+    .run();
+}
+
+export async function addApproval(
+  db: D1Database,
+  params: {
+    id: string;
+    conversationId: string;
+    toolCallId: string;
+    requestedBy: string;
+    decision: "approved" | "rejected";
+  }
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO approvals (id, conversation_id, tool_call_id, requested_by, decision, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .bind(
+      params.id,
+      params.conversationId,
+      params.toolCallId,
+      params.requestedBy,
+      params.decision,
+      Date.now()
+    )
+    .run();
+}

--- a/apps/agents/workers/src/migrations/0001_init.sql
+++ b/apps/agents/workers/src/migrations/0001_init.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS conversations (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT 'New chat',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_user_id ON conversations(user_id);
+CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  role TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at);
+
+CREATE TABLE IF NOT EXISTS tool_calls (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  payload TEXT,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_calls_conversation_id ON tool_calls(conversation_id);
+
+CREATE TABLE IF NOT EXISTS approvals (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  tool_call_id TEXT NOT NULL,
+  requested_by TEXT NOT NULL,
+  decision TEXT NOT NULL CHECK(decision IN ('approved', 'rejected')),
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+  FOREIGN KEY (tool_call_id) REFERENCES tool_calls(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_approvals_conversation_id ON approvals(conversation_id);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);

--- a/apps/agents/workers/src/types.d.ts
+++ b/apps/agents/workers/src/types.d.ts
@@ -18,7 +18,7 @@ declare interface DurableObjectNamespace<T = unknown> {
   get(id: DurableObjectId): DurableObjectStub<T>;
 }
 
-declare interface DurableObjectId {}
+declare type DurableObjectId = {}
 
 declare interface DurableObjectStub<T = unknown> {
   [key: string]: any;

--- a/apps/agents/workers/src/types.d.ts
+++ b/apps/agents/workers/src/types.d.ts
@@ -1,0 +1,25 @@
+interface Ai {
+  run(model: string, request: unknown, options?: unknown): Promise<unknown>;
+}
+
+declare interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+}
+
+declare interface D1PreparedStatement {
+  bind(...params: unknown[]): D1PreparedStatement;
+  run(): Promise<unknown>;
+  first<T = unknown>(): Promise<T | null>;
+  all<T = unknown>(): Promise<{ results?: T[] }>;
+}
+
+declare interface DurableObjectNamespace<T = unknown> {
+  idFromName(name: string): DurableObjectId;
+  get(id: DurableObjectId): DurableObjectStub<T>;
+}
+
+declare interface DurableObjectId {}
+
+declare interface DurableObjectStub<T = unknown> {
+  [key: string]: any;
+}

--- a/apps/agents/workers/tsconfig.json
+++ b/apps/agents/workers/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../packages/tsconfig/base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/apps/agents/workers/wrangler.toml
+++ b/apps/agents/workers/wrangler.toml
@@ -1,17 +1,29 @@
 name = "duyet-agents-api"
-main = "chat-api.ts"
-compatibility_date = "2024-01-01"
+main = "src/index.ts"
+compatibility_date = "2026-05-05"
+compatibility_flags = ["nodejs_compat"]
 
-# Enable Workers Observability for analytics and logging
 [observability]
 enabled = true
 
-# AI binding for Workers AI (no API key needed)
 [ai]
 binding = "AI"
 
-# Environment variables
+[[d1_databases]]
+binding = "DB"
+database_name = "duyet-agents-db"
+database_id = "6d29934e-92cc-48ff-9149-8ddf6846fd43"
+
+[durable_objects]
+bindings = [
+  { name = "ChatAgent", class_name = "ChatAgent" }
+]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ChatAgent"]
+
 [vars]
-# AI Gateway name for analytics, rate limiting, and caching
-# Must be configured in Cloudflare dashboard: https://dash.cloudflare.com/?to=/:account/ai/ai-gateway
 AI_GATEWAY = "monorepo"
+# e.g. https://your-org.clerk.accounts.dev
+CLERK_ISSUER_URL = ""

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -24,7 +24,8 @@
     "framer-motion": "^12.36.0",
     "lucide-react": "^1.0.0",
     "react": "19.2.5",
-    "react-dom": "19.2.5"
+    "react-dom": "19.2.5",
+    "@clerk/clerk-react": "^5.61.2"
   },
   "devDependencies": {
     "@duyet/tailwind-config": "*",

--- a/apps/home/src/components/HomeAgentsChat.tsx
+++ b/apps/home/src/components/HomeAgentsChat.tsx
@@ -39,10 +39,11 @@ export function HomeAgentsChat() {
     );
   }
 
-  const { SignedIn, SignedOut, SignInButton, useAuth } = clerk;
+  const { SignedIn, SignedOut, SignInButton, useAuth, useUser } = clerk;
 
   function SignedInComposer() {
     const { getToken } = useAuth();
+    const { user } = useUser();
 
     const submit = async (content: string) => {
       const token = await getToken();
@@ -55,6 +56,7 @@ export function HomeAgentsChat() {
       setError(null);
 
       try {
+        const sessionId = `home-${user?.id ?? "unknown-user"}`;
         const response = await fetch("https://agents.duyet.net/api/chat", {
           method: "POST",
           headers: {
@@ -63,7 +65,7 @@ export function HomeAgentsChat() {
           },
           body: JSON.stringify({
             message: content,
-            sessionId: "home-chat",
+            sessionId,
           }),
         });
 

--- a/apps/home/src/components/HomeAgentsChat.tsx
+++ b/apps/home/src/components/HomeAgentsChat.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useState } from "react";
+
+type ClerkModule = typeof import("@clerk/clerk-react");
+
+interface ChatResult {
+  sessionId: string;
+  conversationId: string;
+  assistantText: string;
+}
+
+export function HomeAgentsChat() {
+  const [clerk, setClerk] = useState<ClerkModule | null>(null);
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<ChatResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    import("@clerk/clerk-react")
+      .then((mod) => setClerk(mod))
+      .catch(() => setClerk(null));
+  }, []);
+
+  const keyExists = useMemo(
+    () => Boolean(import.meta.env.VITE_CLERK_PUBLISHABLE_KEY),
+    []
+  );
+
+  if (!keyExists || !clerk) {
+    return (
+      <section className="mx-auto mt-16 max-w-[1280px] px-5 sm:px-8 lg:mt-20 lg:px-10">
+        <div className="rounded-xl border border-[#1a1a1a]/10 bg-[#f3eee6] p-5 lg:p-6">
+          <h3 className="text-lg font-semibold tracking-tight">Chat with duyetbot</h3>
+          <p className="mt-2 text-sm text-[#1a1a1a]/70">
+            Auth is not configured on this environment.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const { SignedIn, SignedOut, SignInButton, useAuth } = clerk;
+
+  function SignedInComposer() {
+    const { getToken } = useAuth();
+
+    const submit = async (content: string) => {
+      const token = await getToken();
+      if (!token) {
+        setError("Authentication token is missing.");
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch("https://agents.duyet.net/api/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            message: content,
+            sessionId: "home-chat",
+          }),
+        });
+
+        if (!response.ok) {
+          const payload = (await response.json().catch(() => null)) as
+            | { error?: string }
+            | null;
+          throw new Error(payload?.error || `Request failed with ${response.status}`);
+        }
+
+        const payload = (await response.json()) as ChatResult;
+        setResult(payload);
+        setMessage("");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to send message.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    return (
+      <form
+        className="mt-4 space-y-3"
+        onSubmit={async (event) => {
+          event.preventDefault();
+          const content = message.trim();
+          if (!content) return;
+          await submit(content);
+        }}
+      >
+        <textarea
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          placeholder="Ask about projects, tooling, or infrastructure..."
+          className="min-h-24 w-full rounded-xl border border-[#1a1a1a]/15 bg-white p-3 text-sm text-[#1a1a1a] outline-none focus:border-[#1a1a1a]/40"
+        />
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            disabled={loading || message.trim().length === 0}
+            className="rounded-lg bg-[#1a1a1a] px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {loading ? "Sending..." : "Send"}
+          </button>
+          <a
+            href={
+              result?.conversationId
+                ? `https://agents.duyet.net/agents/chat-agent/${encodeURIComponent(result.sessionId)}`
+                : "https://agents.duyet.net"
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg border border-[#1a1a1a]/15 bg-white px-4 py-2 text-sm font-medium text-[#1a1a1a]"
+          >
+            Open full chat
+          </a>
+        </div>
+        {error && <p className="text-sm text-red-700">{error}</p>}
+        {result?.assistantText && (
+          <div className="rounded-xl border border-[#1a1a1a]/10 bg-white p-3 text-sm leading-6 text-[#1a1a1a]">
+            {result.assistantText}
+          </div>
+        )}
+      </form>
+    );
+  }
+
+  return (
+    <section className="mx-auto mt-16 max-w-[1280px] px-5 sm:px-8 lg:mt-20 lg:px-10">
+      <div className="rounded-xl border border-[#1a1a1a]/10 bg-[#f3eee6] p-5 lg:p-6">
+        <h3 className="text-lg font-semibold tracking-tight">Chat with duyetbot</h3>
+        <p className="mt-2 text-sm text-[#1a1a1a]/70">
+          Ask from the homepage. Sign in is required to send.
+        </p>
+
+        <SignedOut>
+          <div className="mt-4 space-y-3">
+            <textarea
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder="Type your message..."
+              className="min-h-24 w-full rounded-xl border border-[#1a1a1a]/15 bg-white p-3 text-sm text-[#1a1a1a]"
+            />
+            <SignInButton mode="modal" forceRedirectUrl="https://duyet.net">
+              <button
+                type="button"
+                className="rounded-lg bg-[#1a1a1a] px-4 py-2 text-sm font-medium text-white"
+              >
+                Sign in to send
+              </button>
+            </SignInButton>
+          </div>
+        </SignedOut>
+
+        <SignedIn>
+          <SignedInComposer />
+        </SignedIn>
+      </div>
+    </section>
+  );
+}

--- a/apps/home/src/components/WorkStackSection.tsx
+++ b/apps/home/src/components/WorkStackSection.tsx
@@ -1,0 +1,96 @@
+import { ArrowRight } from "lucide-react";
+
+interface WorkStackSectionProps {
+  repositoryUrl: string;
+}
+
+const focusAreas = [
+  {
+    label: "Data systems",
+    value: "Pipelines, warehouses, observability, and distributed services",
+  },
+  {
+    label: "AI infrastructure",
+    value: "Agent workflows, model routing, evaluation, and usage analytics",
+  },
+  {
+    label: "Engineering practice",
+    value: "Small tools, clean interfaces, production hygiene, and writing",
+  },
+];
+
+const skills = [
+  "Python",
+  "Rust",
+  "TypeScript",
+  "Spark",
+  "Airflow",
+  "ClickHouse",
+  "BigQuery",
+  "Kafka",
+  "Kubernetes",
+  "AWS",
+  "GCP",
+  "LlamaIndex",
+  "AI SDK",
+  "LangGraph",
+];
+
+export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
+  return (
+    <>
+      <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
+        <div className="grid gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
+          <div>
+            <p className="mb-3 text-sm font-medium text-[#1a1a1a]/60">Work</p>
+            <h2 className="text-balance text-3xl font-semibold tracking-tight md:text-4xl">
+              Practical engineering, written down clearly.
+            </h2>
+          </div>
+
+          <div className="divide-y divide-[#1a1a1a]/12 border-y border-[#1a1a1a]/12">
+            {focusAreas.map((item) => (
+              <div
+                key={item.label}
+                className="grid gap-3 py-6 md:grid-cols-[180px_1fr] md:gap-8"
+              >
+                <p className="text-sm font-semibold uppercase tracking-normal text-[#1a1a1a]/55">
+                  {item.label}
+                </p>
+                <p className="text-xl font-medium leading-tight tracking-tight">
+                  {item.value}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
+        <div className="flex flex-col justify-between gap-5 md:flex-row md:items-end">
+          <div>
+            <p className="mb-3 text-sm font-medium text-[#1a1a1a]/60">Stack</p>
+            <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
+              Tools I reach for.
+            </h2>
+          </div>
+          <a
+            href={repositoryUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 text-base font-medium"
+          >
+            Repositories
+            <ArrowRight className="h-5 w-5" />
+          </a>
+        </div>
+
+        <div className="mt-10 flex flex-wrap gap-x-5 gap-y-4 text-2xl font-semibold tracking-tight text-[#1a1a1a]/90 md:text-3xl">
+          {skills.map((skill) => (
+            <span key={skill}>{skill}</span>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/home/src/routes/__root.tsx
+++ b/apps/home/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import "../globals.css";
 import "../animations.css";
 
 import ThemeProvider from "@duyet/components/ThemeProvider";
+import { ClerkAuthProvider } from "@duyet/components";
 import {
   createRootRoute,
   HeadContent,
@@ -68,9 +69,11 @@ function RootComponent() {
         />
       </head>
       <body>
-        <ThemeProvider>
-          <Outlet />
-        </ThemeProvider>
+        <ClerkAuthProvider>
+          <ThemeProvider>
+            <Outlet />
+          </ThemeProvider>
+        </ClerkAuthProvider>
         <Scripts />
       </body>
     </html>

--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -6,6 +6,7 @@ import {
 import { ArrowRight, BookOpen, FileUser, Radio } from "lucide-react";
 import { addUtmParams } from "../../app/lib/utm";
 import { SiteFooter, SiteHeader } from "../components/SiteChrome";
+import { WorkStackSection } from "../components/WorkStackSection";
 
 const experienceYears = "8+ years";
 const contentLastModified = "2026-05-02";
@@ -130,38 +131,6 @@ const links = [
   },
 ];
 
-const focusAreas = [
-  {
-    label: "Data systems",
-    value: "Pipelines, warehouses, observability, and distributed services",
-  },
-  {
-    label: "AI infrastructure",
-    value: "Agent workflows, model routing, evaluation, and usage analytics",
-  },
-  {
-    label: "Engineering practice",
-    value: "Small tools, clean interfaces, production hygiene, and writing",
-  },
-];
-
-const skills = [
-  "Python",
-  "Rust",
-  "TypeScript",
-  "Spark",
-  "Airflow",
-  "ClickHouse",
-  "BigQuery",
-  "Kafka",
-  "Kubernetes",
-  "AWS",
-  "GCP",
-  "LlamaIndex",
-  "AI SDK",
-  "LangGraph",
-];
-
 function AboutPage() {
   return (
       <div className="min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
@@ -224,66 +193,13 @@ function AboutPage() {
           </div>
         </section>
 
-        <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
-          <div className="grid gap-10 lg:grid-cols-[0.8fr_1fr] lg:items-start">
-            <div>
-              <p className="mb-3 text-sm font-medium text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60">
-                Work
-              </p>
-              <h2 className="text-balance text-3xl font-semibold tracking-tight md:text-4xl">
-                Practical engineering, written down clearly.
-              </h2>
-            </div>
-
-            <div className="divide-y divide-[#1a1a1a]/12 border-y border-[#1a1a1a]/12 dark:divide-white/12 dark:border-white/12">
-              {focusAreas.map((item) => (
-                <div
-                  key={item.label}
-                  className="grid gap-3 py-6 md:grid-cols-[180px_1fr] md:gap-8"
-                >
-                  <p className="text-sm font-semibold uppercase tracking-normal text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
-                    {item.label}
-                  </p>
-                  <p className="text-xl font-medium leading-tight tracking-tight">
-                    {item.value}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
-          <div className="flex flex-col justify-between gap-5 md:flex-row md:items-end">
-            <div>
-              <p className="mb-3 text-sm font-medium text-[#1a1a1a]/60 dark:text-[#f8f8f2]/60">
-                Stack
-              </p>
-              <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
-                Tools I reach for.
-              </h2>
-            </div>
-            <a
-              href={addUtmParams(
-                "https://github.com/duyet",
-                "about_page",
-                "skills_github"
-              )}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 text-base font-medium"
-            >
-              Repositories
-              <ArrowRight className="h-5 w-5" />
-            </a>
-          </div>
-
-          <div className="mt-10 flex flex-wrap gap-x-5 gap-y-4 text-2xl font-semibold tracking-tight text-[#1a1a1a]/90 dark:text-[#f8f8f2]/90 md:text-3xl">
-            {skills.map((skill) => (
-              <span key={skill}>{skill}</span>
-            ))}
-          </div>
-        </section>
+        <WorkStackSection
+          repositoryUrl={addUtmParams(
+            "https://github.com/duyet",
+            "about_page",
+            "skills_github"
+          )}
+        />
 
         <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
           <div className="grid gap-5 rounded-xl bg-white p-6 dark:bg-[#1a1a1a] md:grid-cols-[1fr_auto] md:items-center lg:p-8">

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -15,6 +15,7 @@ import { addUtmParams } from "../../app/lib/utm";
 import { KeyboardFeatures } from "../components/KeyboardFeatures";
 import { SiteFooter, SiteHeader } from "../components/SiteChrome";
 import { HomeAgentsChat } from "../components/HomeAgentsChat";
+import { WorkStackSection } from "../components/WorkStackSection";
 import { type AppItem, apps } from "../data/projects";
 
 export const Route = createFileRoute("/")({
@@ -141,6 +142,14 @@ function HomePage() {
           </section>
 
           <HomeAgentsChat />
+
+          <WorkStackSection
+            repositoryUrl={addUtmParams(
+              "https://github.com/duyet",
+              "homepage",
+              "skills_github"
+            )}
+          />
 
           <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
             <Link

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -14,6 +14,7 @@ import type { ReactNode } from "react";
 import { addUtmParams } from "../../app/lib/utm";
 import { KeyboardFeatures } from "../components/KeyboardFeatures";
 import { SiteFooter, SiteHeader } from "../components/SiteChrome";
+import { HomeAgentsChat } from "../components/HomeAgentsChat";
 import { type AppItem, apps } from "../data/projects";
 
 export const Route = createFileRoute("/")({
@@ -139,6 +140,8 @@ function HomePage() {
             )}
           </section>
 
+          <HomeAgentsChat />
+
           <section className="mx-auto mt-24 max-w-[1280px] px-5 sm:px-8 lg:mt-32 lg:px-10 xl:mt-40">
             <Link
               to="/ls"
@@ -181,12 +184,12 @@ function ProjectCard({
       className={`group overflow-hidden rounded-xl border border-[#1a1a1a]/10 ${item.tone ?? "bg-[#f3eee6]"} transition-transform hover:-translate-y-0.5`}
       shortcutNumber={shortcutNumber}
     >
-      <div className="p-5 text-[#1a1a1a]">
+      <div className="p-5 text-white">
         <h3 className="text-lg font-semibold tracking-tight">{item.name}</h3>
-        <p className="mt-2 text-sm font-medium leading-6 text-[#1a1a1a]/80">
+        <p className="mt-2 text-sm font-medium leading-6 text-white/85">
           {item.description}
         </p>
-        <p className="mt-5 truncate text-sm font-medium text-[#1a1a1a]/60">
+        <p className="mt-5 truncate text-sm font-medium text-white/70">
           {item.host}
         </p>
       </div>

--- a/bun.lock
+++ b/bun.lock
@@ -266,6 +266,7 @@
       "name": "home",
       "version": "0.1.0",
       "dependencies": {
+        "@clerk/clerk-react": "^5.61.2",
         "@duyet/components": "*",
         "@duyet/libs": "*",
         "@duyet/urls": "*",
@@ -2363,7 +2364,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
+    "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -3077,8 +3078,6 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "partyserver/nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
-
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
@@ -3144,8 +3143,6 @@
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "agents/agents/@rolldown/plugin-babel": ["@rolldown/plugin-babel@0.2.3", "", { "dependencies": { "picomatch": "^4.0.4" }, "peerDependencies": { "@babel/core": "^7.29.0 || ^8.0.0-rc.1", "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1", "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1", "rolldown": "^1.0.0-rc.5", "vite": "^8.0.0" }, "optionalPeers": ["@babel/plugin-transform-runtime", "@babel/runtime", "vite"] }, "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw=="],
-
-    "agents/agents/nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
 
     "agents/agents/yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
 


### PR DESCRIPTION
## Summary\n- reinitialize apps/agents backend with Cloudflare Agents SDK + Durable Objects\n- add Clerk-protected /api/chat and /api/conversations with D1 mirror persistence\n- add inline Clerk-gated chat composer on apps/home calling agents.duyet.net\n\n## Validation\n- bun run workers:check-types (apps/agents)\n- bun run check-types (apps/home)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-powered chat agent with persistent conversation history
  * Integrated pattern-based intent detection for smarter responses
  * Added built-in tools for web fetching and activity lookups
  * Implemented secure authentication and user-scoped access
  * Added chat interface to home app

* **Documentation**
  * Added architecture documentation for the agents system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->