### PR TITLE
style(blog): add dark mode variants to HomeCards, fix YearPost dark bg

### DIFF
--- a/apps/blog/components/layout/HomeCards.tsx
+++ b/apps/blog/components/layout/HomeCards.tsx
@@ -7,10 +7,10 @@ interface HomeCardsProps {
 }
 
 const CARD_SURFACES = [
-  "bg-[#f3eee6]",
-  "bg-[#bfdbfe]",
-  "bg-[#a7f3d0]",
-  "bg-[#fecaca]",
+  "bg-[#f3eee6] dark:bg-[#1f3a5f]",
+  "bg-[#bfdbfe] dark:bg-[#1f3a5f]",
+  "bg-[#a7f3d0] dark:bg-[#164634]",
+  "bg-[#fecaca] dark:bg-[#4f1f1f]",
 ];
 
 export function HomeCards({ seriesList, topTags }: HomeCardsProps) {
@@ -49,13 +49,13 @@ export function HomeCards({ seriesList, topTags }: HomeCardsProps) {
           to={card.href}
           className={`surface-card-base ${CARD_SURFACES[index % CARD_SURFACES.length]} group flex min-h-[180px] flex-col p-5 transition-transform hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1a1a1a] lg:p-6`}
         >
-          <span className="text-sm font-medium text-[#1a1a1a]/65">
+          <span className="text-sm font-medium text-[#1a1a1a]/65 dark:text-[#f8f8f2]/65">
             {card.category}
           </span>
-          <h3 className="mt-5 text-lg font-semibold leading-tight tracking-tight md:text-xl">
+          <h3 className="mt-5 text-lg font-semibold leading-tight tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] md:text-xl">
             {card.title}
           </h3>
-          <p className="mt-2 text-sm font-medium leading-snug text-[#1a1a1a]/80">
+          <p className="mt-2 text-sm font-medium leading-snug text-[#1a1a1a]/80 dark:text-[#f8f8f2]/80">
             {card.description}
           </p>
           {card.tags.length > 0 ? (
@@ -63,7 +63,7 @@ export function HomeCards({ seriesList, topTags }: HomeCardsProps) {
               {card.tags.slice(0, 5).map((tag) => (
                 <span
                   key={tag}
-                  className="rounded-lg border border-[#1a1a1a]/20 bg-[#1a1a1a]/8 px-2.5 py-1 text-xs font-medium text-[#1a1a1a]/85"
+                  className="rounded-lg border border-[#1a1a1a]/20 bg-[#1a1a1a]/8 px-2.5 py-1 text-xs font-medium text-[#1a1a1a]/85 dark:border-white/20 dark:bg-white/8 dark:text-[#f8f8f2]/85"
                 >
                   {tag}
                 </span>

--- a/apps/blog/components/post/YearPost.tsx
+++ b/apps/blog/components/post/YearPost.tsx
@@ -26,7 +26,7 @@ export function YearPost({ year, posts, className }: YearPostProps) {
         {year}
       </h2>
 
-      <div className="overflow-hidden rounded-2xl border border-[#1a1a1a]/12 bg-white dark:border-white/10 dark:bg-[#171815]">
+      <div className="overflow-hidden rounded-2xl border border-[#1a1a1a]/12 bg-white dark:border-white/10 dark:bg-[#1a1a1a]">
         {posts.map((post: Post) => {
           const [, year, month, slug] = post.slug.split("/");
           return (


### PR DESCRIPTION
## Summary
- Add `dark:` background variants to HomeCards surfaces (blue, green, red tints)
- Add `dark:` text color variants to HomeCards category, title, description, and tag pills
- Fix YearPost card dark background from `#171815` to `#1a1a1a` to match home app pattern

## Test plan
- [ ] Visual check in dark mode on homepage cards and year post listings
- [ ] Verify light mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add dark mode styling variants for blog home cards and align year post card dark background with the main app.

New Features:
- Introduce dark mode background variants for HomeCards surfaces with distinct tints per card.
- Add dark mode text and pill styles for HomeCards categories, titles, descriptions, and tags.

Bug Fixes:
- Align YearPost card dark background color with the standard #1a1a1a dark surface color used elsewhere.