### PR TITLE
style(blog): match post detail page to home app white background

### DIFF
--- a/apps/blog/src/routes/$year/$month/$slug.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug.tsx
@@ -110,7 +110,7 @@ function PostPage() {
   };
 
   return (
-    <div className="bg-[#f8f8f2] pb-20 dark:bg-[#0d0e0c]">
+    <div className="pb-20 dark:bg-[#0d0e0c]">
       <Container className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
         <ReadingProgress />
 


### PR DESCRIPTION
## Summary
- Remove `bg-[#f8f8f2]` cream background from post detail page wrapper in `$slug.tsx`
- The parent `<main>` in `__root.tsx` already sets `bg-white`, making the cream background redundant
- Dark mode `bg-[#0d0e0c]` is preserved — already matches home app

## Verification
- `-content.tsx` and `-meta.tsx` already use consistent `#1a1a1a`/`#f8f8f2` text colors throughout
- Type check: passes (pre-existing `bun` type def issue unrelated)
- Tests: 47 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Remove the redundant cream background on the post detail wrapper so it inherits the global white background from the root layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated blog post page styling to include dark mode background color support for improved visual consistency across lighting preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->