### PR TITLE
style(blog): align search component colors with home app palette

### DIFF
--- a/apps/blog/components/blog/search-bar.tsx
+++ b/apps/blog/components/blog/search-bar.tsx
@@ -130,19 +130,19 @@ export function SearchBar({
           placeholder={placeholder}
           className={cn(
             "w-full px-4 py-3 text-lg",
-            "border border-neutral-300 dark:border-neutral-700",
-            "bg-white dark:bg-neutral-900",
-            "text-neutral-900 dark:text-neutral-100",
-            "placeholder:text-neutral-400 dark:placeholder:text-neutral-600",
+            "border border-[#1a1a1a]/10 dark:border-white/10",
+            "bg-white dark:bg-[#1a1a1a]",
+            "text-[#1a1a1a] dark:text-[#f8f8f2]",
+            "placeholder:text-[#1a1a1a]/55 dark:placeholder:text-[#f8f8f2]/55",
             "rounded-lg",
-            "focus:outline-none focus:ring-2 focus:ring-neutral-500",
+            "focus:outline-none focus:ring-2 focus:ring-[#1a1a1a]/55",
             "transition-all",
             inputClassName
           )}
           autoComplete="off"
         />
-        <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-neutral-400">
-          <kbd className="hidden rounded border border-neutral-300 px-2 py-1 text-xs dark:border-neutral-700 sm:inline-block">
+        <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+          <kbd className="hidden rounded border border-[#1a1a1a]/10 px-2 py-1 text-xs dark:border-white/10 sm:inline-block">
             /
           </kbd>
         </div>
@@ -152,16 +152,16 @@ export function SearchBar({
       {showHistory && isInitialized && history.length > 0 && !query && (
         <div
           data-search-history
-          className="absolute z-10 mt-2 w-full rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 shadow-lg"
+          className="absolute z-10 mt-2 w-full rounded-lg border border-[#1a1a1a]/10 dark:border-white/10 bg-white dark:bg-[#1a1a1a] shadow-lg"
         >
-          <div className="flex items-center justify-between border-b border-neutral-200 dark:border-neutral-800 px-4 py-2">
-            <span className="text-xs font-medium text-neutral-500 dark:text-neutral-400">
+          <div className="flex items-center justify-between border-b border-[#1a1a1a]/10 dark:border-white/10 px-4 py-2">
+            <span className="text-xs font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
               Recent searches
             </span>
             <button
               type="button"
               onClick={clear}
-              className="text-xs text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
+              className="text-xs text-[#1a1a1a]/55 hover:text-[#1a1a1a] dark:text-[#f8f8f2]/55 dark:hover:text-[#f8f8f2] transition-colors"
             >
               Clear
             </button>
@@ -172,10 +172,10 @@ export function SearchBar({
                 <button
                   type="button"
                   onClick={() => handleHistoryClick(historyQuery)}
-                  className="w-full px-4 py-2 text-left text-sm text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors flex items-center gap-2"
+                  className="w-full px-4 py-2 text-left text-sm text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 hover:bg-[#f7f7f7] dark:hover:bg-[#1a1a1a] transition-colors flex items-center gap-2"
                 >
                   <svg
-                    className="w-4 h-4 text-neutral-400 shrink-0"
+                    className="w-4 h-4 text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"

--- a/apps/blog/components/blog/search-filters.tsx
+++ b/apps/blog/components/blog/search-filters.tsx
@@ -218,8 +218,8 @@ export function SearchFilters({
               "px-3 py-2 rounded-md text-sm font-medium transition-colors text-left",
               activePreset === option.value ||
                 (!activePreset && option.value === "all")
-                ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900"
-                : "bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+                ? "bg-[#1a1a1a] text-white dark:bg-white dark:text-[#0d0e0c]"
+                : "bg-[#f7f7f7] text-[#1a1a1a]/70 hover:bg-[#f7f7f7] dark:bg-[#1a1a1a] dark:text-[#f8f8f2]/70 dark:hover:bg-[#1a1a1a]"
             )}
           >
             {option.label}
@@ -248,14 +248,14 @@ export function SearchFilters({
     <div className={cn("flex flex-col gap-6", className)}>
       {/* Header with clear button */}
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+        <h2 className="text-lg font-semibold text-[#1a1a1a] dark:text-[#f8f8f2]">
           Filters
         </h2>
         {hasActiveFilters && (
           <button
             type="button"
             onClick={clearAllFilters}
-            className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+            className="text-sm text-[#1a1a1a]/55 hover:text-[#1a1a1a] dark:text-[#f8f8f2]/55 dark:hover:text-[#f8f8f2]"
           >
             Clear all
           </button>
@@ -292,7 +292,7 @@ export function SearchFilters({
         <select
           value={currentCategory}
           onChange={(e) => handleCategoryChange(e.target.value)}
-          className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-neutral-500"
+          className="w-full px-3 py-2 border border-[#1a1a1a]/10 dark:border-white/10 bg-white dark:bg-[#1a1a1a] text-[#1a1a1a] dark:text-[#f8f8f2] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1a1a1a]/55"
         >
           <option value="">All categories</option>
           {sortedCategories.map(([category, count]) => (
@@ -312,8 +312,8 @@ export function SearchFilters({
             className={cn(
               "px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
               currentTags.length === 0
-                ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900"
-                : "bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+                ? "bg-[#1a1a1a] text-white dark:bg-white dark:text-[#0d0e0c]"
+                : "bg-[#f7f7f7] text-[#1a1a1a]/70 hover:bg-[#f7f7f7] dark:bg-[#1a1a1a] dark:text-[#f8f8f2]/70 dark:hover:bg-[#1a1a1a]"
             )}
           >
             All tags
@@ -326,8 +326,8 @@ export function SearchFilters({
               className={cn(
                 "px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
                 currentTags.includes(tag)
-                  ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900"
-                  : "bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+                  ? "bg-[#1a1a1a] text-white dark:bg-white dark:text-[#0d0e0c]"
+                  : "bg-[#f7f7f7] text-[#1a1a1a]/70 hover:bg-[#f7f7f7] dark:bg-[#1a1a1a] dark:text-[#f8f8f2]/70 dark:hover:bg-[#1a1a1a]"
               )}
               title={`${count} posts`}
             >
@@ -348,7 +348,7 @@ export function SearchFilters({
               onClick={() => handleDatePresetChange("custom")}
               className={cn(
                 "px-3 py-2 rounded-md text-sm font-medium transition-colors text-left",
-                "bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
+                "bg-[#f7f7f7] text-[#1a1a1a]/70 hover:bg-[#f7f7f7] dark:bg-[#1a1a1a] dark:text-[#f8f8f2]/70 dark:hover:bg-[#1a1a1a]"
               )}
             >
               Custom range
@@ -360,7 +360,7 @@ export function SearchFilters({
               <div>
                 <label
                   htmlFor="from-date"
-                  className="block text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1"
+                  className="block text-xs font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 mb-1"
                 >
                   From
                 </label>
@@ -371,13 +371,13 @@ export function SearchFilters({
                   onChange={(e) =>
                     handleCustomDateChange("from", e.target.value)
                   }
-                  className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-neutral-500"
+                  className="w-full px-3 py-2 border border-[#1a1a1a]/10 dark:border-white/10 bg-white dark:bg-[#1a1a1a] text-[#1a1a1a] dark:text-[#f8f8f2] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1a1a1a]/55"
                 />
               </div>
               <div>
                 <label
                   htmlFor="to-date"
-                  className="block text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1"
+                  className="block text-xs font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 mb-1"
                 >
                   To
                 </label>
@@ -386,7 +386,7 @@ export function SearchFilters({
                   type="date"
                   value={customToDate}
                   onChange={(e) => handleCustomDateChange("to", e.target.value)}
-                  className="w-full px-3 py-2 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-neutral-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-neutral-500"
+                  className="w-full px-3 py-2 border border-[#1a1a1a]/10 dark:border-white/10 bg-white dark:bg-[#1a1a1a] text-[#1a1a1a] dark:text-[#f8f8f2] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#1a1a1a]/55"
                 />
               </div>
             </div>
@@ -396,7 +396,7 @@ export function SearchFilters({
                 setIsCustomDateRange(false);
                 updateFilters({ preset: "all" });
               }}
-              className="text-sm text-neutral-600 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+              className="text-sm text-[#1a1a1a]/55 hover:text-[#1a1a1a] dark:text-[#f8f8f2]/55 dark:hover:text-[#f8f8f2]"
             >
               Back to presets
             </button>
@@ -416,7 +416,7 @@ function FilterSection({
 }) {
   return (
     <div className="space-y-2">
-      <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+      <h3 className="text-sm font-medium text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
         {title}
       </h3>
       {children}
@@ -449,12 +449,12 @@ function ActiveFilterBadge({
   onRemove: () => void;
 }) {
   return (
-    <span className="inline-flex items-center gap-1 px-2 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 rounded-md text-sm">
+    <span className="inline-flex items-center gap-1 px-2 py-1 bg-[#f7f7f7] dark:bg-[#1a1a1a] text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 rounded-md text-sm">
       {label}
       <button
         type="button"
         onClick={onRemove}
-        className="hover:text-neutral-900 dark:hover:text-neutral-100"
+        className="hover:text-[#1a1a1a] dark:hover:text-[#f8f8f2]"
         aria-label={`Remove ${label} filter`}
       >
         <CloseIcon />


### PR DESCRIPTION
## Summary
- Migrate `search-bar.tsx` and `search-filters.tsx` from `neutral-*` Tailwind colors to `#1a1a1a`/`#f8f8f2` palette
- Matches the home app design system used by already-migrated components (`search-client.tsx`, `search-result-item.tsx`)
- Yellow highlight (`bg-yellow-200`/`bg-yellow-800`) intentionally preserved for search result highlighting

## Test plan
- [x] `bun test` passes (47 tests, 0 fail)
- [x] `check-types` passes (pre-existing bun type def warning only)
- [ ] Visual verification: search page renders correctly in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align blog search bar and filter UI colors with the home app design palette for both light and dark modes.

Enhancements:
- Update search filters, inputs, and badges to use the new #1a1a1a/#f8f8f2-based color system.
- Adjust search history dropdown styling to match the updated palette and typography contrasts.