### PR TITLE
style(blog): align MDX component colors with home app palette

### DIFF
--- a/apps/blog/components/MdxComponents.tsx
+++ b/apps/blog/components/MdxComponents.tsx
@@ -34,7 +34,7 @@ function Image({
       <img
         src={imageSrc || ""}
         alt={alt || ""}
-        className="rounded-xl border border-gray-200 dark:border-gray-700 max-w-full"
+        className="rounded-xl border border-[#1a1a1a]/10 dark:border-white/10 max-w-full"
         loading="lazy"
         {...props}
       />

--- a/apps/blog/components/blog/CardGrid.tsx
+++ b/apps/blog/components/blog/CardGrid.tsx
@@ -120,7 +120,7 @@ export function CardGrid({
   if (!cards || cards.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No cards available
       </div>
@@ -141,26 +141,26 @@ export function CardGrid({
         return (
           <div
             key={card.id}
-            className="border border-gray-200 dark:border-claude-gray-800 p-4 hover:bg-gray-50 dark:hover:bg-claude-gray-900/50 transition-colors"
+            className="border border-[#1a1a1a]/10 dark:border-white/10 p-4 hover:bg-[#f7f7f7] dark:hover:bg-[#1a1a1a] transition-colors"
           >
             <div className="space-y-3">
               <div className="flex items-start gap-3">
-                <div className="flex-shrink-0 text-gray-400 dark:text-gray-600">
+                <div className="flex-shrink-0 text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
                   <IconComponent size={24} />
                 </div>
-                <h3 className="font-medium text-gray-900 dark:text-white text-base">
+                <h3 className="font-medium text-[#1a1a1a] dark:text-[#f8f8f2] text-base">
                   {card.title}
                 </h3>
               </div>
 
-              <p className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">
+              <p className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 text-sm leading-relaxed">
                 {card.description}
               </p>
 
               {card.link && (
                 <a
                   href={card.link.href}
-                  className="inline-block text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+                  className="inline-block text-sm text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55 hover:text-[#1a1a1a] dark:hover:text-[#f8f8f2] transition-colors"
                 >
                   {card.link.text} →
                 </a>

--- a/apps/blog/components/blog/ClaudeCard.tsx
+++ b/apps/blog/components/blog/ClaudeCard.tsx
@@ -271,64 +271,64 @@ const colorSchemes = [
     bgDark: "dark:bg-terracotta/30",
     nested: "bg-terracotta/20", // Darker for nested cards
     nestedDark: "dark:bg-terracotta/40",
-    text: "text-gray-700",
-    textDark: "dark:text-gray-200",
+    text: "text-[#1a1a1a]/70",
+    textDark: "dark:text-[#f8f8f2]/70",
   },
   {
     bg: "bg-lavender-light", // Soft lavender #dfe0ec
     bgDark: "dark:bg-lavender/30",
     nested: "bg-lavender/40",
     nestedDark: "dark:bg-lavender/50",
-    text: "text-gray-700",
-    textDark: "dark:text-gray-200",
+    text: "text-[#1a1a1a]/70",
+    textDark: "dark:text-[#f8f8f2]/70",
   },
   {
     bg: "bg-sage-light", // Soft sage #d0ddd8
     bgDark: "dark:bg-sage/30",
     nested: "bg-sage/40",
     nestedDark: "dark:bg-sage/50",
-    text: "text-gray-700",
-    textDark: "dark:text-gray-200",
+    text: "text-[#1a1a1a]/70",
+    textDark: "dark:text-[#f8f8f2]/70",
   },
   {
     bg: "bg-oat-light", // Warm beige #ebe5db (like "Featured courses")
     bgDark: "dark:bg-oat/30",
     nested: "bg-oat/60",
     nestedDark: "dark:bg-oat/50",
-    text: "text-gray-700",
-    textDark: "dark:text-gray-200",
+    text: "text-[#1a1a1a]/70",
+    textDark: "dark:text-[#f8f8f2]/70",
   },
   {
     bg: "bg-cream", // Warm cream #faf8f3
     bgDark: "dark:bg-cream-warm/30",
     nested: "bg-cream-warm",
     nestedDark: "dark:bg-cream-warm/50",
-    text: "text-gray-700",
-    textDark: "dark:text-gray-200",
+    text: "text-[#1a1a1a]/70",
+    textDark: "dark:text-[#f8f8f2]/70",
   },
   {
     bg: "bg-cactus-light", // Muted green #d4e3de
     bgDark: "dark:bg-cactus/30",
     nested: "bg-cactus/40",
     nestedDark: "dark:bg-cactus/50",
-    text: "text-gray-700",
-    textDark: "dark:text-gray-200",
+    text: "text-[#1a1a1a]/70",
+    textDark: "dark:text-[#f8f8f2]/70",
   },
   {
     bg: "bg-coral-light", // Soft coral #ffc4a8
     bgDark: "dark:bg-coral/30",
     nested: "bg-coral/30",
     nestedDark: "dark:bg-coral/50",
-    text: "text-gray-700",
-    textDark: "dark:text-gray-200",
+    text: "text-[#1a1a1a]/70",
+    textDark: "dark:text-[#f8f8f2]/70",
   },
   {
     bg: "bg-ivory", // Off-white #f5f3ef
     bgDark: "dark:bg-ivory-medium/30",
     nested: "bg-ivory-medium",
     nestedDark: "dark:bg-ivory-medium/50",
-    text: "text-gray-700",
-    textDark: "dark:text-gray-200",
+    text: "text-[#1a1a1a]/70",
+    textDark: "dark:text-[#f8f8f2]/70",
   },
 ];
 
@@ -381,7 +381,7 @@ export function ClaudeCard({ title, items, className }: ClaudeCardProps) {
             <h3
               className={cn(
                 "text-2xl sm:text-3xl md:text-4xl font-serif leading-tight",
-                "text-gray-900 dark:text-white"
+                "text-[#1a1a1a] dark:text-[#f8f8f2]"
               )}
             >
               {title}
@@ -398,7 +398,7 @@ export function ClaudeCard({ title, items, className }: ClaudeCardProps) {
                 className={cn(
                   "flex items-baseline gap-3 sm:gap-4 py-3 sm:py-4",
                   index !== items.length - 1 &&
-                    "border-b border-gray-900/20 dark:border-white/20"
+                    "border-b border-[#1a1a1a]/20 dark:border-white/20"
                 )}
               >
                 <span
@@ -414,7 +414,7 @@ export function ClaudeCard({ title, items, className }: ClaudeCardProps) {
                   <strong
                     className={cn(
                       "font-semibold text-base sm:text-lg",
-                      "text-gray-900 dark:text-white"
+                      "text-[#1a1a1a] dark:text-[#f8f8f2]"
                     )}
                   >
                     {item.label}
@@ -540,7 +540,7 @@ export function ClaudeCardNested({
             <h3
               className={cn(
                 "text-2xl md:text-4xl font-serif leading-tight mt-2",
-                "text-gray-900 dark:text-white"
+                "text-[#1a1a1a] dark:text-[#f8f8f2]"
               )}
             >
               {title}
@@ -565,11 +565,11 @@ export function ClaudeCardNested({
                   href={actionButton.link}
                   className={cn(
                     "inline-flex items-center gap-2 px-5 py-2.5",
-                    "rounded-full border-2 border-gray-900 dark:border-white",
+                    "rounded-full border-2 border-[#1a1a1a] dark:border-[#f8f8f2]",
                     "text-sm font-medium",
-                    "text-gray-900 dark:text-white",
-                    "hover:bg-gray-900 hover:text-white",
-                    "dark:hover:bg-white dark:hover:text-gray-900",
+                    "text-[#1a1a1a] dark:text-[#f8f8f2]",
+                    "hover:bg-[#1a1a1a] hover:text-white",
+                    "dark:hover:bg-[#f8f8f2] dark:hover:text-[#1a1a1a]",
                     "transition-all duration-200"
                   )}
                 >
@@ -612,14 +612,14 @@ export function ClaudeCardNested({
                           href={item.link}
                           className={cn(
                             "text-sm sm:text-base no-underline",
-                            "text-gray-900 dark:text-white",
+                            "text-[#1a1a1a] dark:text-[#f8f8f2]",
                             "hover:opacity-70 transition-opacity"
                           )}
                         >
                           {item.label}
                         </a>
                       ) : (
-                        <span className="text-sm sm:text-base text-gray-900 dark:text-white">
+                        <span className="text-sm sm:text-base text-[#1a1a1a] dark:text-[#f8f8f2]">
                           {item.label}
                         </span>
                       )}
@@ -666,15 +666,15 @@ export function ClaudeCardGrid({ cards, className }: ClaudeCardGridProps) {
             key={index}
             {...cardProps}
             className={cn(
-              "flex flex-col gap-1 p-4 rounded-2xl border border-gray-200 dark:border-gray-700 no-underline",
-              "hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:no-underline transition-colors"
+              "flex flex-col gap-1 p-4 rounded-2xl border border-[#1a1a1a]/10 dark:border-white/10 no-underline",
+              "hover:bg-[#f7f7f7] dark:hover:bg-[#1a1a1a] hover:no-underline transition-colors"
             )}
           >
-            <h4 className="font-semibold text-gray-900 dark:text-white">
+            <h4 className="font-semibold text-[#1a1a1a] dark:text-[#f8f8f2]">
               {card.title}
             </h4>
             {card.description && (
-              <p className="text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
+              <p className="text-sm text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55 line-clamp-2">
                 {card.description}
               </p>
             )}

--- a/apps/blog/components/blog/CodeBlock.tsx
+++ b/apps/blog/components/blog/CodeBlock.tsx
@@ -78,9 +78,9 @@ export function CodeBlock({ children, className, ...props }: CodeBlockProps) {
             "px-2 py-0.5",
             "text-xs font-medium",
             "rounded-md",
-            "bg-gray-100 dark:bg-gray-800",
-            "text-gray-600 dark:text-gray-400",
-            "border border-gray-200 dark:border-gray-700",
+            "bg-[#f7f7f7] dark:bg-[#1a1a1a]",
+            "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55",
+            "border border-[#1a1a1a]/10 dark:border-white/10",
             "select-none"
           )}
         >
@@ -90,10 +90,10 @@ export function CodeBlock({ children, className, ...props }: CodeBlockProps) {
       <pre
         ref={preRef}
         className={cn(
-          "bg-white dark:bg-gray-900",
-          "border border-gray-200 dark:border-gray-700",
+          "bg-white dark:bg-[#1a1a1a]/50",
+          "border border-[#1a1a1a]/10 dark:border-white/10",
           "rounded-xl py-3 px-3 pr-12",
-          "text-gray-800 dark:text-gray-100",
+          "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70",
           "overflow-x-auto",
           "text-sm",
           language && "pt-10",
@@ -109,9 +109,9 @@ export function CodeBlock({ children, className, ...props }: CodeBlockProps) {
           "absolute top-3 right-3",
           "p-1.5",
           "rounded-md",
-          "text-gray-400 dark:text-gray-500",
-          "hover:text-gray-600 dark:hover:text-gray-300",
-          "hover:bg-gray-100 dark:hover:bg-gray-800",
+          "text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55",
+          "hover:text-[#1a1a1a]/70 dark:hover:text-[#f8f8f2]/70",
+          "hover:bg-[#f7f7f7] dark:hover:bg-[#1a1a1a]",
           "transition-all duration-200",
           "opacity-0 group-hover:opacity-100",
           "focus:opacity-100"

--- a/apps/blog/components/blog/ComparisonList.tsx
+++ b/apps/blog/components/blog/ComparisonList.tsx
@@ -25,7 +25,7 @@ export function ComparisonList({
   if (!items || items.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No items to compare
       </div>
@@ -34,15 +34,15 @@ export function ComparisonList({
 
   return (
     <div
-      className={`space-y-4 border-l-2 border-gray-300 dark:border-claude-gray-700 pl-4 py-3 ${className}`}
+      className={`space-y-4 border-l-2 border-[#1a1a1a]/10 dark:border-white/10 pl-4 py-3 ${className}`}
     >
       {title && (
         <div className="space-y-1">
-          <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+          <h2 className="text-lg font-medium text-[#1a1a1a] dark:text-[#f8f8f2]">
             {title}
           </h2>
           {description && (
-            <p className="text-base text-gray-600 dark:text-gray-400">
+            <p className="text-base text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55">
               {description}
             </p>
           )}
@@ -53,16 +53,16 @@ export function ComparisonList({
         {items.map((item) => (
           <div
             key={item.id}
-            className={`flex gap-4 ${item.highlight ? "bg-gray-50 dark:bg-claude-gray-900/50 p-2" : ""}`}
+            className={`flex gap-4 ${item.highlight ? "bg-[#f7f7f7] dark:bg-[#1a1a1a]/50 p-2" : ""}`}
           >
-            <span className="text-gray-500 dark:text-gray-400 font-medium flex-shrink-0 text-sm">
+            <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 font-medium flex-shrink-0 text-sm">
               {item.label}:
             </span>
             <span
               className={`text-base ${
                 item.highlight
-                  ? "font-medium text-gray-900 dark:text-white"
-                  : "text-gray-700 dark:text-gray-300"
+                  ? "font-medium text-[#1a1a1a] dark:text-[#f8f8f2]"
+                  : "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70"
               }`}
             >
               {item.value}

--- a/apps/blog/components/blog/InfoBox.tsx
+++ b/apps/blog/components/blog/InfoBox.tsx
@@ -50,11 +50,11 @@ export function InfoBox({
         </div>
         <div className="flex-1 space-y-1">
           {title && (
-            <h3 className="font-medium text-gray-900 dark:text-white text-base">
+            <h3 className="font-medium text-[#1a1a1a] dark:text-[#f8f8f2] text-base">
               {title}
             </h3>
           )}
-          <div className="text-gray-700 dark:text-gray-300 text-base">
+          <div className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 text-base">
             {children}
           </div>
         </div>

--- a/apps/blog/components/blog/LazyCodeBlock.tsx
+++ b/apps/blog/components/blog/LazyCodeBlock.tsx
@@ -18,7 +18,7 @@ export function LazyCodeBlock(props: ComponentProps<typeof CodeBlockImpl>) {
   return (
     <Suspense
       fallback={
-        <div className="relative min-h-[100px] animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800" />
+        <div className="relative min-h-[100px] animate-pulse rounded-xl bg-[#f7f7f7] dark:bg-[#1a1a1a]" />
       }
     >
       <CodeBlockImpl {...props} />

--- a/apps/blog/components/blog/PricingTable.tsx
+++ b/apps/blog/components/blog/PricingTable.tsx
@@ -31,7 +31,7 @@ export function PricingTable({
   if (!rows || rows.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No pricing data available
       </div>
@@ -40,15 +40,15 @@ export function PricingTable({
 
   return (
     <div
-      className={`space-y-4 border-l-2 border-gray-300 dark:border-claude-gray-700 pl-4 py-3 ${className}`}
+      className={`space-y-4 border-l-2 border-[#1a1a1a]/10 dark:border-white/10 pl-4 py-3 ${className}`}
     >
       {title && (
         <div className="space-y-1">
-          <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+          <h2 className="text-lg font-medium text-[#1a1a1a] dark:text-[#f8f8f2]">
             {title}
           </h2>
           {description && (
-            <p className="text-base text-gray-600 dark:text-gray-400">
+            <p className="text-base text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55">
               {description}
             </p>
           )}
@@ -60,40 +60,40 @@ export function PricingTable({
           <button
             key={idx}
             onClick={() => setExpandedRow(expandedRow === idx ? null : idx)}
-            className="w-full text-left border border-gray-200 dark:border-claude-gray-800 p-3 hover:bg-gray-50 dark:hover:bg-claude-gray-900/50 transition-colors"
+            className="w-full text-left border border-[#1a1a1a]/10 dark:border-white/10 p-3 hover:bg-[#f7f7f7] dark:hover:bg-[#1a1a1a] transition-colors"
           >
             <div className="flex items-center justify-between gap-4">
               <div className="flex-1">
-                <h3 className="font-medium text-gray-900 dark:text-white text-base">
+                <h3 className="font-medium text-[#1a1a1a] dark:text-[#f8f8f2] text-base">
                   {row.model}
                 </h3>
               </div>
-              <span className="text-gray-400 dark:text-gray-600 text-sm">
+              <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 text-sm">
                 {expandedRow === idx ? "−" : "+"}
               </span>
             </div>
 
             {expandedRow === idx && (
-              <div className="mt-3 pt-3 border-t border-gray-200 dark:border-claude-gray-800 space-y-2">
+              <div className="mt-3 pt-3 border-t border-[#1a1a1a]/10 dark:border-white/10 space-y-2">
                 <div className="flex justify-between gap-4 text-sm">
-                  <span className="text-gray-500 dark:text-gray-400">
+                  <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
                     Input:
                   </span>
-                  <span className="text-gray-700 dark:text-gray-300 font-medium">
+                  <span className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 font-medium">
                     {row.input}
                   </span>
                 </div>
                 <div className="flex justify-between gap-4 text-sm">
-                  <span className="text-gray-500 dark:text-gray-400">
+                  <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
                     Output:
                   </span>
-                  <span className="text-gray-700 dark:text-gray-300 font-medium">
+                  <span className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 font-medium">
                     {row.output}
                   </span>
                 </div>
                 {row.note && (
-                  <div className="mt-2 pt-2 border-t border-gray-200 dark:border-claude-gray-800">
-                    <p className="text-xs text-gray-600 dark:text-gray-400">
+                  <div className="mt-2 pt-2 border-t border-[#1a1a1a]/10 dark:border-white/10">
+                    <p className="text-xs text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55">
                       {row.note}
                     </p>
                   </div>

--- a/apps/blog/components/blog/Steps.tsx
+++ b/apps/blog/components/blog/Steps.tsx
@@ -14,10 +14,10 @@ interface StepsProps {
 export function Step({ title, children }: StepProps) {
   return (
     <div className="step-item">
-      <h4 className="step-title font-semibold text-gray-900 dark:text-gray-100 mb-2">
+      <h4 className="step-title font-semibold text-[#1a1a1a] dark:text-[#f8f8f2] mb-2">
         {title}
       </h4>
-      <div className="text-gray-700 dark:text-gray-300">{children}</div>
+      <div className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">{children}</div>
     </div>
   );
 }
@@ -50,7 +50,7 @@ export function Steps({ children }: StepsProps) {
             <div key={index} className="step-item relative pb-8 last:pb-0">
               {/* Vertical line - connecting steps */}
               {!isLast && (
-                <div className="absolute left-[13px] top-7 bottom-0 w-px bg-gray-200 dark:bg-gray-700" />
+                <div className="absolute left-[13px] top-7 bottom-0 w-px bg-[#1a1a1a]/10 dark:bg-white/10" />
               )}
 
               {/* Header row: number + title perfectly aligned on same line */}
@@ -59,18 +59,18 @@ export function Steps({ children }: StepsProps) {
                 className="inline-flex items-center gap-3 text-left group"
               >
                 {/* Step number circle */}
-                <span className="relative z-10 flex-shrink-0 inline-flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-700 group-hover:bg-gray-200 dark:group-hover:bg-gray-700 transition-colors">
+                <span className="relative z-10 flex-shrink-0 inline-flex h-7 w-7 items-center justify-center rounded-full bg-[#f7f7f7] dark:bg-[#1a1a1a] text-sm font-medium text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 border border-[#1a1a1a]/10 dark:border-white/10 group-hover:bg-[#e5e5e5] dark:group-hover:bg-white/10 transition-colors">
                   {index + 1}
                 </span>
 
                 {/* Title inline with number */}
-                <span className="step-title text-base font-semibold text-gray-900 dark:text-gray-100 leading-7">
+                <span className="step-title text-base font-semibold text-[#1a1a1a] dark:text-[#f8f8f2] leading-7">
                   {(child.props as StepProps).title}
                 </span>
 
                 {/* Chevron - only visible on hover */}
                 <svg
-                  className={`w-3.5 h-3.5 text-gray-300 dark:text-gray-600 opacity-0 group-hover:opacity-100 transition-all duration-200 ${isExpanded ? "" : "-rotate-90"}`}
+                  className={`w-3.5 h-3.5 text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 opacity-0 group-hover:opacity-100 transition-all duration-200 ${isExpanded ? "" : "-rotate-90"}`}
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -86,7 +86,7 @@ export function Steps({ children }: StepsProps) {
 
               {/* Content - collapsible, indented to align with title */}
               {isExpanded && (
-                <div className="ml-10 mt-3 text-gray-600 dark:text-gray-400 text-[15px] leading-relaxed [&>p]:mb-3 [&>p:last-child]:mb-0">
+                <div className="ml-10 mt-3 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55 text-[15px] leading-relaxed [&>p]:mb-3 [&>p:last-child]:mb-0">
                   {(child.props as StepProps).children}
                 </div>
               )}

--- a/apps/blog/components/blog/StepsList.tsx
+++ b/apps/blog/components/blog/StepsList.tsx
@@ -31,7 +31,7 @@ export function StepsList({
   if (!steps || steps.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No steps available
       </div>
@@ -40,10 +40,10 @@ export function StepsList({
 
   return (
     <div
-      className={`space-y-4 border-l-2 border-gray-300 dark:border-claude-gray-700 pl-4 py-3 ${className}`}
+      className={`space-y-4 border-l-2 border-[#1a1a1a]/10 dark:border-white/10 pl-4 py-3 ${className}`}
     >
       {title && (
-        <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+        <h2 className="text-lg font-medium text-[#1a1a1a] dark:text-[#f8f8f2]">
           {title}
         </h2>
       )}
@@ -56,29 +56,29 @@ export function StepsList({
                 expandable &&
                 setExpandedStep(expandedStep === step.id ? null : step.id)
               }
-              className="w-full text-left flex gap-3 hover:text-gray-900 dark:hover:text-white transition-colors"
+              className="w-full text-left flex gap-3 hover:text-[#1a1a1a] dark:hover:text-[#f8f8f2] transition-colors"
             >
-              <span className="font-medium text-gray-500 dark:text-gray-400 flex-shrink-0 w-6">
+              <span className="font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 flex-shrink-0 w-6">
                 {idx + 1}.
               </span>
               <div className="flex-1">
-                <h3 className="font-medium text-gray-900 dark:text-white text-base">
+                <h3 className="font-medium text-[#1a1a1a] dark:text-[#f8f8f2] text-base">
                   {step.title}
                 </h3>
-                <p className="text-gray-700 dark:text-gray-300 text-sm mt-0.5">
+                <p className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 text-sm mt-0.5">
                   {step.description}
                 </p>
               </div>
               {expandable && step.details && (
-                <span className="text-gray-400 dark:text-gray-600 text-sm flex-shrink-0">
+                <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 text-sm flex-shrink-0">
                   {expandedStep === step.id ? "−" : "+"}
                 </span>
               )}
             </button>
 
             {expandable && expandedStep === step.id && step.details && (
-              <div className="mt-2 ml-9 p-3 border-t border-gray-200 dark:border-claude-gray-800">
-                <div className="text-sm text-gray-600 dark:text-gray-400">
+              <div className="mt-2 ml-9 p-3 border-t border-[#1a1a1a]/10 dark:border-white/10">
+                <div className="text-sm text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55">
                   {step.details}
                 </div>
               </div>

--- a/apps/blog/components/blog/Tabs.tsx
+++ b/apps/blog/components/blog/Tabs.tsx
@@ -24,7 +24,7 @@ export function Tabs({ tabs, defaultTab, className = "" }: TabsProps) {
   if (!tabs || tabs.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No tabs available
       </div>
@@ -67,7 +67,7 @@ export function Tabs({ tabs, defaultTab, className = "" }: TabsProps) {
       <div
         ref={tablistRef}
         role="tablist"
-        className="flex gap-4 border-b border-gray-200 dark:border-claude-gray-800 mb-4"
+        className="flex gap-4 border-b border-[#1a1a1a]/10 dark:border-white/10 mb-4"
         onKeyDown={handleKeyDown}
       >
         {tabs.map((tab) => (
@@ -81,13 +81,13 @@ export function Tabs({ tabs, defaultTab, className = "" }: TabsProps) {
             onClick={() => setActiveTab(tab.id)}
             className={`pb-2 text-base font-medium transition-colors relative ${
               activeTab === tab.id
-                ? "text-gray-900 dark:text-white"
-                : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                ? "text-[#1a1a1a] dark:text-[#f8f8f2]"
+                : "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55 hover:text-[#1a1a1a] dark:hover:text-[#f8f8f2]"
             }`}
           >
             {tab.label}
             {activeTab === tab.id && (
-              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-gray-900 dark:bg-white" />
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
             )}
           </button>
         ))}


### PR DESCRIPTION
## Summary
- Replace `gray-*`, `slate-*`, and `claude-gray-*` Tailwind utility classes with `#1a1a1a`/`#f8f8f2` hex values across all 11 MDX/blogging component files
- Color mapping: primary text `#1a1a1a`/`#f8f8f2`, secondary `#1a1a1a/70`/`#f8f8f2/70`, muted `#1a1a1a/55`/`#f8f8f2/55`, borders `#1a1a1a/10`/`white/10`, backgrounds `#f7f7f7`/`#1a1a1a`
- No logic changes, purely CSS class substitutions

## Files changed
- `MdxComponents.tsx` (Image border)
- `blog/InfoBox.tsx`, `CardGrid.tsx`, `Tabs.tsx`, `PricingTable.tsx`
- `blog/ComparisonList.tsx`, `StepsList.tsx`, `CodeBlock.tsx`, `Steps.tsx`
- `blog/ClaudeCard.tsx`, `LazyCodeBlock.tsx`

## Test plan
- [x] `check-types` passes (pre-existing `@types/bun` issue unrelated)
- [ ] Visual review: light/dark mode MDX components render correctly
- [ ] No functional regressions (CSS-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align blog MDX component styling with the home app color palette using a shared light/dark hex-based color scheme for text, borders, and backgrounds.

Enhancements:
- Standardize text, border, and background colors in blog MDX components (cards, steps, pricing tables, tabs, code blocks, etc.) to a consistent hex-based palette matching the home app.
- Update light and dark mode hover and accent states for blog UI elements to use the new shared color system.