### PR TITLE
chore(docs): dedupe gitignore and clarify canonical agent file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,10 +40,6 @@ yarn-error.log*
 .wrangler
 .wrangler-seeds*.json
 
-*.local.*
-
-# wrangler
-.wrangler
 .playwright-mcp
 
 # Blog attachments (local drafts)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,5 +7,6 @@ For single-file verification, use `bunx biome lint <path>` before broader app ch
 For root quality checks, use `bun run lint`, `bun run check-types`, and `bun run test`.
 For deploy/config workflows, use root scripts (`bun run config`, `bun run deploy`, `bun run cf:deploy`, `bun run cf:deploy:prod`) when needed.
 For Rust/WASM workflows, use the documented root commands (`bun run rust:build`, `bun run wasm:build`, `bun run wasm:test`, `bun run wasm:clippy`, `bun run bench:wasm`) only when the touched change requires them.
+`AGENTS.md` is a symlink to this file; update `CLAUDE.md` as the canonical instruction entrypoint.
 
 Put durable repository knowledge in `docs/ai/internal-knowledge.md` instead of expanding this file.


### PR DESCRIPTION
## Summary
- dedupe repeated ignore entries in  to reduce config drift
- document that  is a symlink and  is the canonical file to update
- scoped from code-smell/dead-code automation run (fallback to last 7 days because no new commits since last run)

## Findings addressed
- warning: duplicated  entries (, , ) increased maintenance risk
- info: no dead-code candidates found in the strict since-last-run window (no commits)
- info: no performance regression evidence in the strict since-last-run window (no commits)

## Verification
- inspected commit range since  and  (both empty)
- inspected last-7-days diff for maintainability-only issues

## Summary by Sourcery

Clarify internal documentation around AI agent configuration and clean up duplicated gitignore entries.

Documentation:
- Document AGENTS.md as a symlink and direct contributors to edit CLAUDE.md as the canonical instructions file.

Chores:
- Deduplicate repeated patterns in .gitignore to reduce config drift and maintenance overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to remove ignore patterns for local environment files and build configurations.

* **Documentation**
  * Clarified the canonical source for agent-related instructions and configuration setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/monorepo/pull/1114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->