### PR TITLE
fix(blog): rename Apache Airflow tag to Airflow for correct URL slug

### DIFF
--- a/apps/blog/_posts/2019/08/airflow-context.md
+++ b/apps/blog/_posts/2019/08/airflow-context.md
@@ -7,7 +7,7 @@ tags:
   - Data
   - Python
   - Data Engineering
-  - Apache Airflow
+  - Airflow
 
 thumbnail: https://4.bp.blogspot.com/-H9PlWKnP_Gc/XU2U4yVVQtI/AAAAAAABFVY/MZem1VyxGr8ORiZbRNx3Kno5C4nzJeeEgCK4BGAYYCw/s200/1_6jjSw8IqGbsPZp7L_43YyQ.png
 slug: /2019/08/airflow-context.html

--- a/apps/blog/_posts/2019/08/airflow-docker-compose.md
+++ b/apps/blog/_posts/2019/08/airflow-docker-compose.md
@@ -3,7 +3,7 @@ title: Cài đặt Apache Airflow với Docker Compose
 date: '2019-08-26'
 category: Data Engineering
 tags:
-  - Apache Airflow
+  - Airflow
   - Data
   - Data Engineering
 slug: /2019/08/airflow-docker-compose.html

--- a/apps/blog/_posts/2019/08/airflow-note.md
+++ b/apps/blog/_posts/2019/08/airflow-note.md
@@ -3,7 +3,7 @@ title: Airflow - một số ghi chép
 date: '2019-08-27'
 category: Data Engineering
 tags:
-  - Apache Airflow
+  - Airflow
   - Data
   - Data Engineering
 slug: /2019/08/airflow-note.html

--- a/apps/blog/_posts/2019/08/slack-alerts-in-airflow.md
+++ b/apps/blog/_posts/2019/08/slack-alerts-in-airflow.md
@@ -3,7 +3,7 @@ title: Gửi Slack Alerts trên Airflow
 date: '2019-08-20'
 category: Data Engineering
 tags:
-  - Apache Airflow
+  - Airflow
   - Data
   - Data Engineering
 slug: /2019/08/slack-alerts-in-airflow.html

--- a/apps/blog/_posts/2020/05/airflow-dag-serialization.md
+++ b/apps/blog/_posts/2020/05/airflow-dag-serialization.md
@@ -5,7 +5,7 @@ author: Duyet
 category: Data Engineering
 tags:
   - Data Engineering
-  - Apache Airflow
+  - Airflow
 thumbnail: https://1.bp.blogspot.com/-5cIyBwelyrQ/Xvg-wwqPJRI/AAAAAAABeeI/d4DPBinapik2Dffz3wXSTnsU7cgCHPqBACK4BGAYYCw/s1600/dag_serialization.png
 slug: /2020/05/airflow-dag-serialization.html
 description: In order to make Airflow Webserver stateless, Airflow >=1.10.7 supports DAG Serialization and DB Persistence. Note - This guide is for Airflow 1.x; for Airflow 2.x, DAG serialization is enabled by default.

--- a/apps/blog/_posts/2020/06/scheduling-python-script-in-airflow.md
+++ b/apps/blog/_posts/2020/06/scheduling-python-script-in-airflow.md
@@ -5,7 +5,7 @@ author: Duyet
 category: Data Engineering
 tags:
   - Data Engineering
-  - Apache Airflow
+  - Airflow
   - Python
 
 thumbnail: https://images.unsplash.com/photo-1592928038511-20202bdad1fd?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80

--- a/apps/blog/_posts/2020/12/airflow-taskflow-api.md
+++ b/apps/blog/_posts/2020/12/airflow-taskflow-api.md
@@ -5,7 +5,7 @@ featured: true
 author: Duyet
 category: Data Engineering
 tags:
-  - Apache Airflow
+  - Airflow
   - Data Engineering
 thumbnail: https://1.bp.blogspot.com/-ON0KTUqotAs/X-chcnFmhtI/AAAAAAABzmA/-kBwGuYyCS44Q16FCHL23iio9WUm6Ux9wCLcBGAsYHQ/s0/duyet-airflow-taskflow-api.png
 slug: /2020/12/airflow-taskflow-api.html

--- a/apps/blog/_posts/2022/09/airflow-dataset.md
+++ b/apps/blog/_posts/2022/09/airflow-dataset.md
@@ -6,7 +6,7 @@ category: Data
 tags:
   - Data
   - Data Engineering
-  - Apache Airflow
+  - Airflow
 slug: /2022/09/airflow-dataset.html
 thumbnail: https://i.imgur.com/oESqHNY.png
 twitterCommentUrl: https://twitter.com/search?q=https%3A%2F%2Fblog.duyet.net%2F2022%2F09%2Fairflow-dataset.html

--- a/apps/blog/_posts/2023/07/airflow-control-parallelism-concurrency.md
+++ b/apps/blog/_posts/2023/07/airflow-control-parallelism-concurrency.md
@@ -6,7 +6,7 @@ category: Data
 tags:
   - Data
   - Data Engineering
-  - Apache Airflow
+  - Airflow
 slug: /2023/07/airflow-control-parallelism-concurrency.html
 thumbnail: /media/2023/07/airflow-control-parallelism-concurrency.svg
 description: 'How to control parallelism and concurrency'


### PR DESCRIPTION
## Summary
- Rename frontmatter tag `Apache Airflow` to `Airflow` in 9 blog posts
- Fixes `/tag/airflow` returning 404 because `getSlug("Apache Airflow")` produced `"apache-airflow"` instead of `"airflow"`
- No changes to body text or other frontmatter fields

## Test plan
- [x] `bun test` passes in apps/blog (47 tests, 0 failures)
- [ ] Verify `/tag/airflow` resolves correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix broken `/tag/airflow` tag page by aligning post frontmatter tags with the expected Airflow slug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata tags across nine Airflow-related blog posts spanning 2019-2023 to establish and maintain consistent categorization standards. Standardizing the taxonomy throughout the blog archive improves overall content organization, searchability, and discoverability for readers. All original article content, code examples, and documentation remain completely intact and unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->