### PR TITLE
feat(home): simplify responsive public UI

### DIFF
--- a/apps/home/public/icon.svg
+++ b/apps/home/public/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#fbfbfa" />
+  <rect x="7" y="8" width="8" height="16" fill="#141413" />
+  <rect x="17" y="14" width="8" height="10" fill="#141413" />
+</svg>

--- a/apps/home/src/components/HomeAgentsChat.tsx
+++ b/apps/home/src/components/HomeAgentsChat.tsx
@@ -183,27 +183,27 @@ export function HomeAgentsChat() {
     };
 
     return (
-      <div className="mt-4 rounded-2xl border border-[var(--border)] bg-[var(--background)]">
+      <div className="mt-4 border-y border-[var(--hairline)]">
         <form
-          className="border-b border-[var(--border)] p-4"
+          className="border-b border-[var(--hairline)] py-4"
           onSubmit={async (event) => {
             event.preventDefault();
             if (loading) return;
             await sendMessage(input);
           }}
         >
-          <div className="mx-auto flex w-full max-w-5xl items-center gap-3 rounded-[30px] border border-[var(--border)] bg-[var(--muted)] px-4 py-3">
-            <Search className="h-6 w-6 shrink-0 text-[var(--foreground)]" />
+          <div className="mx-auto flex w-full max-w-5xl items-center gap-3 border-b border-[var(--hairline)] py-3">
+            <Search className="h-5 w-5 shrink-0 text-[var(--muted-foreground)]" />
             <input
               value={input}
               onChange={(event) => setInput(event.target.value)}
               placeholder="Type a message..."
-              className="h-10 w-full bg-transparent text-3xl leading-tight text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
+              className="h-10 w-full bg-transparent text-base leading-tight text-[var(--foreground)] outline-none placeholder:text-[var(--muted-foreground)]"
             />
             <button
               type="submit"
               disabled={loading || input.trim().length === 0}
-              className="rounded-3xl bg-[var(--primary)] px-7 py-3 text-2xl font-medium text-white hover:bg-[var(--primary-active)] disabled:cursor-not-allowed disabled:opacity-50"
+              className="bg-[var(--foreground)] px-4 py-2 text-sm font-medium text-[var(--background)] hover:bg-[var(--foreground)]/85 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Search
             </button>
@@ -212,7 +212,7 @@ export function HomeAgentsChat() {
 
         <div className="h-[240px] overflow-y-auto px-4 py-4">
           {messages.length === 0 ? (
-            <div className="rounded-xl border border-[var(--border)] bg-[var(--muted)] p-4 text-sm text-[var(--foreground)]/70">
+            <div className="border-y border-[var(--hairline)] py-4 text-sm text-[var(--foreground)]/70">
               Ask anything about projects, architecture, Cloudflare Agents, or data systems.
             </div>
           ) : (
@@ -220,7 +220,7 @@ export function HomeAgentsChat() {
               {messages.map((message) => (
                 <div
                   key={message.id}
-                  className={`max-w-[88%] rounded-2xl px-4 py-3 text-sm leading-6 ${
+                  className={`max-w-[88%] px-4 py-3 text-sm leading-6 ${
                     message.role === "user"
                       ? "ml-auto bg-[var(--foreground)] text-[var(--background)]"
                       : "bg-[var(--muted)] text-[var(--foreground)]"
@@ -240,7 +240,7 @@ export function HomeAgentsChat() {
                 key={question}
                 type="button"
                 onClick={() => setInput(question)}
-                className="shrink-0 rounded-full border border-[var(--border)] bg-[var(--muted)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)]/85 hover:bg-[var(--muted-foreground)]/15"
+                className="shrink-0 border-b border-[var(--hairline)] px-1 py-1.5 text-xs font-medium text-[var(--foreground)]/85 hover:text-[var(--muted-foreground)]"
               >
                 {question}
               </button>
@@ -259,7 +259,7 @@ export function HomeAgentsChat() {
               value={input}
               onChange={(event) => setInput(event.target.value)}
               placeholder="What would you like to know?"
-              className="min-h-24 w-full resize-none rounded-xl border border-[var(--border)] bg-[var(--background)] p-3 text-sm text-[var(--foreground)] outline-none focus:border-[var(--foreground)]/40"
+              className="min-h-24 w-full resize-none border-y border-[var(--hairline)] bg-transparent py-3 text-sm text-[var(--foreground)] outline-none focus:border-[var(--foreground)]/40"
             />
 
             <div className="flex items-center justify-between">
@@ -281,7 +281,7 @@ export function HomeAgentsChat() {
               <button
                 type="submit"
                 disabled={loading || input.trim().length === 0}
-                className="inline-flex items-center justify-center rounded-xl bg-[var(--foreground)] px-3 py-2 text-[var(--background)] disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex items-center justify-center bg-[var(--foreground)] px-3 py-2 text-[var(--background)] disabled:cursor-not-allowed disabled:opacity-50"
                 title="Send"
               >
                 <CornerDownLeft className="h-4 w-4" />

--- a/apps/home/src/components/NotFound.tsx
+++ b/apps/home/src/components/NotFound.tsx
@@ -4,7 +4,7 @@ export function NotFound() {
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <div className="max-w-md text-center">
-        <h1 className="mb-4 font-serif text-8xl font-bold text-[var(--foreground)]">
+        <h1 className="mb-4 text-6xl font-semibold text-[var(--foreground)]">
           404
         </h1>
         <h2 className="mb-4 text-xl font-semibold text-[var(--foreground)]/85">
@@ -15,7 +15,7 @@ export function NotFound() {
         </p>
         <Link
           to="/"
-          className="inline-block rounded-lg bg-terracotta px-6 py-2 font-medium text-white hover:bg-terracotta-medium transition-colors"
+          className="inline-block rounded-lg bg-[var(--foreground)] px-5 py-3 text-sm font-medium text-[var(--background)] transition-colors hover:bg-[var(--foreground)]/85"
         >
           Go back home
         </Link>

--- a/apps/home/src/components/SiteChrome.tsx
+++ b/apps/home/src/components/SiteChrome.tsx
@@ -32,7 +32,6 @@ export function SiteHeader() {
         className="border-none bg-[var(--background)]/95 backdrop-blur-sm h-16"
         containerClassName="max-w-[1200px]"
       />
-      {/* Visual divider matching Claude's hairline */}
       <div className="h-px w-full bg-[var(--hairline)]" />
     </div>
   );
@@ -42,4 +41,3 @@ export function SiteHeader() {
 export function SiteFooter() {
   return <Footer />;
 }
-

--- a/apps/home/src/components/UrlsList.tsx
+++ b/apps/home/src/components/UrlsList.tsx
@@ -35,14 +35,14 @@ function ExternalIcon({ className }: { className?: string }) {
   );
 }
 
-function UrlCard({ path, target, desc }: UrlEntry) {
+function UrlRow({ path, target, desc }: UrlEntry) {
   const isExternal = target.startsWith("http");
   return (
     <a
       href={target}
       target={isExternal ? "_blank" : undefined}
       rel={isExternal ? "noopener noreferrer" : undefined}
-      className="flex flex-col gap-2 rounded-lg bg-[var(--muted)] p-5 text-[var(--foreground)] no-underline transition-transform duration-150 hover:-translate-y-0.5"
+      className="flex flex-col gap-2 border-t border-[var(--hairline)] py-4 text-[var(--foreground)] no-underline transition-colors first:border-t-0 hover:text-[var(--muted-foreground)]"
     >
       <div className="flex items-center justify-between">
         <code className="font-mono text-[15px] font-semibold text-[var(--foreground)]">
@@ -124,10 +124,10 @@ export default function UrlsList({ urls }: { urls: UrlEntry[] }) {
           <input
             type="text"
             aria-label="Search by path, URL, or description"
-            placeholder="Search by path, URL, or description..."
+            placeholder="Search URLs..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full rounded-lg border border-[var(--hairline)] bg-[var(--background)] px-[100px] py-3.5 text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-soft)] focus:border-[var(--foreground)]/30"
+            className="w-full border-b border-[var(--hairline)] bg-transparent px-10 py-3.5 pr-[100px] text-sm text-[var(--foreground)] outline-none transition-colors placeholder:text-[var(--muted-soft)] focus:border-[var(--foreground)]/30"
           />
           <svg
             aria-hidden="true"
@@ -188,7 +188,7 @@ export default function UrlsList({ urls }: { urls: UrlEntry[] }) {
 
       {/* No results */}
       {filteredUrls.length === 0 && (
-        <div className="rounded-lg bg-[var(--muted)] p-12 text-center">
+        <div className="border-y border-[var(--hairline)] py-12 text-center">
           <p className="text-sm text-[var(--muted-foreground)]">No URLs found matching &ldquo;{searchQuery}&rdquo;</p>
           <button
             type="button"
@@ -206,9 +206,9 @@ export default function UrlsList({ urls }: { urls: UrlEntry[] }) {
           {Array.from(grouped.entries()).map(([category, entries]) => (
             <div key={category} className="mb-8">
               <CategoryHeader category={category} count={entries.length} />
-              <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="border-y border-[var(--hairline)]">
                 {entries.map((entry) => (
-                  <UrlCard key={entry.path} {...entry} />
+                  <UrlRow key={entry.path} {...entry} />
                 ))}
               </div>
             </div>
@@ -216,9 +216,9 @@ export default function UrlsList({ urls }: { urls: UrlEntry[] }) {
         </div>
       )}
 
-      {/* List view — search: flat cards */}
+      {/* List view — search: flat rows */}
       {filteredUrls.length > 0 && view === "list" && searchQuery && (
-        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="border-y border-[var(--hairline)]">
           {filteredUrls.map(({ path, target, desc }) => {
             const isExternal = target.startsWith("http");
             return (
@@ -227,10 +227,10 @@ export default function UrlsList({ urls }: { urls: UrlEntry[] }) {
                 href={target}
                 target={isExternal ? "_blank" : undefined}
                 rel={isExternal ? "noopener noreferrer" : undefined}
-                className="flex flex-col gap-1.5 rounded-lg bg-[var(--muted)] p-4 text-[var(--foreground)] no-underline"
+                className="flex flex-col gap-1.5 border-t border-[var(--hairline)] py-4 text-[var(--foreground)] no-underline first:border-t-0"
               >
                 <div className="flex items-center gap-2">
-                  <code className="rounded bg-[var(--background)] px-2.5 py-1 font-mono text-[13px] font-semibold text-[var(--foreground)]">
+                  <code className="font-mono text-[13px] font-semibold text-[var(--foreground)]">
                     {path}
                   </code>
                   {isExternal && <ExternalIcon className="h-3.5 w-3.5 text-[var(--muted-soft)]" />}
@@ -254,7 +254,7 @@ export default function UrlsList({ urls }: { urls: UrlEntry[] }) {
           {Array.from(grouped.entries()).map(([category, entries]) => (
             <div key={category} className="mb-8">
               <CategoryHeader category={category} count={entries.length} />
-              <div className="overflow-hidden rounded-lg bg-[var(--muted)]">
+              <div className="border-y border-[var(--hairline)]">
                 {entries.map(({ path, target, desc }, i) => {
                   const isExternal = target.startsWith("http");
                   return (
@@ -273,10 +273,10 @@ export default function UrlsList({ urls }: { urls: UrlEntry[] }) {
                       <code className="w-[120px] shrink-0 font-mono text-[13px] font-semibold text-[var(--foreground)]">
                         {path}
                       </code>
-                      <p className="m-0 flex-1 truncate text-[13px] text-[var(--muted-foreground)]">
+                      <p className="m-0 hidden flex-1 truncate text-[13px] text-[var(--muted-foreground)] sm:block">
                         {desc ?? <span className="text-[var(--muted-soft)]">&mdash;</span>}
                       </p>
-                      <span className="max-w-[200px] truncate font-mono text-[11px] text-[var(--muted-soft)]">
+                      <span className="hidden max-w-[200px] truncate font-mono text-[11px] text-[var(--muted-soft)] sm:block">
                         {target}
                       </span>
                       <svg aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-[var(--muted-soft)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/apps/home/src/components/WorkStackSection.tsx
+++ b/apps/home/src/components/WorkStackSection.tsx
@@ -38,14 +38,14 @@ const skills = [
 
 export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
   return (
-    <div className="space-y-16 py-8 lg:space-y-20">
-      <section className="">
-        <div className="grid gap-10 lg:grid-cols-[0.7fr_1fr] lg:items-start">
+    <div className="space-y-12 py-4 lg:space-y-14">
+      <section>
+        <div className="grid gap-8 lg:grid-cols-[0.7fr_1fr] lg:items-start">
           <div className="max-w-md">
-            <p className="mb-4 font-serif text-xl italic text-[var(--primary)] lg:text-2xl">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
               Focus
             </p>
-            <h2 className="font-serif text-3xl sm:text-4xl lg:text-[48px]">
+            <h2 className="text-2xl font-semibold leading-tight sm:text-3xl">
               Practical engineering, written down clearly.
             </h2>
           </div>
@@ -54,12 +54,12 @@ export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
             {focusAreas.map((item) => (
               <div
                 key={item.label}
-                className="grid gap-2 py-8 md:grid-cols-[200px_1fr] md:gap-8 lg:py-10"
+                className="grid gap-2 py-5 md:grid-cols-[180px_1fr] md:gap-8"
               >
-                <p className="font-serif text-xl text-[var(--muted-foreground)] opacity-60 lg:text-[24px]">
+                <p className="text-sm font-semibold text-[var(--foreground)]">
                   {item.label}
                 </p>
-                <p className="text-2xl font-normal leading-snug tracking-tight text-[var(--body-strong)] lg:text-[32px]">
+                <p className="text-base leading-7 text-[var(--muted-foreground)]">
                   {item.value}
                 </p>
               </div>
@@ -68,16 +68,16 @@ export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
         </div>
       </section>
 
-      <section className="">
+      <section>
         <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
           <div className="max-w-2xl">
-            <p className="mb-4 font-serif text-xl italic text-[var(--primary)] lg:text-2xl">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
               Stack
             </p>
-            <h2 className="font-serif text-4xl sm:text-5xl lg:text-[56px]">
+            <h2 className="text-2xl font-semibold sm:text-3xl">
               Tools I reach for.
             </h2>
-            <p className="mt-4 text-xl text-[var(--muted-foreground)] lg:text-2xl">
+            <p className="mt-3 text-base leading-7 text-[var(--muted-foreground)]">
               A curated set of technologies for building reliable, scalable
               systems.
             </p>
@@ -86,28 +86,25 @@ export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
             href={repositoryUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="group inline-flex items-center gap-2 font-serif text-xl hover:text-[var(--primary)] transition-colors lg:text-[28px]"
+            className="group inline-flex items-center gap-2 text-sm font-semibold transition-colors hover:text-[var(--muted-foreground)]"
           >
             Repositories
-            <ArrowRight className="h-6 w-6" />
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
           </a>
         </div>
 
-        <div className="mt-12 flex flex-wrap gap-x-10 gap-y-6 font-serif text-3xl tracking-tight text-[var(--foreground)]/80 md:text-4xl lg:text-[42px] lg:leading-tight">
+        <div className="mt-8 flex flex-wrap gap-x-5 gap-y-2 border-y border-[var(--hairline)] py-5">
           {skills.map((skill) => (
             <span
               key={skill}
-              className="hover:text-[var(--primary)] transition-colors cursor-default"
+              className="text-sm font-medium text-[var(--foreground)]"
             >
               {skill}
             </span>
           ))}
-          <span className="text-[var(--primary)] opacity-40">✱</span>
         </div>
       </section>
     </div>
   );
 }
-
-
 

--- a/apps/home/src/data/projects.ts
+++ b/apps/home/src/data/projects.ts
@@ -20,6 +20,7 @@ const projectUrls = {
   stamp: "https://stamp.duyet.net",
   agentState: "https://agentstate.app",
   pageview: "https://pageview.duyet.net",
+  shareHtml: "https://html.duyet.net",
   fonts: "https://duyet.github.io/fonts/",
 };
 
@@ -107,6 +108,14 @@ export const apps: AppItem[] = [
     description: "Simple, privacy-friendly analytics for websites",
     screenshot: "/screenshots/pageview-art.svg",
     tone: "bg-[#7a705d]",
+  },
+  {
+    name: "ShareHTML",
+    href: projectUrls.shareHtml,
+    host: hostOf(projectUrls.shareHtml),
+    utmContent: "sharehtml_bento",
+    description: "Publish and share HTML documents with simple hosted links",
+    tone: "bg-[#5f6257]",
   },
   {
     name: "LLM Timeline",

--- a/apps/home/src/globals.css
+++ b/apps/home/src/globals.css
@@ -6,13 +6,13 @@
   :root {
     --font-inter: "Inter Variable", "Inter", -apple-system, BlinkMacDesktopFont,
       ui-sans-serif, system-ui, sans-serif;
-    --font-serif: Garamond, "Apple Garamond", "EB Garamond", serif;
+    --font-serif: var(--font-inter);
 
     /* Spacing & Radius Scale */
     --radius-xs: 8px;
     --radius-sm: 12px;
-    --radius-md: 16px;
-    --radius-lg: 24px;
+    --radius-md: 12px;
+    --radius-lg: 16px;
     --radius-max: 1000px;
     
     --gap-xxs: 8px;
@@ -47,36 +47,35 @@
     --body-4: 12px;
 
     /* Base Palette */
-    --background: #faf9f5;
+    --background: #fbfbfa;
     --foreground: #141413;
-    
-    /* Anthropic Ivory Theme */
+
     --foreground-primary: #141413;
     --foreground-secondary: #30302e;
     --foreground-tertiary: #5e5d59;
-    --background-primary: #faf9f5;
-    --background-secondary: #f0eee6;
-    --background-tertiary: #e8e6dc;
-    --background-clay: #d97757;
-    --background-oat: #e3dacc;
-    
+    --background-primary: #fbfbfa;
+    --background-secondary: #f4f4f1;
+    --background-tertiary: #ecebe6;
+    --background-clay: #e7e1d5;
+    --background-oat: #f0ede6;
+
     --border-strong: #141413;
     --border-subtle: #d1cfc5;
     --border-faint: #f0eee6;
 
     /* Semantic Surface Variables */
-    --muted: #efe9de;
-    --muted-foreground: #6c6a64;
-    --border: #e6dfd8;
-    --accent: #cc785c;
-    --primary: #cc785c;
-    --primary-active: #a9583e;
-    --primary-disabled: #e6dfd8;
-    --surface-card: #efe9de;
+    --muted: #f0f0ed;
+    --muted-foreground: #66645f;
+    --border: #e2e0da;
+    --accent: #c06f4f;
+    --primary: #1f1f1d;
+    --primary-active: #3a3935;
+    --primary-disabled: #e2e0da;
+    --surface-card: #ffffff;
     --surface-dark: #181715;
     --surface-dark-elevated: #252320;
     --surface-dark-soft: #1f1e1b;
-    --surface-soft: #f5f0e8;
+    --surface-soft: #f5f5f2;
     --on-dark: #faf9f5;
     --on-dark-soft: #a09d96;
     --hairline: rgba(20, 20, 19, 0.08);
@@ -84,22 +83,21 @@
     --body: #3d3d3a;
     --muted-soft: #8e8b82;
 
-    /* Card Backgrounds */
-    --bg-clay: #d97757;
-    --bg-oat: #e3dacc;
-    --bg-olive: #788c5d;
-    --bg-cactus: #bcd1ca;
-    --bg-sky: #6a9bcc;
-    --bg-heather: #cbcadb;
-    --bg-fig: #c46686;
-    --bg-coral: #ebcece;
+    /* Legacy color utilities */
+    --bg-clay: #ebe5da;
+    --bg-oat: #f2eee7;
+    --bg-olive: #e6ebdf;
+    --bg-cactus: #e5efec;
+    --bg-sky: #e7eef5;
+    --bg-heather: #ecebf3;
+    --bg-fig: #eee6ea;
+    --bg-coral: #f2e7e4;
   }
 
   html.dark {
     --background: #0d0e0c;
     --foreground: #f8f8f2;
     
-    /* Anthropic Slate Theme */
     --foreground-primary: #faf9f5;
     --foreground-secondary: #b0aea5;
     --foreground-tertiary: #87867f;
@@ -147,17 +145,14 @@
   }
 
   h1, h2, h3, h4, h5, .font-serif {
-    font-family: var(--font-serif);
-    font-weight: 400;
+    font-family: var(--font-inter);
+    font-weight: 600;
     color: var(--foreground);
   }
 
-  h1 { letter-spacing: -1.5px; }
-  h2 { letter-spacing: -1px; }
-  h3 { letter-spacing: -0.5px; }
-  h4 { letter-spacing: -0.3px; }
+  h1, h2, h3, h4 { letter-spacing: 0; }
 
-  /* Anthropic Utility Classes */
+  /* Legacy utility classes */
   .bg-slate-1000 { background-color: #0f0f0e!important }
   .bg-slate-950 { background-color: #141413!important }
   .bg-slate-900 { background-color: #1a1918!important }
@@ -176,16 +171,16 @@
 
   /* Target Header branding text from @duyet/components */
   header a span[class*="font-semibold"] {
-    font-family: var(--font-serif);
-    font-weight: 400;
-    font-size: 1.25rem;
-    letter-spacing: -0.01em;
+    font-family: var(--font-inter);
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: 0;
   }
 
   /* Target Header navigation links */
   header nav a {
     font-weight: 500;
-    font-size: 1rem;
+    font-size: 0.875rem;
     color: var(--muted-foreground);
     transition: color 0.2s;
   }

--- a/apps/home/src/routes/__root.tsx
+++ b/apps/home/src/routes/__root.tsx
@@ -45,7 +45,7 @@ export const Route = createRootRoute({
       },
       {
         rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Cormorant+Garamond:wght@400;500;600&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
       },
     ],
   }),
@@ -55,7 +55,7 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>

--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -99,7 +99,6 @@ const links = [
       "Experience building scalable data infrastructure, AI applications, and production systems.",
     url: addUtmParams("https://cv.duyet.net", "about_page", "resume_card"),
     icon: FileUser,
-    tone: "bg-[#bfdbfe]",
   },
   {
     title: "GitHub",
@@ -107,7 +106,6 @@ const links = [
       "Open source work across Python, Rust, TypeScript, analytics, and developer tooling.",
     url: addUtmParams("https://github.com/duyet", "about_page", "github_card"),
     icon: GithubIcon,
-    tone: "bg-[#a7f3d0]",
   },
   {
     title: "LinkedIn",
@@ -119,7 +117,6 @@ const links = [
       "linkedin_card"
     ),
     icon: LinkedInIcon,
-    tone: "bg-[#fecaca]",
   },
   {
     title: "Blog",
@@ -127,7 +124,6 @@ const links = [
       "Technical writing on data engineering, distributed systems, AI agents, and open source.",
     url: addUtmParams("https://blog.duyet.net", "about_page", "blog_card"),
     icon: BookOpen,
-    tone: "bg-[var(--background)]",
   },
 ];
 
@@ -136,24 +132,24 @@ function AboutPage() {
       <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
         <SiteHeader />
 
-      <main className="relative z-10 rounded-b-3xl bg-[var(--background)] pb-20 2xl:rounded-b-[4rem]">
-        <section className="mx-auto max-w-[1200px] px-6 py-12 sm:px-10 md:py-16 lg:py-20 xl:py-24">
-          <p className="mb-6 font-serif text-xl italic text-[var(--primary)] lg:text-2xl">
+      <main className="relative z-10 bg-[var(--background)] pb-16">
+        <section className="mx-auto max-w-[1180px] px-5 py-12 sm:px-8 md:py-16 lg:px-10 lg:py-20">
+          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
             About
           </p>
-          <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.55fr)] lg:items-end">
-            <div className="max-w-[880px] space-y-8">
-              <h1 className="font-serif text-5xl sm:text-6xl lg:text-[72px] xl:text-[84px]">
-                Building data and AI systems that <span className="text-[var(--primary)] italic">stay useful</span> in production.
+          <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(300px,0.55fr)] lg:items-end">
+            <div className="max-w-[780px] space-y-6">
+              <h1 className="text-balance text-4xl font-semibold leading-[1.08] sm:text-5xl lg:text-6xl">
+                Building data and AI systems that stay useful in production.
               </h1>
-              <p className="max-w-[680px] text-xl font-normal leading-relaxed text-[var(--body)] lg:text-2xl">
+              <p className="max-w-[680px] text-base leading-7 text-[var(--body)] sm:text-lg">
                 I’m a Senior Data & AI Engineer with {experienceYears} of experience across
                 modern data infrastructure, AI/ML platforms, distributed
                 systems, and cloud-native engineering.
               </p>
             </div>
 
-            <div className="space-y-6 text-lg font-normal leading-relaxed text-[var(--muted-foreground)] lg:text-xl">
+            <div className="space-y-4 text-base leading-7 text-[var(--muted-foreground)]">
               <p>
                 I care about systems that are easy to operate, easy to explain,
                 and boring in the places where reliability matters.
@@ -166,8 +162,8 @@ function AboutPage() {
           </div>
         </section>
 
-        <section className="mx-auto max-w-[1200px] px-6 sm:px-10">
-          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4 lg:gap-8">
+        <section className="mx-auto max-w-[1180px] px-5 sm:px-8 lg:px-10">
+          <div className="border-y border-[var(--hairline)]">
             {links.map((item) => {
               const Icon = item.icon;
               return (
@@ -176,15 +172,13 @@ function AboutPage() {
                   href={item.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`group flex min-h-[240px] flex-col rounded-2xl p-6 transition-all hover:-translate-y-2 hover:shadow-xl lg:min-h-[280px] lg:p-8 ${item.tone} border border-[var(--border)]`}
+                  className="group grid gap-4 border-t border-[var(--hairline)] py-5 text-[var(--foreground)] transition-colors first:border-t-0 hover:text-[var(--muted-foreground)] md:grid-cols-[32px_160px_1fr] md:items-start"
                 >
-                  <div className="flex items-start justify-between gap-6">
-                    <h2 className="font-serif text-2xl lg:text-[28px]">
-                      {item.title}
-                    </h2>
-                    <Icon className="h-8 w-8 shrink-0 lg:h-10 lg:w-10 opacity-30" />
-                  </div>
-                  <p className="mt-auto text-lg font-normal leading-snug text-[var(--body)] lg:text-xl">
+                  <Icon className="h-5 w-5 shrink-0 text-[var(--muted-foreground)] md:mt-1" />
+                  <h2 className="text-lg font-semibold">
+                    {item.title}
+                  </h2>
+                  <p className="text-sm leading-6 text-[var(--muted-foreground)]">
                     {item.description}
                   </p>
                 </a>
@@ -201,10 +195,10 @@ function AboutPage() {
           )}
         />
 
-        <section className="mx-auto mt-24 max-w-[1200px] px-6 pb-20 sm:px-10 lg:mt-32 lg:pb-32">
-          <div className="grid gap-5 rounded-xl bg-[var(--muted)] p-6 md:grid-cols-[1fr_auto] md:items-center lg:p-8">
+        <section className="mx-auto mt-14 max-w-[1180px] px-5 pb-16 sm:px-8 lg:px-10">
+          <div className="grid gap-5 border-y border-[var(--hairline)] py-6 md:grid-cols-[1fr_auto] md:items-center">
             <div className="flex items-start gap-4">
-              <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-[var(--foreground)] text-[var(--background)]">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center text-[var(--foreground)]">
                 <Radio className="h-5 w-5" />
               </span>
               <div>
@@ -225,7 +219,7 @@ function AboutPage() {
               )}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--foreground)] px-6 py-4 text-base font-medium text-[var(--background)] transition-colors hover:bg-[var(--foreground)]/80"
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-[var(--foreground)] px-5 py-3 text-sm font-medium text-[var(--background)] transition-colors hover:bg-[var(--foreground)]/80"
             >
               Read blog
               <ArrowRight className="h-5 w-5" />

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@duyet/libs/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   ArrowRight,
@@ -27,7 +26,6 @@ const capabilities = [
       "Deep dives into data engineering architecture, distributed systems, AI agents, and lessons learned from scaling open source.",
     href: addUtmParams("https://blog.duyet.net", "homepage", "blog_card"),
     icon: Newspaper,
-    className: "bg-cactus dark:bg-[#252320]",
   },
   {
     title: "Resume",
@@ -35,7 +33,6 @@ const capabilities = [
       "Scalable data infrastructure, intelligent applications, and production systems that stay fast as usage grows.",
     href: addUtmParams("https://cv.duyet.net", "homepage", "resume_card"),
     icon: FileUser,
-    className: "bg-oat dark:bg-[#1f1e1b]",
   },
   {
     title: "Insights",
@@ -47,7 +44,6 @@ const capabilities = [
       "insights_card"
     ),
     icon: ChartNoAxesCombined,
-    className: "bg-sky dark:bg-[#2a2824]",
   },
   {
     title: "About",
@@ -55,7 +51,6 @@ const capabilities = [
       "Clear project surfaces for Rust, ClickHouse, MCP tools, AI agents, and the small systems that make them useful.",
     href: "/about",
     icon: UserRound,
-    className: "bg-fig dark:bg-[#181715] text-white",
   },
 ];
 
@@ -71,28 +66,25 @@ function HomePage() {
 
         <main className="relative z-10">
           {/* Hero Section */}
-          <section className="mx-auto max-w-[var(--container-max-width)] px-6 py-16 sm:px-10 lg:px-[var(--page-margins)] lg:py-[var(--section-spacer-lg)]">
-            <div className="grid gap-[var(--gap-xl)] lg:grid-cols-2 lg:items-center">
+          <section className="mx-auto max-w-[1180px] px-5 py-14 sm:px-8 md:py-20 lg:px-10">
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)] lg:items-center">
               <div className="space-y-[var(--gap-md)]">
-                <div className="space-y-[var(--gap-xs)]">
-                  <p className="font-serif text-xl italic text-[var(--primary)] lg:text-2xl">
+                <div className="space-y-4">
+                  <p className="text-sm font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
                     Duyet Le
                   </p>
-                  <h1 className="font-serif text-5xl sm:text-6xl lg:text-[72px] xl:text-[84px] tracking-tight">
-                    Data Engineer & <br />
-                    <span className="text-[var(--primary)] italic">
-                      AI Agent Engineer
-                    </span>
+                  <h1 className="max-w-3xl text-balance text-4xl font-semibold leading-[1.06] sm:text-5xl lg:text-6xl">
+                    Data engineer building practical AI systems
                   </h1>
                 </div>
-                <p className="max-w-[var(--text-column-max-width)] text-xl leading-relaxed text-[var(--body)] lg:text-2xl">
+                <p className="max-w-2xl text-base leading-7 text-[var(--body)] sm:text-lg">
                   I build scalable data infrastructure and intelligent systems that
-                  feel human — engineered with clarity for production at scale.
+                  stay clear, useful, and reliable in production.
                 </p>
-                <div className="flex flex-wrap gap-4 pt-4">
+                <div className="flex flex-wrap gap-3 pt-2">
                   <Link
                     to="/about"
-                    className="inline-flex h-14 items-center justify-center rounded-xl bg-[var(--foreground)] px-8 text-lg font-medium text-[var(--background)] transition-all hover:opacity-90 active:scale-95"
+                    className="inline-flex h-11 items-center justify-center rounded-lg bg-[var(--foreground)] px-5 text-sm font-medium text-[var(--background)] transition-colors hover:bg-[var(--foreground)]/85"
                   >
                     About me
                   </Link>
@@ -104,39 +96,54 @@ function HomePage() {
                     )}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex h-14 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--background)] px-8 text-lg font-medium transition-all hover:bg-[var(--surface-card)] active:scale-95"
+                    className="inline-flex h-11 items-center justify-center px-1 text-sm font-medium underline underline-offset-4 transition-colors hover:text-[var(--muted-foreground)]"
                   >
                     GitHub
                   </a>
                 </div>
               </div>
               <div className="hidden lg:block">
-                 <div className="aspect-[4/3] rounded-[var(--radius-lg)] bg-clay p-16 flex items-center justify-center shadow-2xl relative overflow-hidden group">
-                    <div className="absolute inset-0 bg-black/5 opacity-0 group-hover:opacity-100 transition-opacity" />
-                    <span className="text-white opacity-20 font-serif text-[160px] select-none">✱</span>
-                 </div>
+                <div className="border-y border-[var(--hairline)] py-2">
+                  {[
+                    ["Data systems", "Pipelines, warehouses, observability"],
+                    ["AI products", "Agents, routing, evaluation"],
+                    ["Open source", "Rust, TypeScript, Cloudflare"],
+                  ].map(([label, value]) => (
+                    <div
+                      key={label}
+                      className="grid grid-cols-[140px_1fr] gap-8 border-t border-[var(--hairline)] py-4 first:border-t-0"
+                    >
+                      <p className="text-sm font-semibold text-[var(--foreground)]">
+                        {label}
+                      </p>
+                      <p className="text-sm text-[var(--muted-foreground)]">
+                        {value}
+                      </p>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </section>
 
           {/* Capabilities Section */}
-          <section className="mx-auto max-w-[var(--container-max-width)] px-6 py-12 sm:px-10 lg:px-[var(--page-margins)] lg:py-20">
-            <div className="mb-[var(--gap-lg)]">
-              <h2 className="font-serif text-4xl sm:text-5xl lg:text-[56px] tracking-tight">
-                Network.
+          <section className="mx-auto max-w-[1180px] px-5 py-10 sm:px-8 lg:px-10 lg:py-14">
+            <div className="mb-6">
+              <h2 className="text-2xl font-semibold sm:text-3xl">
+                Network
               </h2>
             </div>
 
-            <div className="grid grid-cols-1 gap-[var(--gap-md)] md:grid-cols-2 lg:gap-[var(--gap-lg)]">
+            <div className="border-y border-[var(--hairline)]">
               {capabilities.map((item) => (
-                <CapabilityCard key={item.title} {...item} />
+                <CapabilityRow key={item.title} {...item} />
               ))}
             </div>
           </section>
 
           {/* WorkStack Band */}
-          <section className="bg-[var(--background-secondary)] py-16 lg:py-[var(--section-spacer-lg)]">
-            <div className="mx-auto max-w-[var(--container-max-width)] px-6 sm:px-10 lg:px-[var(--page-margins)]">
+          <section className="border-y border-[var(--hairline)] bg-[var(--background-secondary)] py-12 lg:py-16">
+            <div className="mx-auto max-w-[1180px] px-5 sm:px-8 lg:px-10">
               <WorkStackSection
                 repositoryUrl={addUtmParams(
                   "https://github.com/duyet",
@@ -150,45 +157,45 @@ function HomePage() {
           {/* Apps Section */}
           <section
             id="apps"
-            className="mx-auto max-w-[var(--container-max-width)] px-6 py-12 sm:px-10 lg:px-[var(--page-margins)] lg:py-20"
+            className="mx-auto max-w-[1180px] px-5 py-10 sm:px-8 lg:px-10 lg:py-14"
           >
-            <div className="mb-[var(--gap-lg)] flex flex-col justify-between gap-4 md:flex-row md:items-end">
+            <div className="mb-6 flex flex-col justify-between gap-4 md:flex-row md:items-end">
               <div>
-                <h2 className="font-serif text-4xl sm:text-5xl lg:text-[56px] tracking-tight">
-                  Apps.
+                <h2 className="text-2xl font-semibold sm:text-3xl">
+                  Apps
                 </h2>
-                <p className="mt-4 max-w-xl text-lg font-medium text-[var(--muted-foreground)] lg:text-xl">
+                <p className="mt-3 max-w-xl text-sm leading-6 text-[var(--muted-foreground)] sm:text-base">
                   A curated collection of production tools, experimental
                   interfaces, and data systems managed by <span className="text-[var(--foreground)]">@duyetbot</span>.
                 </p>
               </div>
             </div>
 
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-1 gap-x-10 border-y border-[var(--hairline)] md:grid-cols-2 lg:grid-cols-3">
               {apps.map((item) => (
                 <AppRow key={item.name} item={item} />
               ))}
             </div>
 
-            <div className="mt-12 flex justify-center">
+            <div className="mt-8 flex justify-start">
               <Link
                 to="/projects"
-                className="group inline-flex items-center gap-2 font-serif text-xl hover:text-[var(--primary)] transition-colors lg:text-2xl"
+                className="group inline-flex items-center gap-2 text-sm font-semibold text-[var(--foreground)] transition-colors hover:text-[var(--muted-foreground)]"
               >
-                View all artifacts
-                <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+                View all projects
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
               </Link>
             </div>
           </section>
 
           {/* Contact Section */}
-          <section className="mx-auto max-w-[var(--container-max-width)] px-6 py-12 sm:px-10 lg:px-[var(--page-margins)] lg:py-20">
+          <section className="mx-auto max-w-[1180px] px-5 py-10 sm:px-8 lg:px-10 lg:py-14">
             <div className="flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
               <div className="max-w-xl">
-                <h2 className="font-serif text-4xl sm:text-5xl lg:text-[56px] tracking-tight">
-                  Let’s build.
+                <h2 className="text-2xl font-semibold sm:text-3xl">
+                  Let’s build
                 </h2>
-                <p className="mt-4 text-xl text-[var(--muted-foreground)] lg:text-2xl">
+                <p className="mt-3 text-base leading-7 text-[var(--muted-foreground)]">
                   Interested in data infrastructure, AI agents, or open source
                   collaboration? I’m always open to discussing new projects and
                   ideas.
@@ -197,7 +204,7 @@ function HomePage() {
               <div className="flex flex-wrap gap-4">
                 <a
                   href="mailto:me@duyet.net"
-                  className="inline-flex h-14 items-center justify-center rounded-xl bg-[var(--foreground)] px-8 text-lg font-medium text-[var(--background)] transition-all hover:opacity-90 hover:shadow-lg active:scale-95"
+                  className="inline-flex h-11 items-center justify-center rounded-lg bg-[var(--foreground)] px-5 text-sm font-medium text-[var(--background)] transition-colors hover:bg-[var(--foreground)]/85"
                 >
                   Send an email
                 </a>
@@ -205,7 +212,7 @@ function HomePage() {
                   href="https://linkedin.com/in/duyet"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex h-14 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--background)] px-8 text-lg font-medium transition-all hover:bg-[var(--surface-card)] active:scale-95"
+                  className="inline-flex h-11 items-center justify-center px-1 text-sm font-medium underline underline-offset-4 transition-colors hover:text-[var(--muted-foreground)]"
                 >
                   LinkedIn
                 </a>
@@ -213,21 +220,21 @@ function HomePage() {
             </div>
           </section>
 
-          {/* Footer Callout (Coral Band) */}
-          <section className="mx-auto max-w-[var(--container-max-width)] px-6 pb-20 sm:px-10 lg:px-[var(--page-margins)]">
+          <section className="mx-auto max-w-[1180px] px-5 pb-16 sm:px-8 lg:px-10">
             <Link
               to="/ls"
-              className="group flex flex-col items-center justify-center overflow-hidden rounded-[var(--radius-lg)] bg-[var(--primary)] px-10 py-16 text-center text-white transition-all hover:scale-[1.01] active:scale-[0.99] lg:py-24"
+              className="group flex flex-col justify-between gap-6 border-y border-[var(--hairline)] py-8 text-[var(--foreground)] transition-colors hover:text-[var(--muted-foreground)] md:flex-row md:items-center"
             >
-              <h3 className="font-serif text-4xl sm:text-6xl lg:text-[72px] tracking-tight">
-                duyet.net/ls
-              </h3>
-              <p className="mt-6 max-w-lg text-lg text-white/90 lg:text-xl">
-                Browse the complete directory of redirects, short URLs, and
-                connected apps in the network.
-              </p>
-              <div className="mt-10 flex h-14 w-14 items-center justify-center rounded-full bg-white text-[var(--primary)] transition-transform group-hover:rotate-45">
-                <ArrowRight className="h-7 w-7" />
+              <div>
+                <h3 className="text-2xl font-semibold sm:text-3xl">
+                  duyet.net/ls
+                </h3>
+                <p className="mt-2 max-w-lg text-sm leading-6 text-[var(--muted-foreground)]">
+                  Browse redirects, short URLs, and connected apps in the network.
+                </p>
+              </div>
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center transition-transform group-hover:translate-x-1">
+                <ArrowRight className="h-5 w-5" />
               </div>
             </Link>
           </section>
@@ -247,16 +254,16 @@ function AppRow({
   return (
     <AppLink
       item={item}
-      className="group flex items-start gap-4 rounded-xl border border-[var(--border)] p-5 transition-all hover:bg-[var(--surface-soft)] hover:shadow-md"
+      className="group flex items-start gap-4 border-t border-[var(--hairline)] py-5 text-[var(--foreground)] transition-colors first:border-t-0 hover:text-[var(--muted-foreground)]"
     >
-      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-[var(--background)] text-[var(--foreground)] shadow-sm ring-1 ring-[var(--border)] group-hover:bg-[var(--primary)] group-hover:text-white transition-all group-hover:scale-110">
-        <Server className="h-6 w-6" />
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center text-[var(--muted-foreground)]">
+        <Server className="h-4 w-4" />
       </div>
-      <div className="min-w-0 pt-1">
-        <h3 className="font-serif text-xl leading-snug tracking-tight group-hover:text-[var(--primary)] transition-colors">
+      <div className="min-w-0">
+        <h3 className="text-base font-semibold leading-snug">
           {item.name}
         </h3>
-        <p className="mt-2 text-[15px] font-normal leading-relaxed text-[var(--muted-foreground)] line-clamp-2">
+        <p className="mt-1 text-sm leading-6 text-[var(--muted-foreground)] line-clamp-2">
           {item.description}
         </p>
       </div>
@@ -264,39 +271,32 @@ function AppRow({
   );
 }
 
-function CapabilityCard({
+function CapabilityRow({
   title,
   description,
   href,
   icon: Icon,
-  className,
 }: {
   title: string;
   description: string;
   href: string;
   icon: typeof Newspaper;
-  className: string;
 }) {
   const isExternal = href.startsWith("http");
   const children = (
-    <div className="flex h-full flex-col justify-between p-8 lg:p-10">
-      <div className="flex items-start justify-between gap-4">
-        <Icon className="h-8 w-8 shrink-0 lg:h-10 lg:w-10 text-current opacity-20" />
-        <span className="font-serif text-xl opacity-40">0{title === "Blog" ? 1 : title === "Resume" ? 2 : title === "Insights" ? 3 : 4}</span>
+    <div className="grid gap-4 py-6 md:grid-cols-[32px_180px_1fr] md:items-start">
+      <div className="pt-1">
+        <Icon className="h-5 w-5 shrink-0 text-[var(--muted-foreground)]" />
       </div>
-      <div className="mt-12">
-        <h3 className="font-serif text-2xl lg:text-[32px] tracking-tight">{title}</h3>
-        <p className="mt-3 text-lg font-normal leading-snug text-current opacity-80 lg:text-xl">
-          {description}
-        </p>
-      </div>
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <p className="text-sm leading-6 text-[var(--muted-foreground)]">
+        {description}
+      </p>
     </div>
   );
 
-  const classes = cn(
-    "flex min-h-[240px] flex-col rounded-2xl transition-all hover:-translate-y-2 hover:shadow-xl lg:min-h-[280px]",
-    className
-  );
+  const classes =
+    "block border-t border-[var(--hairline)] text-[var(--foreground)] transition-colors first:border-t-0 hover:text-[var(--muted-foreground)]";
 
   if (isExternal) {
     return (

--- a/apps/home/src/routes/ls.tsx
+++ b/apps/home/src/routes/ls.tsx
@@ -34,8 +34,7 @@ const publicUrls = Object.entries(urls)
 function ListPage() {
   return (
     <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
-      <main className="mx-auto max-w-[1024px] px-4 pb-16 pt-12">
-        {/* Header */}
+      <main className="mx-auto max-w-[1024px] px-5 pb-16 pt-12 sm:px-8">
         <div className="mb-10">
           <a
             href="/"
@@ -47,7 +46,7 @@ function ListPage() {
             Back to home
           </a>
           <div className="flex items-baseline gap-4">
-            <h1 className="m-0 font-[family-name:var(--font-serif)] text-5xl font-normal tracking-tight text-[var(--foreground)]">
+            <h1 className="m-0 text-4xl font-semibold text-[var(--foreground)] sm:text-5xl">
               Short URLs
             </h1>
             <span className="text-[13px] text-[var(--muted-soft)]">
@@ -59,10 +58,8 @@ function ListPage() {
           </p>
         </div>
 
-        {/* Client-side search and list */}
         <UrlsList urls={publicUrls} />
 
-        {/* Footer link */}
         <div className="mt-16 text-center">
           <a
             href="/"

--- a/apps/home/src/routes/p/$project.tsx
+++ b/apps/home/src/routes/p/$project.tsx
@@ -108,8 +108,8 @@ function ProductPage() {
     <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       <SiteHeader />
 
-      <main className="relative z-10 rounded-b-3xl bg-[var(--background)] pb-16 2xl:rounded-b-[4rem]">
-        <section className="mx-auto max-w-[1340px] px-5 py-12 sm:px-8 md:py-16 lg:px-10 lg:py-24 xl:py-28">
+      <main className="relative z-10 bg-[var(--background)] pb-16">
+        <section className="mx-auto max-w-[1180px] px-5 py-12 sm:px-8 md:py-16 lg:px-10">
           <Link
             to="/"
             className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
@@ -121,32 +121,32 @@ function ProductPage() {
             <p className="text-sm font-medium text-[var(--muted-foreground)]">
               {product.eyebrow}
             </p>
-            <h1 className="text-5xl font-semibold tracking-tight sm:text-6xl lg:text-7xl xl:text-8xl">
+            <h1 className="text-4xl font-semibold leading-[1.08] sm:text-5xl lg:text-6xl">
               {product.name}
             </h1>
-            <p className="max-w-[580px] text-lg leading-7 lg:text-xl">
+            <p className="max-w-[580px] text-base leading-7 text-[var(--muted-foreground)] sm:text-lg">
               {product.summary}
             </p>
           </div>
         </section>
 
-        <section className="mx-auto max-w-[1340px] px-5 sm:px-8 lg:px-10">
+        <section className="mx-auto max-w-[1180px] px-5 sm:px-8 lg:px-10">
           <img
             src={product.image}
             alt={`${product.name} product screenshot`}
-            className="aspect-[4/3] w-full rounded-lg bg-[#050505] object-cover sm:aspect-[6/4] lg:aspect-[5/3] xl:rounded-xl"
+            className="aspect-[4/3] w-full bg-[#050505] object-cover sm:aspect-[6/4] lg:aspect-[5/3]"
           />
         </section>
 
-        <section className="mx-auto mt-16 max-w-[1340px] px-5 sm:px-8 md:mt-20 lg:mt-24 lg:px-10">
+        <section className="mx-auto mt-14 max-w-[1180px] px-5 sm:px-8 lg:px-10">
           <div className="space-y-4 lg:space-y-6">
-            <h2 className="text-lg lg:text-xl">About {product.name}</h2>
-            <p className="max-w-[1180px] text-2xl font-semibold tracking-tight sm:text-3xl md:text-4xl xl:text-5xl">
+            <h2 className="text-lg font-semibold">About {product.name}</h2>
+            <p className="max-w-[900px] text-xl font-semibold leading-snug sm:text-2xl md:text-3xl">
               {product.overview}
             </p>
           </div>
 
-          <div className="my-12 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4 lg:mt-16 lg:gap-6 xl:mt-20 xl:gap-8">
+          <div className="my-10 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
             <Meta label="Product" value={product.name} />
             <Meta label="Industry" value={product.industry} />
             <Meta label="Role" value={product.role} />
@@ -154,14 +154,14 @@ function ProductPage() {
           </div>
 
           <div className="space-y-4 lg:space-y-6">
-            <h2 className="text-lg lg:text-xl">Highlights</h2>
-            <div className="grid gap-4 md:grid-cols-3 lg:gap-6 xl:gap-8">
+            <h2 className="text-lg font-semibold">Highlights</h2>
+            <div className="border-y border-[var(--hairline)]">
               {product.highlights.map((highlight) => (
                 <div
                   key={highlight}
-                  className="rounded-lg border border-[var(--border)] bg-[var(--background)] p-5"
+                  className="border-t border-[var(--hairline)] py-4 first:border-t-0"
                 >
-                  <p className="text-base font-semibold leading-snug md:text-lg">
+                  <p className="text-sm font-medium leading-6 md:text-base">
                     {highlight}
                   </p>
                 </div>
@@ -169,7 +169,7 @@ function ProductPage() {
             </div>
           </div>
 
-          <div className="my-12 flex justify-center lg:my-16">
+          <div className="my-10 flex justify-start">
             <a
               href={addUtmParams(
                 product.url,
@@ -178,7 +178,7 @@ function ProductPage() {
               )}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg bg-[var(--foreground)] px-6 py-4 text-base font-medium text-[var(--background)] transition-colors hover:bg-[var(--foreground)]/80 md:text-lg"
+              className="inline-flex items-center gap-2 rounded-lg bg-[var(--foreground)] px-5 py-3 text-sm font-medium text-[var(--background)] transition-colors hover:bg-[var(--foreground)]/80"
             >
               Visit project
               <ExternalLink className="h-5 w-5" />
@@ -186,27 +186,28 @@ function ProductPage() {
           </div>
         </section>
 
-        <section className="mx-auto mt-20 max-w-[1340px] px-5 sm:px-8 lg:mt-28 lg:px-10 xl:mt-32">
-          <h2 className="text-3xl font-semibold tracking-tight md:text-4xl xl:text-5xl">
+        <section className="mx-auto mt-16 max-w-[1180px] px-5 sm:px-8 lg:px-10">
+          <h2 className="text-2xl font-semibold md:text-3xl">
             More projects
           </h2>
-          <div className="mt-10 grid grid-cols-1 gap-4 md:grid-cols-2 lg:gap-6 xl:mt-16 xl:gap-8">
+          <div className="mt-6 border-y border-[var(--hairline)]">
             {related.map((item) => (
               <Link
                 key={item.slug}
                 to="/p/$project"
                 params={{ project: item.slug }}
-                className="group relative overflow-hidden rounded-lg bg-[#050505]"
+                className="group grid gap-4 border-t border-[var(--hairline)] py-5 text-[var(--foreground)] first:border-t-0 hover:text-[var(--muted-foreground)] sm:grid-cols-[180px_1fr] sm:items-center"
               >
                 <img
                   src={item.image}
                   alt=""
-                  className="aspect-[4/3] w-full object-cover opacity-75 transition-transform duration-500 group-hover:scale-[1.025] sm:aspect-[6/4]"
+                  className="aspect-[16/9] w-full bg-[#050505] object-cover object-top"
                 />
-                <div className="absolute inset-0 bg-gradient-to-b from-black/70 to-transparent" />
-                <div className="absolute left-6 top-6 z-10 text-white lg:left-8 lg:top-8">
-                  <p className="text-xl font-medium">{item.name}</p>
-                  <p className="text-sm opacity-80">{item.eyebrow}</p>
+                <div>
+                  <p className="text-lg font-semibold">{item.name}</p>
+                  <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                    {item.eyebrow}
+                  </p>
                 </div>
               </Link>
             ))}

--- a/apps/home/src/routes/projects.tsx
+++ b/apps/home/src/routes/projects.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowLeft, ArrowRight } from "lucide-react";
 import type { ReactNode } from "react";
 import { addUtmParams } from "../../app/lib/utm";
 import { SiteFooter, SiteHeader } from "../components/SiteChrome";
@@ -24,36 +23,21 @@ function ProjectsPage() {
     <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       <SiteHeader />
 
-      <main className="mx-auto max-w-[1280px] px-5 pb-20 pt-10 sm:px-8 md:pt-16 lg:px-10">
-        <Link
-          to="/"
-          className="mb-10 inline-flex items-center gap-2 text-sm font-medium text-[var(--muted-foreground)] transition-colors hover:text-[var(--foreground)]"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back home
-        </Link>
-
-        <section className="max-w-3xl">
-          <p className="mb-3 text-sm font-medium text-[var(--muted-foreground)]">
-            Projects
-          </p>
-          <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
-            Apps, tools, dashboards, and open source systems.
+      <main className="mx-auto max-w-[1180px] px-5 pb-20 pt-12 sm:px-8 md:pt-16 lg:px-10">
+        <section className="grid gap-8 md:grid-cols-[minmax(0,2fr)_minmax(220px,1fr)] md:items-start">
+          <h1 className="text-balance text-4xl font-semibold leading-[1.08] sm:text-5xl lg:text-6xl">
+            Apps, tools, dashboards, and open source systems
           </h1>
-          <p className="mt-5 max-w-2xl text-base font-medium leading-7 text-[var(--muted-foreground)]">
+          <p className="max-w-sm text-base leading-7 text-[var(--muted-foreground)] md:pt-2">
             A complete list of public project surfaces across data engineering,
             AI infrastructure, analytics, developer tooling, and writing.
           </p>
         </section>
 
-        <section className="mt-12 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3 lg:gap-6 xl:mt-16 xl:gap-8">
-          {apps.map((item, index) =>
-            item.screenshot ? (
-              <ProjectCard key={item.name} item={item} />
-            ) : (
-              <CompactProjectCard key={item.name} item={item} />
-            )
-          )}
+        <section className="mt-12 grid grid-cols-1 gap-x-10 gap-y-8 border-t border-[var(--hairline)] pt-8 sm:grid-cols-2 lg:grid-cols-3">
+          {apps.map((item) => (
+            <ProjectIndexItem key={item.name} item={item} />
+          ))}
         </section>
       </main>
       <SiteFooter />
@@ -61,7 +45,7 @@ function ProjectsPage() {
   );
 }
 
-function ProjectCard({
+function ProjectIndexItem({
   item,
 }: {
   item: AppItem;
@@ -69,47 +53,19 @@ function ProjectCard({
   return (
     <ProjectLink
       item={item}
-      className={`group overflow-hidden rounded-xl border border-[var(--border)] ${item.tone ?? "bg-[var(--foreground)]"} transition-transform hover:-translate-y-0.5`}
+      className="group block min-w-0 rounded-md text-[var(--foreground)] no-underline outline-none hover:no-underline focus-visible:ring-2 focus-visible:ring-[var(--foreground)]/30"
     >
-      <div className="overflow-hidden bg-[var(--foreground)]">
-        <img
-          src={item.screenshot}
-          alt={item.name}
-          loading="lazy"
-          className="aspect-[16/10] w-full object-cover object-top transition-transform duration-500 group-hover:scale-[1.025]"
-        />
-      </div>
-      <div className="p-5 text-white">
-        <h2 className="text-lg font-semibold tracking-tight">{item.name}</h2>
-        <p className="mt-2 text-sm font-medium leading-6 text-white/80">
+      <article className="min-w-0">
+        <h2 className="w-fit max-w-full text-xl font-semibold leading-7 transition-colors group-hover:text-[var(--muted-foreground)]">
+          <span className="break-words">{item.name}</span>
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-[var(--muted-foreground)]">
           {item.description}
         </p>
-        <p className="mt-5 truncate text-sm font-medium text-white/60">
+        <p className="mt-3 truncate font-mono text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--muted-soft)]">
           {item.host}
         </p>
-      </div>
-    </ProjectLink>
-  );
-}
-
-function CompactProjectCard({
-  item,
-}: {
-  item: AppItem;
-}) {
-  return (
-    <ProjectLink
-      item={item}
-      className="group flex min-h-44 flex-col rounded-xl border border-[var(--border)] bg-[var(--background)] p-5 transition-colors"
-    >
-      <h2 className="text-lg font-semibold tracking-tight">{item.name}</h2>
-      <p className="mt-2 text-sm font-medium leading-6 text-[var(--muted-foreground)]">
-        {item.description}
-      </p>
-      <div className="mt-auto flex items-center justify-between gap-4 pt-8 text-sm font-medium text-[var(--muted-foreground)]">
-        <span className="truncate">{item.host}</span>
-        <ArrowRight className="h-5 w-5 shrink-0 transition-transform group-hover:translate-x-1" />
-      </div>
+      </article>
     </ProjectLink>
   );
 }

--- a/apps/home/tailwind.config.js
+++ b/apps/home/tailwind.config.js
@@ -14,21 +14,17 @@ module.exports = {
     ...config.theme,
     extend: {
       ...config.theme?.extend,
-      // Claude's color palette and card colors are now defined in shared config:
-      // - @duyet/tailwind-config/claude.theme.js (claude-*, claude-gray-*)
-      // - @duyet/tailwind-config/colors.js (ivory, oat, cream, cactus, sage, lavender, terracotta, coral)
-      // All colors are automatically available via config.theme?.extend?.colors
       colors: {
         ...config.theme?.extend?.colors,
       },
       fontFamily: {
         sans: ["var(--font-inter)", "system-ui", "sans-serif"],
-        serif: ["var(--font-serif)", "Georgia", "serif"],
+        serif: ["var(--font-inter)", "system-ui", "sans-serif"],
       },
     },
   },
   safelist: [
-    // Card color backgrounds
+    // Legacy color backgrounds
     "bg-ivory",
     "bg-oat-light",
     "bg-cream",


### PR DESCRIPTION
## Summary
- Simplify `apps/home` visual system to reduce card-heavy/shadcn-like surfaces
- Convert home/about/project/link surfaces to divider-based rows and simpler text-led sections
- Keep mobile layouts responsive, add missing favicon, and suppress theme-managed HTML hydration warnings

## Verification
- `bunx biome lint apps/home/src/routes/index.tsx apps/home/src/routes/about.tsx apps/home/src/routes/projects.tsx 'apps/home/src/routes/p/$project.tsx' apps/home/src/components/WorkStackSection.tsx apps/home/src/components/UrlsList.tsx apps/home/src/components/HomeAgentsChat.tsx apps/home/src/globals.css apps/home/tailwind.config.js`
- `bun run check-types` from `apps/home`
- `bun run build` from `apps/home`
- Browser QA: checked `/`, `/about`, `/projects`, `/ls`, and `/p/anyrouter` at 320, 390, 768, and 1440 widths with no horizontal overflow

## Notes
- Unrelated local `apps/blog` changes were left unstaged and are not part of this PR.
- Local build still prints existing warnings for Vite tsconfig paths, gray-matter eval, chunk size, and missing local Clerk env.
