### PR TITLE
style(blog): align remaining component colors with home app palette

### DIFF
--- a/apps/blog/components/MdxComponents.tsx
+++ b/apps/blog/components/MdxComponents.tsx
@@ -34,7 +34,7 @@ function Image({
       <img
         src={imageSrc || ""}
         alt={alt || ""}
-        className="rounded-xl border border-gray-200 dark:border-gray-700 max-w-full"
+        className="rounded-xl border border-[#1a1a1a]/10 dark:border-white/10 max-w-full"
         loading="lazy"
         {...props}
       />

--- a/apps/blog/components/blog/CardGrid.tsx
+++ b/apps/blog/components/blog/CardGrid.tsx
@@ -120,7 +120,7 @@ export function CardGrid({
   if (!cards || cards.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No cards available
       </div>
@@ -141,26 +141,26 @@ export function CardGrid({
         return (
           <div
             key={card.id}
-            className="border border-gray-200 dark:border-claude-gray-800 p-4 hover:bg-gray-50 dark:hover:bg-claude-gray-900/50 transition-colors"
+            className="border border-[#1a1a1a]/10 dark:border-white/10 p-4 hover:bg-[#f7f7f7] dark:hover:bg-[#1a1a1a] transition-colors"
           >
             <div className="space-y-3">
               <div className="flex items-start gap-3">
-                <div className="flex-shrink-0 text-gray-400 dark:text-gray-600">
+                <div className="flex-shrink-0 text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
                   <IconComponent size={24} />
                 </div>
-                <h3 className="font-medium text-gray-900 dark:text-white text-base">
+                <h3 className="font-medium text-[#1a1a1a] dark:text-[#f8f8f2] text-base">
                   {card.title}
                 </h3>
               </div>
 
-              <p className="text-gray-700 dark:text-gray-300 text-sm leading-relaxed">
+              <p className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 text-sm leading-relaxed">
                 {card.description}
               </p>
 
               {card.link && (
                 <a
                   href={card.link.href}
-                  className="inline-block text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+                  className="inline-block text-sm text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55 hover:text-[#1a1a1a] dark:hover:text-[#f8f8f2] transition-colors"
                 >
                   {card.link.text} →
                 </a>

--- a/apps/blog/components/blog/ComparisonList.tsx
+++ b/apps/blog/components/blog/ComparisonList.tsx
@@ -25,7 +25,7 @@ export function ComparisonList({
   if (!items || items.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No items to compare
       </div>
@@ -34,15 +34,15 @@ export function ComparisonList({
 
   return (
     <div
-      className={`space-y-4 border-l-2 border-gray-300 dark:border-claude-gray-700 pl-4 py-3 ${className}`}
+      className={`space-y-4 border-l-2 border-[#1a1a1a]/10 dark:border-white/10 pl-4 py-3 ${className}`}
     >
       {title && (
         <div className="space-y-1">
-          <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+          <h2 className="text-lg font-medium text-[#1a1a1a] dark:text-[#f8f8f2]">
             {title}
           </h2>
           {description && (
-            <p className="text-base text-gray-600 dark:text-gray-400">
+            <p className="text-base text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55">
               {description}
             </p>
           )}
@@ -53,16 +53,16 @@ export function ComparisonList({
         {items.map((item) => (
           <div
             key={item.id}
-            className={`flex gap-4 ${item.highlight ? "bg-gray-50 dark:bg-claude-gray-900/50 p-2" : ""}`}
+            className={`flex gap-4 ${item.highlight ? "bg-[#f7f7f7] dark:bg-[#1a1a1a]/50 p-2" : ""}`}
           >
-            <span className="text-gray-500 dark:text-gray-400 font-medium flex-shrink-0 text-sm">
+            <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 font-medium flex-shrink-0 text-sm">
               {item.label}:
             </span>
             <span
               className={`text-base ${
                 item.highlight
-                  ? "font-medium text-gray-900 dark:text-white"
-                  : "text-gray-700 dark:text-gray-300"
+                  ? "font-medium text-[#1a1a1a] dark:text-[#f8f8f2]"
+                  : "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70"
               }`}
             >
               {item.value}

--- a/apps/blog/components/blog/InfoBox.tsx
+++ b/apps/blog/components/blog/InfoBox.tsx
@@ -50,11 +50,11 @@ export function InfoBox({
         </div>
         <div className="flex-1 space-y-1">
           {title && (
-            <h3 className="font-medium text-gray-900 dark:text-white text-base">
+            <h3 className="font-medium text-[#1a1a1a] dark:text-[#f8f8f2] text-base">
               {title}
             </h3>
           )}
-          <div className="text-gray-700 dark:text-gray-300 text-base">
+          <div className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 text-base">
             {children}
           </div>
         </div>

--- a/apps/blog/components/blog/PricingTable.tsx
+++ b/apps/blog/components/blog/PricingTable.tsx
@@ -31,7 +31,7 @@ export function PricingTable({
   if (!rows || rows.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No pricing data available
       </div>
@@ -40,15 +40,15 @@ export function PricingTable({
 
   return (
     <div
-      className={`space-y-4 border-l-2 border-gray-300 dark:border-claude-gray-700 pl-4 py-3 ${className}`}
+      className={`space-y-4 border-l-2 border-[#1a1a1a]/10 dark:border-white/10 pl-4 py-3 ${className}`}
     >
       {title && (
         <div className="space-y-1">
-          <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+          <h2 className="text-lg font-medium text-[#1a1a1a] dark:text-[#f8f8f2]">
             {title}
           </h2>
           {description && (
-            <p className="text-base text-gray-600 dark:text-gray-400">
+            <p className="text-base text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55">
               {description}
             </p>
           )}
@@ -60,40 +60,40 @@ export function PricingTable({
           <button
             key={idx}
             onClick={() => setExpandedRow(expandedRow === idx ? null : idx)}
-            className="w-full text-left border border-gray-200 dark:border-claude-gray-800 p-3 hover:bg-gray-50 dark:hover:bg-claude-gray-900/50 transition-colors"
+            className="w-full text-left border border-[#1a1a1a]/10 dark:border-white/10 p-3 hover:bg-[#f7f7f7] dark:hover:bg-[#1a1a1a] transition-colors"
           >
             <div className="flex items-center justify-between gap-4">
               <div className="flex-1">
-                <h3 className="font-medium text-gray-900 dark:text-white text-base">
+                <h3 className="font-medium text-[#1a1a1a] dark:text-[#f8f8f2] text-base">
                   {row.model}
                 </h3>
               </div>
-              <span className="text-gray-400 dark:text-gray-600 text-sm">
+              <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 text-sm">
                 {expandedRow === idx ? "−" : "+"}
               </span>
             </div>
 
             {expandedRow === idx && (
-              <div className="mt-3 pt-3 border-t border-gray-200 dark:border-claude-gray-800 space-y-2">
+              <div className="mt-3 pt-3 border-t border-[#1a1a1a]/10 dark:border-white/10 space-y-2">
                 <div className="flex justify-between gap-4 text-sm">
-                  <span className="text-gray-500 dark:text-gray-400">
+                  <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
                     Input:
                   </span>
-                  <span className="text-gray-700 dark:text-gray-300 font-medium">
+                  <span className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 font-medium">
                     {row.input}
                   </span>
                 </div>
                 <div className="flex justify-between gap-4 text-sm">
-                  <span className="text-gray-500 dark:text-gray-400">
+                  <span className="text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
                     Output:
                   </span>
-                  <span className="text-gray-700 dark:text-gray-300 font-medium">
+                  <span className="text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70 font-medium">
                     {row.output}
                   </span>
                 </div>
                 {row.note && (
-                  <div className="mt-2 pt-2 border-t border-gray-200 dark:border-claude-gray-800">
-                    <p className="text-xs text-gray-600 dark:text-gray-400">
+                  <div className="mt-2 pt-2 border-t border-[#1a1a1a]/10 dark:border-white/10">
+                    <p className="text-xs text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55">
                       {row.note}
                     </p>
                   </div>

--- a/apps/blog/components/blog/Tabs.tsx
+++ b/apps/blog/components/blog/Tabs.tsx
@@ -24,7 +24,7 @@ export function Tabs({ tabs, defaultTab, className = "" }: TabsProps) {
   if (!tabs || tabs.length === 0) {
     return (
       <div
-        className={`text-base text-gray-500 dark:text-gray-400 ${className}`}
+        className={`text-base text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 ${className}`}
       >
         No tabs available
       </div>
@@ -67,7 +67,7 @@ export function Tabs({ tabs, defaultTab, className = "" }: TabsProps) {
       <div
         ref={tablistRef}
         role="tablist"
-        className="flex gap-4 border-b border-gray-200 dark:border-claude-gray-800 mb-4"
+        className="flex gap-4 border-b border-[#1a1a1a]/10 dark:border-white/10 mb-4"
         onKeyDown={handleKeyDown}
       >
         {tabs.map((tab) => (
@@ -81,13 +81,13 @@ export function Tabs({ tabs, defaultTab, className = "" }: TabsProps) {
             onClick={() => setActiveTab(tab.id)}
             className={`pb-2 text-base font-medium transition-colors relative ${
               activeTab === tab.id
-                ? "text-gray-900 dark:text-white"
-                : "text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+                ? "text-[#1a1a1a] dark:text-[#f8f8f2]"
+                : "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/55 hover:text-[#1a1a1a] dark:hover:text-[#f8f8f2]"
             }`}
           >
             {tab.label}
             {activeTab === tab.id && (
-              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-gray-900 dark:bg-white" />
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#1a1a1a] dark:bg-[#f8f8f2]" />
             )}
           </button>
         ))}

--- a/apps/blog/components/layout/HeroBanner.tsx
+++ b/apps/blog/components/layout/HeroBanner.tsx
@@ -21,21 +21,21 @@ export function HeroBanner({
 }: HeroBannerProps) {
   return (
     <div
-      className={`${colorClass} mb-12 rounded-xl border border-neutral-950/10 p-6 dark:border-white/10 sm:p-8 md:p-10`}
+      className={`${colorClass} mb-12 rounded-xl border border-[#1a1a1a]/10 p-6 dark:border-white/10 sm:p-8 md:p-10`}
     >
       <div className="mb-4">
         <BackLink href={backLinkHref} text={backLinkText} />
       </div>
 
-      <h1 className="mb-5 text-4xl font-semibold tracking-tight text-neutral-950 dark:text-[#f8f8f2] md:text-5xl">
+      <h1 className="mb-5 text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] md:text-5xl">
         {title}
       </h1>
 
-      <p className="mb-6 max-w-2xl text-sm leading-6 text-neutral-700 dark:text-[#f8f8f2]/75 sm:text-base">
+      <p className="mb-6 max-w-2xl text-sm leading-6 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/75 sm:text-base">
         {description}
       </p>
 
-      <div className="flex flex-wrap gap-4 text-sm font-medium text-neutral-600 dark:text-[#f8f8f2]/60">
+      <div className="flex flex-wrap gap-4 text-sm font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
         <div className="flex items-center gap-2">
           <svg
             className="h-5 w-5"

--- a/apps/blog/components/ui/BackLink.tsx
+++ b/apps/blog/components/ui/BackLink.tsx
@@ -7,7 +7,7 @@ export function BackLink({ href, text }: BackLinkProps) {
   return (
     <a
       href={href}
-      className="inline-flex cursor-pointer items-center text-sm font-medium text-neutral-600 dark:text-neutral-400 transition-colors hover:text-neutral-900 dark:hover:text-neutral-100"
+      className="inline-flex cursor-pointer items-center text-sm font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55 transition-colors hover:text-[#1a1a1a] dark:hover:text-[#f8f8f2]"
     >
       <svg
         className="mr-2 h-4 w-4"


### PR DESCRIPTION
## Summary
- Replace all `neutral-*`, `gray-*`, and `claude-gray-*` Tailwind color classes in blog components with the `#1a1a1a`/`#f8f8f2` color pattern used by the home app
- Covers 8 component files: BackLink, HeroBanner, MdxComponents, CardGrid, ComparisonList, InfoBox, PricingTable, and Tabs
- All route files (`archives.tsx`, `category.tsx`, `tags.tsx`, etc.) were already using the correct palette — no changes needed there

## Test plan
- [x] `bun run check-types` passes
- [ ] Visual review of blog pages (archives, category, tags, series) in light and dark mode
- [ ] Verify MDX blog components (CardGrid, Tabs, PricingTable, ComparisonList, InfoBox) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update blog layout and MDX UI components to use the shared #1a1a1a/#f8f8f2 color scheme for text, borders, and backgrounds across light and dark modes.