### PR TITLE
fix(insights,docs): remove unused wakatime binding and add file-lint check note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 Read [docs/ai/internal-knowledge.md](docs/ai/internal-knowledge.md) before changing this repository.
 
 Use semantic commit messages. Keep changes surgical and verify with the narrowest useful command for the touched app or package.
+For single-file verification, use `bunx biome lint <path>` before broader app checks.
 For root quality checks, use `bun run lint`, `bun run check-types`, and `bun run test`.
 For deploy/config workflows, use root scripts (`bun run config`, `bun run deploy`, `bun run cf:deploy`, `bun run cf:deploy:prod`) when needed.
 For Rust/WASM workflows, use the documented root commands (`bun run rust:build`, `bun run wasm:build`, `bun run wasm:test`, `bun run wasm:clippy`, `bun run bench:wasm`) only when the touched change requires them.

--- a/apps/insights/src/routes/wakatime/$period.tsx
+++ b/apps/insights/src/routes/wakatime/$period.tsx
@@ -73,7 +73,7 @@ export const Route = createFileRoute("/wakatime/$period")({
 });
 
 function WakaTimePeriodPage() {
-  const { config, days, isAllTime, metrics, activity, languages } =
+  const { config, isAllTime, metrics, activity, languages } =
     Route.useLoaderData();
 
   const activityTitle = isAllTime ? "Monthly Activity" : "Daily Activity";


### PR DESCRIPTION
## Summary
- remove unused `days` binding in `apps/insights/src/routes/wakatime/$period.tsx`
- add a narrow single-file lint command note to `CLAUDE.md` (syncs `AGENTS.md` symlink)

## Evidence
- recent commit window since last run (`2026-05-05T21:01:49Z`) touched Insights/blog only
- concrete warning in modified file: `src/routes/wakatime/$period.tsx:76:19 lint/correctness/noUnusedVariables`
- verify: `bunx biome lint apps/insights/src/routes/wakatime/$period.tsx`

## Scope
- no functionality change
- surgical 2-file update

## Summary by Sourcery

Remove an unused WakaTime route loader binding and document a narrow single-file lint command for contributors.

Bug Fixes:
- Eliminate an unused `days` variable from the WakaTime period route loader data to satisfy linting correctness rules.

Documentation:
- Document a single-file Biome lint command in CLAUDE.md to guide targeted verification before broader app checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer guidance for code verification procedures.

* **Refactor**
  * Streamlined data handling in the WakaTime period functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->