### PR TITLE
docs(blog): add cloudflare agents post

### DIFF
--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -77,6 +77,7 @@
     "embla-carousel-react": "^8.6.0",
     "fast-deep-equal": "^3.1.0",
     "framer-motion": "^12.34.0",
+    "lucide-react": "^1.0.0",
     "motion": "^12.34.3",
     "nanoid": "^5.0.0",
     "orderedmap": "^2.0.0",

--- a/apps/blog/_posts/2026/05/building-ai-agents-cloudflare.mdx
+++ b/apps/blog/_posts/2026/05/building-ai-agents-cloudflare.mdx
@@ -1,0 +1,74 @@
+---
+title: Building AI Agents on Cloudflare
+date: 2026-05-06
+author: Duyet
+category: AI
+series: AI Harness Engineering
+tags:
+  - AI
+  - Agents
+  - Cloudflare
+slug: /2026/05/building-ai-agents-cloudflare.html
+thumbnail: /media/2026/05/building-ai-agents-cloudflare/npm-i-agents.svg
+description: Cloudflare's Agents SDK runs stateful TypeScript agents on Durable Objects, with Workers AI, AI Gateway, AI Search, Vectorize, Browser Run, Queues, Workflows, Email, Dynamic Workers, and Sandboxes around it.
+---
+
+Cloudflare has one of the most generous free plans I've seen for building websites in the last 10 years, and it is still true now that they are shifting focus to AI agents. With the free tier, you already get enough for personal projects and medium-scale workloads.
+
+Start with [agents.cloudflare.com](https://agents.cloudflare.com). It already lists almost everything you need.
+
+![npm i agents](/media/2026/05/building-ai-agents-cloudflare/npm-i-agents.svg)
+
+Cloudflare's `agents` SDK is a good one, alongside the [AI SDK](https://github.com/vercel/ai).
+
+Each agent runs as a TypeScript class on a Durable Object, with its own SQL database, WebSocket connections, scheduling, state, and lifecycle.
+
+The stack is simple: run agent logic on [Workers](https://workers.cloudflare.com/), keep state in [Durable Objects](https://developers.cloudflare.com/durable-objects/), call models with Workers AI or AI Gateway, retrieve knowledge from AI Search or Vectorize, and let agents act through Browser Run, MCP, Queues, Workflows, Email, Dynamic Workers, and Sandboxes.
+
+The starter for the Agents SDK also includes streaming chat, tools, human-in-the-loop approval, scheduling, and Workers AI by default.
+
+This is the free/pricing snapshot they offer today, May 6, 2026:
+
+| Service | Free budget | Pricing |
+| --- | --- | --- |
+| **Agents SDK** | No separate quota. Uses Workers and Durable Objects. | Pay for the underlying services. ([Cloudflare Docs][1]) |
+| **Workers** | 100k requests/day, 10 ms CPU/invocation. | Paid starts at $5/mo: 10M requests/mo, 30M CPU-ms/mo, then usage-based overage. ([Cloudflare Docs][2]) |
+| **Durable Objects** | 100k requests/day, 13k GB-s/day, SQLite-backed DOs on Free. | Paid includes 1M requests/mo and 400k GB-s/mo, then overage. ([Cloudflare Docs][2]) |
+| **Workers AI** | 10k Neurons/day. | $0.011 per 1k Neurons after free allocation on Paid. ([Cloudflare Docs][3]) |
+| **AI Gateway** | Core features free; 100k persistent logs total on Free. | Paid has 10M logs/gateway. Logpush: $0.05/M requests. Guardrails bill through Workers AI. ([Cloudflare Docs][4]) |
+| **AI Search** | Open beta: 100 instances, 100k files/instance, 20k queries/mo, 500 crawled pages/day. | Paid: 5k instances, 1M files or 500k hybrid search, unlimited queries/crawling. Future pricing has not been announced yet. ([Cloudflare Docs][5]) |
+| **Vectorize** | 30M queried vector dimensions/mo, 5M stored dimensions. | Paid includes 50M queried dimensions/mo and 10M stored dimensions, then $0.01/M queried and $0.05/100M stored. ([Cloudflare Docs][6]) |
+| **D1** | 5M rows read/day, 100k rows written/day, 5 GB storage. | Paid includes 25B reads/mo, 50M writes/mo, 5 GB storage, then overage. ([Cloudflare Docs][2]) |
+| **R2** | 10 GB-month, 1M Class A ops, 10M Class B ops, free egress. | $0.015/GB-month, $4.50/M Class A, $0.36/M Class B, egress free. ([Cloudflare Docs][2]) |
+| **KV** | 100k reads/day, 1k writes/day, 1 GB storage. | Paid includes 10M reads/mo and 1M writes/mo, then usage-based overage. ([Cloudflare Docs][2]) |
+| **Queues** | 10k operations/day, 24h retention. | Paid includes 1M operations/mo, then $0.40/M operations. ([Cloudflare Docs][2]) |
+| **Workflows** | Included on Free; shares Workers limits; 1 GB storage. | Same as Workers pricing, plus workflow storage after quota. ([Cloudflare Docs][7]) |
+| **Browser Run** | 10 min/day, 3 concurrent browsers. | Paid includes 10 hours/mo and 10 browsers, then $0.09/hour and $2/browser. ([Cloudflare Docs][8]) |
+| **MCP Servers** | Cloudflare provides managed remote MCP servers. | Cost depends on the services/tools used by the MCP server. ([Cloudflare Docs][9]) |
+| **Email Service** | Inbound Email Routing is unlimited. Outbound email is not on Free. | Paid includes 3k outbound emails/mo, then $0.35/1k emails. ([Cloudflare Docs][10]) |
+| **Dynamic Workers** | Paid only. | 1k unique Dynamic Workers/mo included, then $0.002 per Dynamic Worker/day. Requests and CPU bill as Workers. Billing starts May 26, 2026. ([Cloudflare Docs][11]) |
+| **Sandboxes / Containers** | No free container budget. | Paid includes 25 GiB-hours, 375 vCPU-min, 200 GB-hours/mo, then usage-based overage. ([Cloudflare Docs][2]) |
+| **Realtime** | 1,000 GB free tier. | $0.05/GB egress after the free tier. ([Cloudflare Docs][12]) |
+
+[1]: https://developers.cloudflare.com/agents/ "Agents - Cloudflare Agents docs"
+[2]: https://developers.cloudflare.com/workers/platform/pricing/ "Pricing - Cloudflare Workers docs"
+[3]: https://developers.cloudflare.com/workers-ai/platform/pricing/ "Pricing - Cloudflare Workers AI docs"
+[4]: https://developers.cloudflare.com/ai-gateway/reference/pricing/ "Pricing - Cloudflare AI Gateway docs"
+[5]: https://developers.cloudflare.com/ai-search/platform/limits-pricing/ "Limits & pricing - Cloudflare AI Search docs"
+[6]: https://developers.cloudflare.com/vectorize/platform/pricing/ "Pricing - Cloudflare Vectorize docs"
+[7]: https://developers.cloudflare.com/workflows/reference/pricing/ "Pricing - Cloudflare Workflows docs"
+[8]: https://developers.cloudflare.com/browser-run/pricing/ "Pricing - Cloudflare Browser Run docs"
+[9]: https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/ "Cloudflare's own MCP servers - Cloudflare Agents docs"
+[10]: https://developers.cloudflare.com/email-service/platform/pricing/ "Pricing - Cloudflare Email Service docs"
+[11]: https://developers.cloudflare.com/dynamic-workers/pricing/ "Pricing - Cloudflare Dynamic Workers docs"
+[12]: https://developers.cloudflare.com/realtime/sfu/pricing/ "Pricing - Cloudflare Realtime docs"
+
+# My default stack
+
+For a simple agent, I would start with:
+
+Workers + Agents SDK + Durable Objects + Workers AI + AI Gateway + AI Search
+
+Then add:
+
+Browser Run for web browsing, Queues and Workflows for background jobs, R2 for files, Email Service for email agents, and Sandboxes or Dynamic Workers for coding agents.

--- a/apps/blog/public/llms-full.txt
+++ b/apps/blog/public/llms-full.txt
@@ -1,7 +1,78 @@
 # Duyet Le - Technical Blog (Full Content)
 
-> This file contains the full markdown content of all 298 blog posts.
+> This file contains the full markdown content of all 299 blog posts.
 > For a summary index, see https://blog.duyet.net/llms.txt
+
+---
+
+# Building AI Agents on Cloudflare
+
+- **URL**: https://blog.duyet.net/2026/05/building-ai-agents-cloudflare
+- **Date**: 2026-05-06
+- **Category**: AI
+- **Tags**: Ai, Agents, Cloudflare
+
+
+Cloudflare has one of the most generous free plans I've seen for building websites in the last 10 years, and it is still true now that they are shifting focus to AI agents. With the free tier, you already get enough for personal projects and medium-scale workloads.
+
+Start with [agents.cloudflare.com](https://agents.cloudflare.com). It already lists almost everything you need.
+
+![npm i agents](/media/2026/05/building-ai-agents-cloudflare/npm-i-agents.svg)
+
+Cloudflare's `agents` SDK is a good one, alongside the [AI SDK](https://github.com/vercel/ai).
+
+Each agent runs as a TypeScript class on a Durable Object, with its own SQL database, WebSocket connections, scheduling, state, and lifecycle.
+
+The stack is simple: run agent logic on [Workers](https://workers.cloudflare.com/), keep state in [Durable Objects](https://developers.cloudflare.com/durable-objects/), call models with Workers AI or AI Gateway, retrieve knowledge from AI Search or Vectorize, and let agents act through Browser Run, MCP, Queues, Workflows, Email, Dynamic Workers, and Sandboxes.
+
+The starter for the Agents SDK also includes streaming chat, tools, human-in-the-loop approval, scheduling, and Workers AI by default.
+
+This is the free/pricing snapshot they offer today, May 6, 2026:
+
+| Service | Free budget | Pricing |
+| --- | --- | --- |
+| **Agents SDK** | No separate quota. Uses Workers and Durable Objects. | Pay for the underlying services. ([Cloudflare Docs][1]) |
+| **Workers** | 100k requests/day, 10 ms CPU/invocation. | Paid starts at $5/mo: 10M requests/mo, 30M CPU-ms/mo, then usage-based overage. ([Cloudflare Docs][2]) |
+| **Durable Objects** | 100k requests/day, 13k GB-s/day, SQLite-backed DOs on Free. | Paid includes 1M requests/mo and 400k GB-s/mo, then overage. ([Cloudflare Docs][2]) |
+| **Workers AI** | 10k Neurons/day. | $0.011 per 1k Neurons after free allocation on Paid. ([Cloudflare Docs][3]) |
+| **AI Gateway** | Core features free; 100k persistent logs total on Free. | Paid has 10M logs/gateway. Logpush: $0.05/M requests. Guardrails bill through Workers AI. ([Cloudflare Docs][4]) |
+| **AI Search** | Open beta: 100 instances, 100k files/instance, 20k queries/mo, 500 crawled pages/day. | Paid: 5k instances, 1M files or 500k hybrid search, unlimited queries/crawling. Future pricing has not been announced yet. ([Cloudflare Docs][5]) |
+| **Vectorize** | 30M queried vector dimensions/mo, 5M stored dimensions. | Paid includes 50M queried dimensions/mo and 10M stored dimensions, then $0.01/M queried and $0.05/100M stored. ([Cloudflare Docs][6]) |
+| **D1** | 5M rows read/day, 100k rows written/day, 5 GB storage. | Paid includes 25B reads/mo, 50M writes/mo, 5 GB storage, then overage. ([Cloudflare Docs][2]) |
+| **R2** | 10 GB-month, 1M Class A ops, 10M Class B ops, free egress. | $0.015/GB-month, $4.50/M Class A, $0.36/M Class B, egress free. ([Cloudflare Docs][2]) |
+| **KV** | 100k reads/day, 1k writes/day, 1 GB storage. | Paid includes 10M reads/mo and 1M writes/mo, then usage-based overage. ([Cloudflare Docs][2]) |
+| **Queues** | 10k operations/day, 24h retention. | Paid includes 1M operations/mo, then $0.40/M operations. ([Cloudflare Docs][2]) |
+| **Workflows** | Included on Free; shares Workers limits; 1 GB storage. | Same as Workers pricing, plus workflow storage after quota. ([Cloudflare Docs][7]) |
+| **Browser Run** | 10 min/day, 3 concurrent browsers. | Paid includes 10 hours/mo and 10 browsers, then $0.09/hour and $2/browser. ([Cloudflare Docs][8]) |
+| **MCP Servers** | Cloudflare provides managed remote MCP servers. | Cost depends on the services/tools used by the MCP server. ([Cloudflare Docs][9]) |
+| **Email Service** | Inbound Email Routing is unlimited. Outbound email is not on Free. | Paid includes 3k outbound emails/mo, then $0.35/1k emails. ([Cloudflare Docs][10]) |
+| **Dynamic Workers** | Paid only. | 1k unique Dynamic Workers/mo included, then $0.002 per Dynamic Worker/day. Requests and CPU bill as Workers. Billing starts May 26, 2026. ([Cloudflare Docs][11]) |
+| **Sandboxes / Containers** | No free container budget. | Paid includes 25 GiB-hours, 375 vCPU-min, 200 GB-hours/mo, then usage-based overage. ([Cloudflare Docs][2]) |
+| **Realtime** | 1,000 GB free tier. | $0.05/GB egress after the free tier. ([Cloudflare Docs][12]) |
+
+[1]: https://developers.cloudflare.com/agents/ "Agents - Cloudflare Agents docs"
+[2]: https://developers.cloudflare.com/workers/platform/pricing/ "Pricing - Cloudflare Workers docs"
+[3]: https://developers.cloudflare.com/workers-ai/platform/pricing/ "Pricing - Cloudflare Workers AI docs"
+[4]: https://developers.cloudflare.com/ai-gateway/reference/pricing/ "Pricing - Cloudflare AI Gateway docs"
+[5]: https://developers.cloudflare.com/ai-search/platform/limits-pricing/ "Limits & pricing - Cloudflare AI Search docs"
+[6]: https://developers.cloudflare.com/vectorize/platform/pricing/ "Pricing - Cloudflare Vectorize docs"
+[7]: https://developers.cloudflare.com/workflows/reference/pricing/ "Pricing - Cloudflare Workflows docs"
+[8]: https://developers.cloudflare.com/browser-run/pricing/ "Pricing - Cloudflare Browser Run docs"
+[9]: https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/ "Cloudflare's own MCP servers - Cloudflare Agents docs"
+[10]: https://developers.cloudflare.com/email-service/platform/pricing/ "Pricing - Cloudflare Email Service docs"
+[11]: https://developers.cloudflare.com/dynamic-workers/pricing/ "Pricing - Cloudflare Dynamic Workers docs"
+[12]: https://developers.cloudflare.com/realtime/sfu/pricing/ "Pricing - Cloudflare Realtime docs"
+
+# My default stack
+
+For a simple agent, I would start with:
+
+Workers + Agents SDK + Durable Objects + Workers AI + AI Gateway + AI Search
+
+Then add:
+
+Browser Run for web browsing, Queues and Workflows for background jobs, R2 for files, Email Service for email agents, and Sandboxes or Dynamic Workers for coding agents.
+
 
 ---
 

--- a/apps/blog/public/llms.txt
+++ b/apps/blog/public/llms.txt
@@ -12,7 +12,7 @@ A comprehensive collection of technical blog posts covering Data Engineering, So
 
 ## About This Blog
 
-298+ technical articles covering topics including:
+299+ technical articles covering topics including:
 - Data Engineering & Big Data
 - Apache Spark, ClickHouse, Apache Airflow
 - Cloud Computing (AWS, GCP, Azure)
@@ -24,6 +24,13 @@ A comprehensive collection of technical blog posts covering Data Engineering, So
 Articles span from 2015 to 2026, documenting the evolution of modern data engineering and software development practices.
 
 ## Recent Posts
+
+### [Building AI Agents on Cloudflare](https://blog.duyet.net/2026/05/building-ai-agents-cloudflare)
+- **Date**: 2026-05-06
+- **Category**: AI
+- **Tags**: Ai, Agents, Cloudflare
+- **URL**: https://blog.duyet.net/2026/05/building-ai-agents-cloudflare
+- **Description**: Cloudflare's Agents SDK runs stateful TypeScript agents on Durable Objects, with Workers AI, AI Gateway, AI Search, Vectorize, Browser Run, Queues, Workflows, Email, Dynamic Workers, and Sandboxes around it.
 
 ### [Claws](https://blog.duyet.net/2026/02/claws)
 - **Date**: 2026-02-22
@@ -158,18 +165,12 @@ Articles span from 2015 to 2026, documenting the evolution of modern data engine
 - **URL**: https://blog.duyet.net/2023/04/helm-charts-problem
 - **Description**: Why does Helm Charts interpret 0777 to 511? It took me quite some time to debug it.
 
-### [GPT vs Traditional NLP Models](https://blog.duyet.net/2023/04/nlp-vs-gpt)
-- **Date**: 2023-04-01
-- **Category**: Data
-- **Tags**: Data, Data Engineering, Nlp
-- **URL**: https://blog.duyet.net/2023/04/nlp-vs-gpt
-- **Description**: The field of Natural Language Processing (NLP) has seen remarkable advancements in recent years, and the emergence of the Generative Pre-trained Transformer (GPT) has revolutionized the way NLP models operate. GPT is a cutting-edge language model that employs deep learning to generate human-like text. Unlike conventional NLP models, which required extensive training on specific tasks, GPT is pre-trained on vast amounts of data and can be fine-tuned for various NLP tasks
-
 
 ## All Blog Posts by Year
 
-### 2026 (2 posts)
+### 2026 (3 posts)
 
+- [Building AI Agents on Cloudflare](https://blog.duyet.net/2026/05/building-ai-agents-cloudflare) - 2026-05-06
 - [Claws](https://blog.duyet.net/2026/02/claws) - 2026-02-22
 - [Coding Agents](https://blog.duyet.net/2026/01/ai) - 2026-01-01
 
@@ -503,9 +504,9 @@ Articles span from 2015 to 2026, documenting the evolution of modern data engine
 ---
 
 **Blog Statistics:**
-- Total Posts: 298
+- Total Posts: 299
 - Years Active: 2015-2026
 - Categories: 15
-- Tags: 59
+- Tags: 60
 
 Generated from: https://blog.duyet.net

--- a/apps/blog/public/media/2026/05/building-ai-agents-cloudflare/npm-i-agents.svg
+++ b/apps/blog/public/media/2026/05/building-ai-agents-cloudflare/npm-i-agents.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
+  <title id="title">npm i agents terminal card</title>
+  <desc id="desc">A Cloudflare orange terminal illustration showing the npm i agents command and a Lunch Agent TypeScript example.</desc>
+  <defs>
+    <pattern id="dots" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="3" cy="3" r="1.8" fill="#f97316" opacity="0.8" />
+    </pattern>
+    <filter id="softShadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="16" stdDeviation="22" flood-color="#7c2d12" flood-opacity="0.12" />
+    </filter>
+  </defs>
+  <rect width="1600" height="760" fill="#fffdf8" />
+  <rect width="1600" height="760" fill="url(#dots)" />
+  <g transform="translate(535 58)">
+    <rect width="530" height="246" rx="10" fill="#fffdf8" stroke="#f97316" stroke-width="2" />
+    <circle cx="54" cy="55" r="14" fill="none" stroke="#f97316" stroke-width="2" />
+    <circle cx="90" cy="55" r="14" fill="none" stroke="#f97316" stroke-width="2" />
+    <circle cx="126" cy="55" r="14" fill="none" stroke="#f97316" stroke-width="2" />
+    <text x="64" y="168" fill="#c2410c" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="52" letter-spacing="1">$ npm i agents</text>
+  </g>
+  <g filter="url(#softShadow)" transform="translate(90 292)">
+    <rect width="1420" height="430" rx="10" fill="#fffdf8" stroke="#f97316" stroke-width="2" />
+    <text x="42" y="74" fill="#c2410c" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700">Lunch Agent</text>
+    <text x="244" y="74" fill="#c2410c" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="28">An agent that helps pick lunch for coworkers in an office.</text>
+    <line x1="42" y1="118" x2="1378" y2="118" stroke="#f97316" stroke-width="2" />
+    <text x="42" y="178" fill="#991b1b" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">import</text>
+    <text x="146" y="178" fill="#7c2d12" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">{ Agent, callable } from</text>
+    <text x="508" y="178" fill="#78716c" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">'agents';</text>
+    <text x="42" y="216" fill="#991b1b" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">import</text>
+    <text x="146" y="216" fill="#7c2d12" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">{ searchMenusByAgent, chooseWinners } from</text>
+    <text x="770" y="216" fill="#78716c" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">'../utils';</text>
+    <text x="42" y="284" fill="#991b1b" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">export class</text>
+    <text x="240" y="284" fill="#b45309" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">LunchAgent</text>
+    <text x="410" y="284" fill="#991b1b" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">extends</text>
+    <text x="532" y="284" fill="#c2410c" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">Agent&lt;Env, LunchState&gt; {</text>
+    <text x="92" y="326" fill="#b45309" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">onStart()</text>
+    <text x="260" y="326" fill="#7c2d12" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">{</text>
+    <text x="146" y="368" fill="#c2410c" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">this.schedule(</text>
+    <text x="350" y="368" fill="#78716c" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">'weekdays at 11:30pm'</text>
+    <text x="690" y="368" fill="#7c2d12" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">,</text>
+    <text x="728" y="368" fill="#78716c" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">'chooseLunch'</text>
+    <text x="922" y="368" fill="#7c2d12" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="25">);</text>
+  </g>
+</svg>

--- a/apps/blog/public/ping.json
+++ b/apps/blog/public/ping.json
@@ -1,1 +1,1 @@
-{"status":"ok","timestamp":"2026-05-05T16:03:40.976Z"}
+{"status":"ok","timestamp":"2026-05-06T15:15:09.380Z"}

--- a/apps/blog/public/rss.xml
+++ b/apps/blog/public/rss.xml
@@ -4,8 +4,15 @@
         <description><![CDATA[Sr. Data Engineer. Rustacean at night]]></description>
         <link>https://blog.duyet.net</link>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Tue, 05 May 2026 16:03:40 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 06 May 2026 15:15:09 GMT</lastBuildDate>
         <atom:link href="https://blog.duyet.net/rss.xml" rel="self" type="application/rss+xml"/>
+        <item>
+            <title><![CDATA[Building AI Agents on Cloudflare]]></title>
+            <description><![CDATA[Cloudflare's Agents SDK runs stateful TypeScript agents on Durable Objects, with Workers AI, AI Gateway, AI Search, Vectorize, Browser Run, Queues, Workflows, Email, Dynamic Workers, and Sandboxes around it.]]></description>
+            <link>https://blog.duyet.net/2026/05/building-ai-agents-cloudflare</link>
+            <guid isPermaLink="true">https://blog.duyet.net/2026/05/building-ai-agents-cloudflare</guid>
+            <pubDate>Wed, 06 May 2026 00:00:00 GMT</pubDate>
+        </item>
         <item>
             <title><![CDATA[Claws]]></title>
             <description><![CDATA[OpenClaw, NanoBot, PicoClaw, ZeroClaw, NullClaw, NemoClaw, ...]]></description>
@@ -348,13 +355,6 @@
             <link>https://blog.duyet.net/2021/12/rust-ownership</link>
             <guid isPermaLink="true">https://blog.duyet.net/2021/12/rust-ownership</guid>
             <pubDate>Sun, 19 Dec 2021 00:00:00 GMT</pubDate>
-        </item>
-        <item>
-            <title><![CDATA[Rust và Data Engineering? 🤔]]></title>
-            <description><![CDATA[Tại sao Rust là lựa chọn cho Data Engineering? Khám phá 7 lý do chính từ performance, memory safety, đến WebAssembly và hệ sinh thái data tools như Apache Arrow, DataFusion, và Polars. Bài viết chi tiết về ưu nhược điểm, learning curve, và tương lai của Rust trong lĩnh vực Data Engineering và Big Data processing.]]></description>
-            <link>https://blog.duyet.net/2021/11/rust-data-engineering</link>
-            <guid isPermaLink="true">https://blog.duyet.net/2021/11/rust-data-engineering</guid>
-            <pubDate>Sat, 27 Nov 2021 00:00:00 GMT</pubDate>
         </item>
     </channel>
 </rss>

--- a/apps/blog/public/sitemap.xml
+++ b/apps/blog/public/sitemap.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
+    <loc>https://blog.duyet.net/2026/05/building-ai-agents-cloudflare</loc>
+    <lastmod>2026-05-06</lastmod>
+  </url>
+  <url>
     <loc>https://blog.duyet.net/2026/02/claws</loc>
     <lastmod>2026-02-22</lastmod>
   </url>
@@ -1194,90 +1198,90 @@
   </url>
   <url>
     <loc>https://blog.duyet.net/category/rust</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/data</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/story</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/project</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/productivity</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/news</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/software-engineering</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/web</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/linux</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/git</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/javascript</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/data-engineering</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/infrastructure</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/machine-learning</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/ai</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/feed</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/tags</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/archives</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/featured</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/series</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-06</lastmod>
   </url>
 </urlset>

--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
         "agents": "^0.12.0",
         "ai": "^6.0.103",
         "ai-gateway-provider": "^3.1.1",
+        "lucide-react": "^1.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary

- add the Building AI Agents on Cloudflare blog post
- add the local npm i agents SVG image asset
- regenerate blog LLM, RSS, sitemap, and ping outputs

## Verification

- bun run prebuild
- bun run check-types
- bun run build

Note: pricing links were checked against current Cloudflare docs on 2026-05-06.

## Summary by Sourcery

Add a new blog post detailing how to build AI agents on Cloudflare and refresh associated public artifacts.

Enhancements:
- Update sitemap, RSS feed, LLM prompt files, and ping metadata to include the new post and reflect the latest blog state.

Documentation:
- Add a new "Building AI Agents on Cloudflare" post, including an overview of the Agents SDK stack and a current pricing/limits snapshot for related Cloudflare services.

Chores:
- Add a new SVG thumbnail asset used by the Cloudflare agents blog post.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published a new blog post "Building AI Agents on Cloudflare" with architecture overview, pricing comparison, footnotes, and a recommended default stack.
* **Content / Public Site**
  * Updated site indexes, recent-post listings, RSS feed, and sitemap to include the new post and refreshed last-modified dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->