### PR TITLE
style(blog): add dark mode variants to series and about pages

### DIFF
--- a/apps/blog/src/routes/about.tsx
+++ b/apps/blog/src/routes/about.tsx
@@ -32,7 +32,7 @@ function About() {
       description:
         "Experience building scalable data infrastructure and leading engineering teams.",
       url: "https://cv.duyet.net",
-      color: "bg-orange-100/50",
+      color: "bg-orange-100/50 dark:bg-[#4f2f1f]",
     },
     {
       icon: GithubIcon,
@@ -40,7 +40,7 @@ function About() {
       description:
         "Open source contributions and personal projects in Python, Rust, and TypeScript.",
       url: "https://github.com/duyet",
-      color: "bg-purple-100/50",
+      color: "bg-purple-100/50 dark:bg-[#2f1f3f]",
     },
     {
       icon: LinkedInIcon,
@@ -48,7 +48,7 @@ function About() {
       description:
         "Professional network and career highlights in data engineering.",
       url: "https://linkedin.com/in/duyet",
-      color: "bg-blue-100/50",
+      color: "bg-blue-100/50 dark:bg-[#1f2a3f]",
     },
     {
       icon: BlogIcon,
@@ -56,7 +56,7 @@ function About() {
       description:
         "Technical writings on data engineering, distributed systems, and open source.",
       url: "/",
-      color: "bg-amber-100/60",
+      color: "bg-amber-100/60 dark:bg-[#3f2f1f]",
     },
   ];
 
@@ -125,13 +125,13 @@ function About() {
               to={link.url as "/"}
               className={`group flex flex-col p-10 ${link.color} rounded-xl transition-transform duration-200 hover:scale-[1.02]`}
             >
-              <div className="mb-8 text-[#1a1a1a]">
+              <div className="mb-8 text-[#1a1a1a] dark:text-[#f8f8f2]">
                 <Icon />
               </div>
-              <h3 className="mb-3 text-xl font-medium text-[#1a1a1a]">
+              <h3 className="mb-3 text-xl font-medium text-[#1a1a1a] dark:text-[#f8f8f2]">
                 {link.title}
               </h3>
-              <p className="text-sm leading-relaxed text-[#1a1a1a]/70">
+              <p className="text-sm leading-relaxed text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
                 {link.description}
               </p>
             </Link>

--- a/apps/blog/src/routes/series.tsx
+++ b/apps/blog/src/routes/series.tsx
@@ -19,13 +19,13 @@ export const Route = createFileRoute("/series")({
 });
 
 const seriesBackgrounds = [
-  "bg-[#eef4ff]",
-  "bg-[#edf7f1]",
-  "bg-[#fff4e8]",
-  "bg-[#f3efff]",
-  "bg-[#ffeef0]",
-  "bg-[#ecf7f7]",
-  "bg-[#f7f1e8]",
+  "bg-[#eef4ff] dark:bg-[#1a2a3f]",
+  "bg-[#edf7f1] dark:bg-[#164634]",
+  "bg-[#fff4e8] dark:bg-[#3f2f1f]",
+  "bg-[#f3efff] dark:bg-[#2f1f3f]",
+  "bg-[#ffeef0] dark:bg-[#4f1f1f]",
+  "bg-[#ecf7f7] dark:bg-[#1f3f3f]",
+  "bg-[#f7f1e8] dark:bg-[#3f2f1f]",
 ];
 
 function SeriesPage() {


### PR DESCRIPTION
## Summary
- Add `dark:bg-*` variants to series card backgrounds in `series.tsx` (7 background colors)
- Add `dark:bg-*` variants to about page link card colors in `about.tsx` (4 background colors)
- Fix missing `dark:text-*` classes on about page internal `<Link>` variant (icon, title, description)

## Test plan
- [x] TypeScript check passes (pre-existing `@types/bun` error unrelated)
- [ ] Visual: verify series page cards render dark backgrounds in dark mode
- [ ] Visual: verify about page cards render dark backgrounds in dark mode
- [ ] Visual: verify about page Blog Home card text is visible in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add dark mode support for blog series and about page cards.

New Features:
- Add dark mode background variants for all series page cards.
- Add dark mode background variants for about page link cards and blog home card.

Bug Fixes:
- Ensure about page internal link cards use appropriate text colors in dark mode for icons, titles, and descriptions.