### PR TITLE
feat(ui): refine home and blog UI

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,46 @@
+# Public App Design Direction
+
+Use this note when refreshing public apps such as `apps/home` and `apps/blog`.
+Keep the product content, routes, data loading, auth, and app workflows intact.
+
+## Direction
+
+- Keep the interface simple, editorial, and quiet.
+- Prefer white backgrounds with near-black text.
+- Use one primary sans font stack: `Inter, ui-sans-serif, system-ui, sans-serif`.
+- Avoid serif/display font pairings unless the app already depends on them.
+- Avoid Anthropic-style cream surfaces, oversized bento blocks, and decorative
+  warm palettes.
+- Avoid shadcn-looking UI: no generic rounded cards, soft shadows, heavy
+  component chrome, or nested card layouts.
+- Use restrained borders and line-based grouping before boxed panels.
+- Use compact controls with 8px radius where a bordered control is needed.
+- Keep accent color rare. Primary actions should usually be black or near-black.
+
+## Layout
+
+- Start with the real app content, not a marketing landing page.
+- Use left-aligned page headers with clear hierarchy.
+- Keep sections full-width or simply constrained. Do not place cards inside
+  cards.
+- For lists, prefer rows separated by thin borders.
+- For grids, prefer simple bordered tiles with no shadow and minimal padding.
+- Keep copy short and scannable. Do not use large feature-card descriptions.
+
+## Mobile
+
+- Test around 390px width before finishing.
+- No horizontal overflow. Check:
+  `document.documentElement.scrollWidth - document.documentElement.clientWidth`.
+- Use `min-w-0`, `break-words`, `truncate`, or responsive wrapping for long
+  titles, tags, URLs, dates, and labels.
+- Keep grids as one column on mobile, then add columns only where content stays
+  readable.
+- Avoid fixed-height blocks that can clip translated or long text.
+
+## App Notes
+
+- `apps/home`: minimal editorial homepage, simple app/project lists, black
+  controls, restrained spacing, and mobile-safe navigation.
+- `apps/blog`: white page, single sans typography, line-based post lists,
+  bordered topic/category tiles, and no card-heavy archive/search surfaces.

--- a/apps/blog/app/globals.css
+++ b/apps/blog/app/globals.css
@@ -20,11 +20,12 @@
   }
 }
 
-/* Design system tokens — Anthropic warm cream palette */
+/* Blog design tokens */
 :root {
   --font-inter: "Inter Variable", "Inter", -apple-system, BlinkMacDesktopFont,
     ui-sans-serif, system-ui, sans-serif;
-  --font-serif: Garamond, "Apple Garamond", "EB Garamond", serif;
+  --font-serif: var(--font-inter);
+  --font-mono: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
 
   /* Spacing & Radius Scale */
   --radius-xs: 8px;
@@ -64,26 +65,26 @@
   --body-4: 12px;
 
   /* Base Palette */
-  --background: #faf9f5;
+  --background: #ffffff;
   --foreground: #141413;
   
-  /* Anthropic Ivory Theme */
+  /* Neutral light theme */
   --foreground-primary: #141413;
   --foreground-secondary: #30302e;
   --foreground-tertiary: #5e5d59;
-  --background-primary: #faf9f5;
-  --background-secondary: #f0eee6;
-  --background-tertiary: #e8e6dc;
+  --background-primary: #ffffff;
+  --background-secondary: #f7f7f5;
+  --background-tertiary: #efefec;
   --background-clay: #d97757;
-  --background-oat: #e3dacc;
+  --background-oat: #ededeb;
   
   --border-strong: #141413;
-  --border-subtle: #d1cfc5;
-  --border-faint: #f0eee6;
+  --border-subtle: #d8d8d3;
+  --border-faint: #eeeeea;
 
   /* Surface hierarchy */
-  --surface-soft: #f5f0e8;
-  --surface-card: #efe9de;
+  --surface-soft: #f7f7f5;
+  --surface-card: #ffffff;
   --surface-dark: #181715;
   --surface-dark-elevated: #252320;
 
@@ -100,9 +101,9 @@
   --on-dark-soft: #a09d96;
 
   /* Primary / Coral */
-  --primary: #cc785c;
-  --primary-active: #a9583e;
-  --primary-disabled: #e6dfd8;
+  --primary: #141413;
+  --primary-active: #30302e;
+  --primary-disabled: #d8d8d3;
 
   /* Legacy aliases */
   --muted-foreground: #6c6a64;
@@ -161,16 +162,16 @@ body {
 }
 
 h1, h2, h3, h4, h5, .font-serif {
-  font-family: var(--font-serif);
-  font-weight: 400;
+  font-family: var(--font-inter);
+  font-weight: 600;
 }
 
-h1 { letter-spacing: -1.5px; }
-h2 { letter-spacing: -1px; }
-h3 { letter-spacing: -0.5px; }
-h4 { letter-spacing: -0.3px; }
+h1 { letter-spacing: -0.025em; }
+h2 { letter-spacing: -0.018em; }
+h3 { letter-spacing: -0.012em; }
+h4 { letter-spacing: -0.008em; }
 
-/* Anthropic Utility Classes */
+/* Neutral utility aliases */
 .bg-slate-1000 { background-color: #0f0f0e!important }
 .bg-slate-950 { background-color: #141413!important }
 .bg-slate-900 { background-color: #1a1918!important }
@@ -187,7 +188,7 @@ h4 { letter-spacing: -0.3px; }
 .bg-fig { background-color: var(--bg-fig)!important }
 .bg-coral { background-color: var(--bg-coral)!important }
 
-/* Warm code styling — cream surfaces */
+/* Code styling */
 .prose :where(code):not(:where(pre code)) {
   background-color: var(--surface-card) !important;
   color: var(--body) !important;
@@ -340,4 +341,3 @@ html.dark .prose pre {
   outline: 2px solid var(--primary);
   outline-offset: 2px;
 }
-

--- a/apps/blog/components/blog/search-client.tsx
+++ b/apps/blog/components/blog/search-client.tsx
@@ -1,7 +1,6 @@
 import type { CategoryCount, Post, TagCount } from "@duyet/interfaces";
 import { useMemo } from "react";
 import { useSearch } from "@tanstack/react-router";
-import type { SearchParams } from "@/src/routes/search";
 import { SearchBar, SearchFilters, SearchResultItem } from "@/components/blog";
 
 const DEFAULT_INITIAL_POST_COUNT = 20;
@@ -139,7 +138,7 @@ export function SearchClient({ posts, categories, tags }: SearchClientProps) {
       <div className="flex flex-1 flex-col gap-6">
         <SearchBar placeholder="Search by title, category, or tags..." />
 
-        <div className="surface-card-base surface-card-warm flex flex-col gap-4 p-4 lg:p-5">
+        <div className="flex flex-col gap-4 border-y border-[var(--border-faint)] py-4 lg:py-5">
           {hasFilters && (
             <p className="text-sm text-[#1a1a1a]/75 dark:text-[#f8f8f2]/75">
               Found {sortedPosts.length}{" "}

--- a/apps/blog/components/blog/search-result-item.tsx
+++ b/apps/blog/components/blog/search-result-item.tsx
@@ -46,7 +46,7 @@ export function SearchResultItem({
   return (
     <article
       className={cn(
-        "surface-card-base surface-card-warm group flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:gap-4",
+        "group flex flex-col gap-3 border-t border-[var(--border-faint)] py-4 first:border-t-0 sm:flex-row sm:items-center sm:gap-4",
         className
       )}
     >

--- a/apps/blog/components/layout/BlogHeader.tsx
+++ b/apps/blog/components/layout/BlogHeader.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@duyet/libs/utils";
+import type { ReactNode } from "react";
+
+interface BlogHeaderProps {
+  eyebrow?: string;
+  title: string;
+  titleEmphasis?: string;
+  intro: ReactNode;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function BlogHeader({
+  eyebrow = "Blog",
+  title,
+  titleEmphasis,
+  intro,
+  children,
+  className,
+}: BlogHeaderProps) {
+  return (
+    <header className={cn("masthead", className)}>
+      <div className="eyebrow">{eyebrow}</div>
+      <h1>
+        {title}
+        {titleEmphasis && <em> {titleEmphasis}</em>}
+      </h1>
+      <div className="intro">{intro}</div>
+      {children}
+    </header>
+  );
+}

--- a/apps/blog/components/layout/BlogPillNav.tsx
+++ b/apps/blog/components/layout/BlogPillNav.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@duyet/libs/utils";
+import { Link } from "@tanstack/react-router";
+
+export interface PillNavItem {
+  label: string;
+  href: string;
+  count?: number;
+  isActive?: boolean;
+}
+
+interface BlogPillNavProps {
+  items: PillNavItem[];
+  className?: string;
+}
+
+export function BlogPillNav({ items, className }: BlogPillNavProps) {
+  return (
+    <nav className={cn("pill-nav", className)}>
+      {items.map((item) => {
+        const isExternal = item.href.startsWith("http");
+
+        if (isExternal) {
+          return (
+            <a
+              key={item.label}
+              href={item.href}
+              className={cn(item.isActive && "pill-active")}
+            >
+              {item.label}
+              {item.count !== undefined && (
+                <span className="pill-count">{item.count}</span>
+              )}
+            </a>
+          );
+        }
+
+        return (
+          <Link
+            key={item.label}
+            to={item.href}
+            className={cn(item.isActive && "pill-active")}
+          >
+            {item.label}
+            {item.count !== undefined && (
+              <span className="pill-count">{item.count}</span>
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/blog/components/layout/HeroBanner.tsx
+++ b/apps/blog/components/layout/HeroBanner.tsx
@@ -3,7 +3,7 @@ import { BackLink } from "../ui/BackLink";
 interface HeroBannerProps {
   title: string;
   description: string;
-  colorClass: string;
+  colorClass?: string;
   postCount: number;
   yearCount: number;
   backLinkHref: string;
@@ -19,59 +19,29 @@ export function HeroBanner({
   backLinkHref,
   backLinkText,
 }: HeroBannerProps) {
+  void colorClass;
+
   return (
-    <div
-      className={`${colorClass} mb-12 rounded-xl border border-[var(--hairline)] p-6 dark:border-white/10 sm:p-8 md:p-10`}
-    >
+    <div className="blog-page-head mb-12 border-b border-[var(--border-faint)] pb-8">
       <div className="mb-4">
         <BackLink href={backLinkHref} text={backLinkText} />
       </div>
 
-      <h1 className="mb-5 text-4xl font-semibold tracking-tight text-[var(--foreground)] dark:text-[var(--on-dark)] md:text-5xl">
+      <h1 className="mb-5 text-4xl font-semibold tracking-tight text-[var(--foreground)] dark:text-[var(--on-dark)] sm:text-5xl">
         {title}
       </h1>
 
-      <p className="mb-6 max-w-2xl text-sm leading-6 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/75 sm:text-base">
+      <p className="mb-6 max-w-2xl text-base leading-7 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/75">
         {description}
       </p>
 
-      <div className="flex flex-wrap gap-4 text-sm font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
-        <div className="flex items-center gap-2">
-          <svg
-            className="h-5 w-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-            />
-          </svg>
-          <span>
-            {postCount} {postCount === 1 ? "post" : "posts"}
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <svg
-            className="h-5 w-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-            />
-          </svg>
-          <span>
-            {yearCount} {yearCount === 1 ? "year" : "years"}
-          </span>
-        </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+        <span>
+          {postCount} {postCount === 1 ? "post" : "posts"}
+        </span>
+        <span>
+          {yearCount} {yearCount === 1 ? "year" : "years"}
+        </span>
       </div>
     </div>
   );

--- a/apps/blog/components/layout/SeriesBox.tsx
+++ b/apps/blog/components/layout/SeriesBox.tsx
@@ -6,11 +6,13 @@ export function SeriesBox({
   current,
   className,
   tone = "light",
+  showTitle = true,
 }: {
   series: Series | null;
   current?: string;
   className?: string;
   tone?: "light" | "dark";
+  showTitle?: boolean;
 }) {
   if (!series) return null;
   const { name, posts } = series;
@@ -25,19 +27,21 @@ export function SeriesBox({
         className
       )}
     >
-      <h2
-        className={cn(
-          "mb-6 text-2xl font-semibold tracking-[-0.02em] text-[var(--ink)] dark:text-[var(--on-dark)]"
-        )}
-      >
-        Series:{" "}
-        <a
-          className="underline-offset-4 transition-colors hover:text-[var(--body)] hover:underline"
-          href={`/series/${series.slug}`}
+      {showTitle && (
+        <h2
+          className={cn(
+            "mb-6 text-2xl font-semibold tracking-[-0.02em] text-[var(--ink)] dark:text-[var(--on-dark)]"
+          )}
         >
-          {name}
-        </a>
-      </h2>
+          Series:{" "}
+          <a
+            className="underline-offset-4 transition-colors hover:text-[var(--body)] hover:underline"
+            href={`/series/${series.slug}/`}
+          >
+            {name}
+          </a>
+        </h2>
+      )}
 
       <div className="grid grid-cols-1 gap-3">
         {posts.map(({ slug, title, excerpt }) => {
@@ -64,7 +68,7 @@ export function SeriesBox({
                     className={cn(
                       "line-clamp-1 text-base font-medium text-[var(--body-strong)] transition-colors hover:text-[var(--body)] dark:text-[var(--on-dark-soft)] dark:hover:text-[var(--on-dark)]"
                     )}
-                    href={slug}
+                    href={`${slug}/`}
                   >
                     {title}
                   </a>

--- a/apps/blog/components/layout/SeriesBox.tsx
+++ b/apps/blog/components/layout/SeriesBox.tsx
@@ -1,6 +1,5 @@
 import type { Series } from "@duyet/interfaces";
 import { cn } from "@duyet/libs/utils";
-import { NewspaperIcon } from "lucide-react";
 
 export function SeriesBox({
   series,
@@ -22,19 +21,18 @@ export function SeriesBox({
   return (
     <div
       className={cn(
-        "rounded-lg border border-[var(--hairline)] p-8 dark:border-white/10",
+        "border-y border-[var(--border-faint)] py-6 dark:border-white/10",
         className
       )}
     >
       <h2
         className={cn(
-          "mb-6 flex flex-row items-center gap-3 font-serif text-2xl tracking-[-0.3px] text-[var(--ink)] dark:text-[var(--on-dark)] md:text-3xl"
+          "mb-6 text-2xl font-semibold tracking-[-0.02em] text-[var(--ink)] dark:text-[var(--on-dark)]"
         )}
       >
-        <NewspaperIcon size={24} strokeWidth={1.5} className="text-[var(--muted)] dark:text-[var(--on-dark-soft)]" />
         Series:{" "}
         <a
-          className="underline-offset-4 hover:text-[var(--primary)] hover:underline transition-colors"
+          className="underline-offset-4 transition-colors hover:text-[var(--body)] hover:underline"
           href={`/series/${series.slug}`}
         >
           {name}
@@ -47,8 +45,8 @@ export function SeriesBox({
           return (
             <div
               className={cn(
-                "rounded-md bg-white/60 p-4 transition-colors dark:bg-black/20",
-                isCurrent && "bg-white/80 dark:bg-black/30"
+                "border-t border-[var(--border-faint)] py-4 transition-colors hover:bg-[var(--surface-soft)]",
+                isCurrent && "bg-[var(--surface-soft)]"
               )}
               key={slug}
             >
@@ -64,7 +62,7 @@ export function SeriesBox({
                 ) : (
                   <a
                     className={cn(
-                      "line-clamp-1 text-base font-medium text-[var(--body-strong)] hover:text-[var(--primary)] transition-colors dark:text-[var(--on-dark-soft)] dark:hover:text-[var(--primary)]"
+                      "line-clamp-1 text-base font-medium text-[var(--body-strong)] transition-colors hover:text-[var(--body)] dark:text-[var(--on-dark-soft)] dark:hover:text-[var(--on-dark)]"
                     )}
                     href={slug}
                   >

--- a/apps/blog/components/layout/TagHero.tsx
+++ b/apps/blog/components/layout/TagHero.tsx
@@ -13,32 +13,25 @@ export function TagHero({
   postCount,
   yearCount,
 }: TagHeroProps) {
+  void colorClass;
+
   return (
-    <div className="relative mb-16 mt-10 overflow-hidden rounded-2xl border border-[var(--hairline)]/60 dark:border-white/[0.06] sm:mt-14 lg:mt-20">
-      <div
-        className={`${colorClass} absolute inset-0 opacity-60 dark:opacity-20`}
-      />
+    <div className="blog-page-head mb-12 border-b border-[var(--border-faint)] pb-8">
+      <div className="mb-4">
+        <BackLink href="/tags/" text="All Topics" />
+      </div>
 
-      <div className="relative px-6 py-12 sm:px-10 sm:py-16 md:px-14 md:py-20">
-        <div className="mb-8">
-          <BackLink href="/tags" text="All Topics" />
-        </div>
+      <h1 className="mb-5 text-4xl font-semibold tracking-tight text-[var(--foreground)] dark:text-[var(--on-dark)] sm:text-5xl">
+        {tagName}
+      </h1>
 
-        <h1 className="mb-6 font-serif text-5xl font-bold tracking-tight text-[var(--foreground)] dark:text-[var(--on-dark)] sm:text-6xl md:text-7xl lg:text-8xl">
-          {tagName}
-        </h1>
-
-        <div className="flex items-center gap-3 text-sm font-medium text-[#1a1a1a]/50 dark:text-[#f8f8f2]/45">
-          <span>
-            {postCount} {postCount === 1 ? "post" : "posts"}
-          </span>
-          <span className="text-[#1a1a1a]/20 dark:text-[#f8f8f2]/20">
-            &middot;
-          </span>
-          <span>
-            {yearCount} {yearCount === 1 ? "year" : "years"}
-          </span>
-        </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+        <span>
+          {postCount} {postCount === 1 ? "post" : "posts"}
+        </span>
+        <span>
+          {yearCount} {yearCount === 1 ? "year" : "years"}
+        </span>
       </div>
     </div>
   );

--- a/apps/blog/components/post/FeaturedPost.tsx
+++ b/apps/blog/components/post/FeaturedPost.tsx
@@ -16,39 +16,35 @@ export function FeaturedPost({ post, className }: FeaturedPostProps) {
       to="/$year/$month/$slug/"
       params={{ year, month, slug }}
       className={cn(
-        "group block rounded-xl p-8",
-        // Always dark surface — cream-to-dark pacing rhythm
-        "bg-[var(--surface-dark)]",
+        "group block border-y border-[var(--border-faint)] py-7 transition-colors hover:bg-[var(--surface-soft)] sm:py-8",
         className
       )}
     >
-      <span className="inline-block rounded-full bg-[var(--accent)] px-3 py-1 text-[12px] font-medium uppercase tracking-[1.5px] text-white">
-        {post.category}
-      </span>
+      <div className="flex flex-wrap items-center gap-2 text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--muted)]">
+        <span>{post.category}</span>
+        <span>/</span>
+        <time>{dateFormat(post.date, "MMMM d, yyyy")}</time>
+      </div>
       <h2
         className={cn(
-          "mt-4 text-[36px] font-normal leading-[1.15] tracking-[-0.5px]",
-          "text-[var(--on-dark)]",
-          "font-serif",
-          "group-hover:text-[var(--on-dark)]/80",
+          "mt-4 max-w-4xl text-[30px] font-semibold leading-[1.12] tracking-[-0.02em] sm:text-[38px]",
+          "text-[var(--ink)]",
+          "group-hover:text-[var(--body)]",
           "transition-colors"
         )}
       >
         {post.title}
       </h2>
       {post.excerpt && (
-        <p className="mt-3 line-clamp-3 text-[16px] leading-[1.55] text-[#a09d96]">
+        <p className="mt-4 max-w-3xl text-[15px] leading-[1.65] text-[var(--body)]">
           {post.excerpt}
         </p>
       )}
-      <div className="mt-5 flex items-center gap-2 text-[14px] text-[#a09d96]">
-        <time>{dateFormat(post.date, "MMMM d, yyyy")}</time>
+      <div className="mt-5 flex items-center gap-2 text-[13px] text-[var(--muted)]">
         {post.readingTime && (
-          <>
-            <span>·</span>
-            <span>{post.readingTime} min read</span>
-          </>
+          <span>{post.readingTime} min read</span>
         )}
+        <span className="transition-transform group-hover:translate-x-1">→</span>
       </div>
     </Link>
   );

--- a/apps/blog/components/post/PostCard.tsx
+++ b/apps/blog/components/post/PostCard.tsx
@@ -15,35 +15,27 @@ export function PostCard({ post, className }: PostCardProps) {
     <Link
       to="/$year/$month/$slug/"
       params={{ year, month, slug }}
-      className={cn(
-        "group block rounded-xl p-6",
-        "bg-[var(--surface-card)] dark:bg-white/5",
-        "transition-colors",
-        "hover:bg-[var(--surface-soft)] dark:hover:bg-white/8",
-        className
-      )}
+      className={cn("card", className)}
     >
-      <div className="flex items-center gap-2 text-[13px] font-medium text-[var(--muted-foreground)]">
-        <span>{post.category}</span>
-        <span>·</span>
-        <time>{dateFormat(post.date, "MMM d, yyyy")}</time>
-      </div>
-      <h3
-        className={cn(
-          "mt-2 text-[18px] font-medium leading-[1.3] tracking-tight",
-          "text-[var(--foreground)]",
-          "font-serif",
-          "group-hover:text-[var(--accent)]",
-          "transition-colors"
+      <div className="card-body">
+        <div className="post-meta">
+          <span>{post.category}</span>
+          <span>·</span>
+          <time>{dateFormat(post.date, "MMM d, yyyy")}</time>
+        </div>
+        <h3 className="card-title mt-3">
+          {post.title}
+        </h3>
+        {post.excerpt && (
+          <p className="card-desc mt-2">
+            {post.excerpt}
+          </p>
         )}
-      >
-        {post.title}
-      </h3>
-      {post.excerpt && (
-        <p className="mt-2 line-clamp-2 text-[14px] leading-[1.55] text-[var(--body)] dark:text-[var(--foreground)]/60">
-          {post.excerpt}
-        </p>
-      )}
+        <div className="card-footer">
+          <span>{post.readingTime || "Article"}</span>
+          <span className="card-arrow">→</span>
+        </div>
+      </div>
     </Link>
   );
 }

--- a/apps/blog/components/post/YearPost.tsx
+++ b/apps/blog/components/post/YearPost.tsx
@@ -14,24 +14,24 @@ export function YearPost({ year, posts, className }: YearPostProps) {
 
   return (
     <div className={cn(className)}>
-      <h2 className="mb-4 font-serif text-[36px] font-normal tracking-[-0.5px] text-[var(--foreground)]">
+      <h2 className="mb-4 text-[26px] font-semibold tracking-[-0.02em] text-[var(--foreground)]">
         {year}
       </h2>
 
-      <div className="divide-y divide-[var(--border)] dark:divide-white/8 rounded-xl border border-[var(--border)] dark:border-white/8 bg-[var(--surface-card)]/70 dark:bg-white/[0.02] overflow-hidden">
+      <div className="divide-y divide-[var(--border-faint)] border-y border-[var(--border-faint)]">
         {posts.map((post: Post) => {
           const [, year, month, slug] = post.slug.split("/");
           return (
             <Link
-              className="group flex flex-row items-center gap-3 px-5 py-4 transition-colors hover:bg-[var(--muted)]/50 dark:hover:bg-white/[0.03]"
+              className="group flex flex-col gap-1 py-4 transition-colors hover:bg-[var(--surface-soft)] sm:flex-row sm:items-center sm:gap-4 sm:px-3"
               to="/$year/$month/$slug/"
               params={{ year, month, slug }}
               key={post.slug}
             >
-              <div className="min-w-0 flex-1 text-[16px] font-medium leading-[1.4] text-[var(--foreground)] transition-colors group-hover:text-[var(--accent)]">
+              <div className="min-w-0 flex-1 break-words text-[15px] font-medium leading-[1.45] text-[var(--foreground)] transition-colors group-hover:text-[var(--body)]">
                 {post.title}
               </div>
-              <time className="flex-shrink-0 whitespace-nowrap text-[13px] font-medium text-[var(--muted-foreground)]">
+              <time className="flex-shrink-0 whitespace-nowrap text-[12px] font-medium text-[var(--muted-foreground)]">
                 {dateFormat(post.date, "MMM dd")}
               </time>
             </Link>

--- a/apps/blog/src/routes/$year/$month/$slug.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug.tsx
@@ -123,7 +123,7 @@ function PostPage() {
           <div className="min-w-0 max-w-3xl flex-1">
             <Content post={post} />
 
-            <div className="my-12 border-t border-[#e6dfd8] dark:border-white/10" />
+            <div className="my-12 border-t border-[var(--border-faint)] dark:border-white/10" />
 
             <Meta post={post} series={series} />
 

--- a/apps/blog/src/routes/$year/$month/-content.tsx
+++ b/apps/blog/src/routes/$year/$month/-content.tsx
@@ -69,9 +69,9 @@ function MDXRenderer({ source }: { source: string }) {
         "[&>table]:border-t [&>table]:border-b [&>table]:border-[var(--border)] dark:[&>table]:border-white/10",
         "[&>pre]:overflow-x-auto [&>pre]:sm:-mx-4 [&>pre]:sm:-mx-8 [&>pre]:lg:-mx-16 [&>pre]:xl:-mx-24",
         "prose-headings:text-[var(--foreground)]",
-        "prose-headings:font-serif prose-headings:font-normal prose-headings:tracking-tight",
+        "prose-headings:font-semibold prose-headings:tracking-tight",
         "prose-p:text-[#3d3d3a] dark:prose-p:text-[var(--foreground)]/80",
-        "prose-a:text-[var(--accent)] dark:prose-a:text-[var(--accent)]",
+        "prose-a:text-[var(--ink)] dark:prose-a:text-[var(--on-dark)]",
         "prose-a:underline prose-a:underline-offset-4",
         "prose-strong:text-[var(--foreground)]",
         "prose-code:break-words",
@@ -86,14 +86,13 @@ function MDXRenderer({ source }: { source: string }) {
 export default function Content({ post }: { post: ContentPost }) {
   return (
     <>
-      <header className="mb-12 flex flex-col gap-5 pt-14 sm:pt-20 lg:pt-24">
+      <header className="mb-10 flex flex-col gap-5 border-b border-[var(--border-faint)] pb-8 pt-10 sm:pt-14 lg:pt-16">
         <h1
           className={cn(
             "mt-2 break-words py-2",
             "text-[var(--foreground)]",
-            "font-serif",
-            "text-[48px] font-normal leading-[1.1] tracking-[-1px]",
-            "sm:text-[64px] sm:tracking-[-1.5px]"
+            "text-[34px] font-semibold leading-[1.12] tracking-tight",
+            "sm:text-[46px]"
           )}
         >
           {post.title}
@@ -109,15 +108,14 @@ export default function Content({ post }: { post: ContentPost }) {
           className={cn(
             'prose dark:prose-invert',
             "max-w-none",
-            "prose-lg",
             "[&>table]:overflow-x-auto [&>table]:sm:-mx-4 [&>table]:sm:-mx-8 [&>table]:lg:-mx-16 [&>table]:xl:-mx-24",
             "[&>table]:border-t [&>table]:border-b [&>table]:border-[var(--border)] dark:[&>table]:border-white/10",
             "[&>pre]:overflow-x-auto [&>pre]:sm:-mx-4 [&>pre]:sm:-mx-8 [&>pre]:lg:-mx-16 [&>pre]:xl:-mx-24",
             "prose-headings:text-[var(--foreground)]",
-            "prose-headings:font-serif prose-headings:font-normal prose-headings:tracking-tight",
+            "prose-headings:font-semibold prose-headings:tracking-tight",
             "prose-p:text-[#3d3d3a] dark:prose-p:text-[var(--foreground)]/80",
             "prose-p:leading-8",
-            "prose-a:text-[var(--accent)] dark:prose-a:text-[var(--accent)]",
+            "prose-a:text-[var(--ink)] dark:prose-a:text-[var(--on-dark)]",
             "prose-a:underline prose-a:underline-offset-4",
             "prose-strong:text-[var(--foreground)]",
             "prose-code:break-words",

--- a/apps/blog/src/routes/__root.tsx
+++ b/apps/blog/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import "@duyet/components/styles.css";
 import "../../app/globals.css";
+import "../../styles/blog-design.css";
 
 import Analytics from "@duyet/components/Analytics";
 import Footer from "@duyet/components/Footer";
@@ -76,7 +77,7 @@ export const Route = createRootRoute({
       {
         rel: "preload",
         as: "style",
-        href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Cormorant+Garamond:wght@400;500;600&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
       },
       {
         rel: "alternate",
@@ -98,7 +99,7 @@ function RootComponent() {
         {/* Non-blocking Google Fonts: preloaded above, applied here */}
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Cormorant+Garamond:wght@400;500;600&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
           media="print"
           // @ts-expect-error onLoad is valid on link elements
           onLoad="this.media='all'"
@@ -106,7 +107,7 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider>
-          <div className="min-h-screen bg-[var(--background)] font-sans text-[var(--foreground)] subpixel-antialiased [--font-inter:Inter,system-ui,sans-serif] [--font-serif:'Cormorant_Garamond',Garamond,'Times New Roman',serif]">
+          <div className="min-h-screen bg-[var(--background)] font-sans text-[var(--foreground)] subpixel-antialiased [--font-inter:Inter,system-ui,sans-serif] [--font-serif:Inter,system-ui,sans-serif]">
             <Header
               shortText="Duyet Le"
               longText="Duyet Le"
@@ -114,7 +115,7 @@ function RootComponent() {
               showAuthButtons
               actions={<AppCommandPalette />}
             />
-            <main className="relative z-10 rounded-b-3xl pb-16 2xl:rounded-b-[4rem]">
+            <main className="relative z-10 pb-16">
               <Outlet />
             </main>
             <Footer />

--- a/apps/blog/src/routes/about.tsx
+++ b/apps/blog/src/routes/about.tsx
@@ -21,7 +21,6 @@ interface LinkItem {
   title: string;
   description: string;
   url: string;
-  color: string;
 }
 
 function About() {
@@ -32,7 +31,6 @@ function About() {
       description:
         "Experience building scalable data infrastructure and leading engineering teams.",
       url: "https://cv.duyet.net",
-      color: "bg-orange-100/50 dark:bg-[#4f2f1f]",
     },
     {
       icon: GithubIcon,
@@ -40,7 +38,6 @@ function About() {
       description:
         "Open source contributions and personal projects in Python, Rust, and TypeScript.",
       url: "https://github.com/duyet",
-      color: "bg-purple-100/50 dark:bg-[#2f1f3f]",
     },
     {
       icon: LinkedInIcon,
@@ -48,7 +45,6 @@ function About() {
       description:
         "Professional network and career highlights in data engineering.",
       url: "https://linkedin.com/in/duyet",
-      color: "bg-blue-100/50 dark:bg-[#1f2a3f]",
     },
     {
       icon: BlogIcon,
@@ -56,7 +52,6 @@ function About() {
       description:
         "Technical writings on data engineering, distributed systems, and open source.",
       url: "/",
-      color: "bg-amber-100/60 dark:bg-[#3f2f1f]",
     },
   ];
 
@@ -80,13 +75,12 @@ function About() {
   ];
 
   return (
-    <div className="mx-auto max-w-[1280px] px-5 py-16 sm:px-8 sm:py-24 lg:px-10">
-      {/* Header */}
-      <div className="mx-auto mb-16 max-w-[820px] text-center sm:mb-24">
-        <h1 className="mb-6 font-serif text-4xl tracking-[-0.5px] text-[var(--ink)] dark:text-[var(--on-dark)] sm:text-5xl lg:text-[56px] lg:tracking-[-1px]">
+    <div className="mx-auto max-w-[1180px] px-5 py-12 sm:px-8 sm:py-16 lg:px-10">
+      <div className="blog-page-head mb-12 max-w-[760px]">
+        <h1>
           About
         </h1>
-        <p className="mx-auto max-w-3xl text-lg leading-relaxed text-[var(--body)] dark:text-[var(--muted)]">
+        <p>
           <strong className="font-medium text-[var(--body-strong)] dark:text-[var(--on-dark)]">
             Data Engineer
           </strong>{" "}
@@ -96,8 +90,7 @@ function About() {
         </p>
       </div>
 
-      {/* Links Grid */}
-      <div className="mx-auto mb-16 grid max-w-[820px] gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="blog-link-grid mb-16">
         {links.map((link, index) => {
           const Icon = link.icon;
           const isExternal = link.url.startsWith("http");
@@ -107,48 +100,43 @@ function About() {
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className={`group flex flex-col p-10 ${link.color} rounded-xl transition-transform duration-200 hover:scale-[1.02]`}
             >
-              <div className="mb-8 text-[#1a1a1a] dark:text-[#f8f8f2]">
-                <Icon />
+              <div>
+                <div className="mb-6 text-[#1a1a1a] dark:text-[#f8f8f2]">
+                  <Icon />
+                </div>
+                <h3>{link.title}</h3>
+                <p>{link.description}</p>
               </div>
-              <h3 className="mb-3 text-xl font-medium text-[#1a1a1a] dark:text-[#f8f8f2]">
-                {link.title}
-              </h3>
-              <p className="text-sm leading-relaxed text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
-                {link.description}
-              </p>
+              <span className="meta">Open →</span>
             </a>
           ) : (
             <Link
               key={index}
               to={link.url as "/"}
-              className={`group flex flex-col p-10 ${link.color} rounded-xl transition-transform duration-200 hover:scale-[1.02]`}
             >
-              <div className="mb-8 text-[#1a1a1a] dark:text-[#f8f8f2]">
-                <Icon />
+              <div>
+                <div className="mb-6 text-[#1a1a1a] dark:text-[#f8f8f2]">
+                  <Icon />
+                </div>
+                <h3>{link.title}</h3>
+                <p>{link.description}</p>
               </div>
-              <h3 className="mb-3 text-xl font-medium text-[#1a1a1a] dark:text-[#f8f8f2]">
-                {link.title}
-              </h3>
-              <p className="text-sm leading-relaxed text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
-                {link.description}
-              </p>
+              <span className="meta">Open →</span>
             </Link>
           );
         })}
       </div>
 
-      {/* Skills Section */}
-      <div className="mx-auto max-w-[820px] rounded-xl bg-[var(--surface-card)] p-8 dark:bg-[var(--surface-dark)] sm:p-12">
-        <h2 className="mb-6 font-serif text-2xl tracking-[-0.3px] text-[var(--ink)] dark:text-[var(--on-dark)] sm:text-3xl">
+      <div className="border-y border-[var(--border-faint)] py-8">
+        <h2 className="mb-6 text-2xl font-semibold tracking-[-0.02em] text-[var(--ink)] dark:text-[var(--on-dark)]">
           Skills & Stacks
         </h2>
         <div className="flex flex-wrap gap-3">
           {skills.map(({ name, link }) => (
             <span
               key={name}
-              className="inline-block rounded-full bg-[var(--background-primary)] px-5 py-2 text-sm font-medium text-[var(--ink)] dark:bg-white/10 dark:text-[var(--on-dark-soft)]"
+              className="inline-block rounded-lg border border-[var(--border-faint)] px-3 py-2 text-sm font-medium text-[var(--ink)] dark:bg-white/10 dark:text-[var(--on-dark-soft)]"
             >
               {link ? (
                 <a

--- a/apps/blog/src/routes/ai.tsx
+++ b/apps/blog/src/routes/ai.tsx
@@ -12,12 +12,12 @@ export const Route = createFileRoute("/ai")({
 
 function AI() {
   return (
-    <div className="mx-auto mb-16 max-w-[820px] space-y-6 leading-loose">
-      <div className="mb-8 pt-10 md:mb-16 sm:pt-14 lg:pt-20">
-        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl lg:text-6xl">
+    <div className="mx-auto mb-16 max-w-[820px] px-5 leading-loose sm:px-8 lg:px-10">
+      <div className="blog-page-head border-b border-[var(--border-faint)] pb-8">
+        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl">
           AI
         </h1>
-        <div className="mt-8 space-y-5 text-lg font-medium leading-7 tracking-tight text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+        <div className="mt-6 space-y-5 text-base font-medium leading-7 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
           <p>
             None of the contents in my blog was written by an AI tool. I have
             used AI for{" "}

--- a/apps/blog/src/routes/archives.tsx
+++ b/apps/blog/src/routes/archives.tsx
@@ -33,11 +33,11 @@ function Archives() {
 
   return (
     <Container className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
-      <div className="mx-auto max-w-[820px] pt-10 sm:pt-14 lg:pt-20">
-        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl lg:text-6xl">
+      <div className="blog-page-head mx-auto max-w-[820px]">
+        <h1>
           Archives
         </h1>
-        <p className="mt-5 text-lg font-medium leading-7 tracking-tight text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+        <p>
           Lists all {postCount} posts of the past {pastYears} years. You can also
           explore <Link to="/tags/">by the topics</Link>.
         </p>

--- a/apps/blog/src/routes/category.tsx
+++ b/apps/blog/src/routes/category.tsx
@@ -1,9 +1,12 @@
-import { ContentCard } from "@duyet/components";
 import Container from "@duyet/components/Container";
 import type { CategoryCount } from "@duyet/interfaces";
 import { getSlug } from "@duyet/libs/getSlug";
-import { createFileRoute, Outlet, useMatches } from "@tanstack/react-router";
-import { getCategoryMetadata } from "@/lib/category-metadata";
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useMatches,
+} from "@tanstack/react-router";
 import { getAllCategories } from "@/lib/posts";
 
 export const Route = createFileRoute("/category")({
@@ -35,11 +38,11 @@ function Categories() {
 
   return (
     <Container className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
-      <div className="mb-12 max-w-[820px] pt-10 sm:pt-14 lg:pt-20">
-        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl lg:text-6xl">
+      <div className="blog-page-head mb-12 max-w-[820px]">
+        <h1>
           Categories
         </h1>
-        <p className="mt-5 text-lg font-medium leading-7 tracking-tight text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+        <p>
           Explore my writing organized by{" "}
           <strong className="font-semibold text-[#1a1a1a] dark:text-[#f8f8f2]">
             {categoryEntries.length} main categories
@@ -50,22 +53,22 @@ function Categories() {
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {categoryEntries.map(([category, count], index) => {
-          const metadata = getCategoryMetadata(category, count, index);
-
-          return (
-            <ContentCard
-              key={category}
-              title={category}
-              href={`/category/${getSlug(category)}`}
-              description={metadata.description}
-              color={metadata.color}
-              illustration={metadata.illustration}
-              tags={[`${count} ${count === 1 ? "post" : "posts"}`]}
-            />
-          );
-        })}
+      <div className="blog-link-grid">
+        {categoryEntries.map(([category, count]) => (
+          <Link
+            key={category}
+            to="/category/$category/"
+            params={{ category: getSlug(category) }}
+          >
+            <div>
+              <h2>{category}</h2>
+              <p>Posts grouped by this category.</p>
+            </div>
+            <span className="meta">
+              {count} {count === 1 ? "post" : "posts"}
+            </span>
+          </Link>
+        ))}
       </div>
     </Container>
   );

--- a/apps/blog/src/routes/category/$category.tsx
+++ b/apps/blog/src/routes/category/$category.tsx
@@ -4,10 +4,7 @@ import { getSlug } from "@duyet/libs/getSlug";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { HeroBanner } from "@/components/layout";
 import { YearPost } from "@/components/post";
-import {
-  getCategoryColorClass,
-  getCategoryMetadata,
-} from "@/lib/category-metadata";
+import { getCategoryMetadata } from "@/lib/category-metadata";
 import { getAllCategories, getPostsByCategory } from "@/lib/posts";
 
 export const Route = createFileRoute("/category/$category")({
@@ -69,17 +66,15 @@ function PostsByCategory() {
 
   // Get dynamic metadata
   const metadata = getCategoryMetadata(categoryName, postCount, categoryIndex);
-  const colorClass = getCategoryColorClass(metadata.color, "light");
 
   return (
     <Container className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
       <HeroBanner
         title={categoryName}
         description={metadata.description}
-        colorClass={colorClass}
         postCount={postCount}
         yearCount={yearCount}
-        backLinkHref="/category"
+        backLinkHref="/category/"
         backLinkText="All Categories"
       />
 

--- a/apps/blog/src/routes/featured.tsx
+++ b/apps/blog/src/routes/featured.tsx
@@ -30,11 +30,11 @@ function Featured() {
 
   return (
     <Container className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
-      <div className="mx-auto max-w-[820px] pt-10 sm:pt-14 lg:pt-20">
-        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl lg:text-6xl">
+      <div className="blog-page-head mx-auto max-w-[820px]">
+        <h1>
           Featured
         </h1>
-        <p className="mt-5 text-lg font-medium leading-7 tracking-tight text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+        <p>
           This page highlights{" "}
           <strong className="font-semibold text-[#1a1a1a] dark:text-[#f8f8f2]">
             {postCount} featured blog posts

--- a/apps/blog/src/routes/feed.tsx
+++ b/apps/blog/src/routes/feed.tsx
@@ -1,5 +1,4 @@
 import Container from "@duyet/components/Container";
-import Feed from "@duyet/components/Feed";
 import type { Post } from "@duyet/interfaces";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { getAllPosts } from "@/lib/posts";
@@ -17,14 +16,54 @@ function FeedPage() {
   const { posts } = Route.useLoaderData() as { posts: Post[] };
 
   return (
-    <Container className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
-      <Feed posts={posts} />
+    <Container className="mx-auto max-w-[960px] px-5 sm:px-8 lg:px-10">
+      <header className="blog-page-head border-b border-[var(--border-faint)] pb-8">
+        <h1 className="text-4xl font-semibold tracking-tight text-[var(--foreground)] dark:text-[var(--on-dark)] sm:text-5xl">
+          Feed
+        </h1>
+        <p className="mt-4 max-w-2xl text-base leading-7 text-[#1a1a1a]/70 dark:text-[#f8f8f2]/75">
+          Latest posts from the blog.
+        </p>
+      </header>
 
-      <Link to="/archives/">
-        <div className="mt-12 rounded-lg py-4 text-center text-base font-medium text-[#141413] hover:text-[#cc785c] dark:text-[#f8f8f2] dark:hover:text-[#cc785c] hover:underline hover:underline-offset-4">
+      <div className="mt-10 divide-y divide-[var(--border-faint)]">
+        {posts.map((post) => {
+          const [, year, month, slug] = post.slug.split("/");
+          return (
+            <Link
+              key={post.slug}
+              to="/$year/$month/$slug/"
+              params={{ year, month, slug }}
+              className="block py-5 transition-colors hover:bg-[var(--surface-soft)]"
+            >
+              <time className="text-sm text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+                {new Date(post.date).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+              </time>
+              <h2 className="mt-2 text-xl font-semibold tracking-tight text-[var(--foreground)] dark:text-[var(--on-dark)]">
+                {post.title}
+              </h2>
+              {post.excerpt && (
+                <p className="mt-2 line-clamp-2 text-sm leading-6 text-[#1a1a1a]/65 dark:text-[#f8f8f2]/65">
+                  {post.excerpt}
+                </p>
+              )}
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="mt-10 border-t border-[var(--border-faint)] pt-5">
+        <Link
+          to="/archives/"
+          className="text-sm font-medium text-[var(--ink)] underline underline-offset-4 transition-colors hover:text-[var(--body)]"
+        >
           See more posts
-        </div>
-      </Link>
+        </Link>
+      </div>
     </Container>
   );
 }

--- a/apps/blog/src/routes/html-sitemap.tsx
+++ b/apps/blog/src/routes/html-sitemap.tsx
@@ -1,4 +1,4 @@
-import type { CategoryCount, Post } from "@duyet/interfaces";
+import type { Post } from "@duyet/interfaces";
 import { getSlug } from "@duyet/libs/getSlug";
 import { createFileRoute } from "@tanstack/react-router";
 import { getAllCategories, getAllPosts } from "@/lib/posts";
@@ -23,11 +23,13 @@ function HtmlSitemapPage() {
     categories: string[];
   };
   const HOME_URL = import.meta.env.VITE_DUYET_HOME_URL || "https://duyet.net";
+  const linkClass =
+    "text-[var(--ink)] underline underline-offset-4 transition-colors hover:text-[var(--body)] dark:text-[var(--on-dark)] dark:hover:text-[var(--on-dark-soft)]";
 
   return (
     <div className="mx-auto max-w-[820px] px-5 sm:px-8 lg:px-10">
-      <div className="pt-10 sm:pt-14 lg:pt-20">
-        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl lg:text-6xl">
+      <div className="blog-page-head border-b border-[var(--border-faint)] pb-8">
+        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl">
           HTML Sitemap
         </h1>
       </div>
@@ -42,7 +44,7 @@ function HtmlSitemapPage() {
               <li key={post.slug}>
                 <a
                   href={post.slug}
-                  className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+                  className={linkClass}
                 >
                   {post.title}
                 </a>
@@ -62,8 +64,8 @@ function HtmlSitemapPage() {
             {categories.map((category) => (
               <li key={category}>
                 <a
-                  href={`/category/${getSlug(category)}`}
-                  className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+                  href={`/category/${getSlug(category)}/`}
+                  className={linkClass}
                 >
                   {category}
                 </a>
@@ -78,7 +80,7 @@ function HtmlSitemapPage() {
             <li>
               <a
                 href="/"
-                className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+                className={linkClass}
               >
                 Home
               </a>
@@ -86,7 +88,7 @@ function HtmlSitemapPage() {
             <li>
               <a
                 href={`${HOME_URL}/about`}
-                className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+                className={linkClass}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -95,32 +97,32 @@ function HtmlSitemapPage() {
             </li>
             <li>
               <a
-                href="/archives"
-                className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+                href="/archives/"
+                className={linkClass}
               >
                 Archives
               </a>
             </li>
             <li>
               <a
-                href="/featured"
-                className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+                href="/featured/"
+                className={linkClass}
               >
                 Featured
               </a>
             </li>
             <li>
               <a
-                href="/tags"
-                className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+                href="/tags/"
+                className={linkClass}
               >
                 Tags
               </a>
             </li>
             <li>
               <a
-                href="/series"
-                className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+                href="/series/"
+                className={linkClass}
               >
                 Series
               </a>
@@ -134,7 +136,7 @@ function HtmlSitemapPage() {
           This sitemap is also available in XML format at{" "}
           <a
             href="/sitemap.xml"
-            className="text-[#1a1a1a] underline underline-offset-4 hover:text-[#1a1a1a]/70 dark:text-[#f8f8f2] dark:hover:text-[#f8f8f2]/70"
+            className={linkClass}
           >
             /sitemap.xml
           </a>

--- a/apps/blog/src/routes/index.tsx
+++ b/apps/blog/src/routes/index.tsx
@@ -3,6 +3,8 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { PostCard } from "@/components/post/PostCard";
 import { FeaturedPost } from "@/components/post/FeaturedPost";
 import { YearPost } from "@/components/post/YearPost";
+import { BlogHeader } from "@/components/layout/BlogHeader";
+import { BlogPillNav } from "@/components/layout/BlogPillNav";
 import { getAllSeries, getAllTags, getPostsByAllYear } from "@/lib/posts";
 import type { Post } from "@duyet/interfaces";
 
@@ -29,51 +31,41 @@ function HomePage() {
   const recentCards = allPosts.slice(1, 7);
   const allByYear = groupByYear(allPosts);
 
+  const categoryPills = [
+    { label: "Latest", href: "/feed/" },
+    { label: "Topics", href: "/tags/" },
+    { label: "Featured", href: "/featured/" },
+    { label: "Series", href: "/series/" },
+    { label: "Archives", href: "/archives/" },
+  ];
+
   return (
     <Container className="mx-auto max-w-[1200px] px-5 sm:px-8 lg:px-10">
-      {/* Large serif hero */}
-      <div className="pt-16 sm:pt-24 lg:pt-32">
-        <h1 className="font-serif text-[48px] font-normal tracking-[-1px] text-[var(--foreground)] sm:text-[64px] sm:tracking-[-1.5px]">
-          Notes on data,
-          <br />
-          systems &amp; engineering
-        </h1>
-        <p className="mt-6 max-w-xl text-[16px] leading-[1.55] text-[#3d3d3a] dark:text-[var(--foreground)]/60">
-          {allPosts.length} posts. Explore{" "}
-          <Link
-            to="/feed/"
-            className="text-[var(--accent)] underline underline-offset-4"
-          >
-            latest
-          </Link>
-          ,{" "}
-          <Link
-            to="/tags/"
-            className="text-[var(--accent)] underline underline-offset-4"
-          >
-            topics
-          </Link>
-          , or{" "}
-          <Link
-            to="/featured/"
-            className="text-[var(--accent)] underline underline-offset-4"
-          >
-            featured
-          </Link>
-          .
-        </p>
-      </div>
+      <BlogHeader
+        eyebrow="Blog"
+        title="Notes on data,"
+        titleEmphasis="systems and engineering"
+        intro={
+          <>
+            {allPosts.length} posts on data engineering, distributed systems,
+            and open source. Explore{" "}
+            <Link to="/feed/">latest</Link>,{" "}
+            <Link to="/tags/">topics</Link>, or{" "}
+            <Link to="/featured/">featured</Link>.
+          </>
+        }
+      >
+        <BlogPillNav items={categoryPills} />
+      </BlogHeader>
 
-      {/* Featured post — dark surface */}
       {featured && (
-        <div className="mt-16">
+        <div className="mt-14">
           <FeaturedPost post={featured} />
         </div>
       )}
 
-      {/* Recent posts as cream cards */}
       {recentCards.length > 0 && (
-        <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-10 card-grid">
           {recentCards.map((post) => (
             <PostCard key={post.slug} post={post} />
           ))}
@@ -82,7 +74,7 @@ function HomePage() {
 
       {/* All posts grouped by year */}
       {allByYear.map(([year, posts]) => (
-        <YearPost key={year} year={year} posts={posts} className="mt-16" />
+        <YearPost key={year} year={year} posts={posts} className="mt-14" />
       ))}
 
       <div className="pb-24" />

--- a/apps/blog/src/routes/search.tsx
+++ b/apps/blog/src/routes/search.tsx
@@ -48,11 +48,11 @@ function SearchPage() {
 
   return (
     <div className="mx-auto max-w-[820px] px-5 sm:px-8 lg:px-10">
-      <div className="pt-10 sm:pt-14 lg:pt-20">
-        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl lg:text-6xl">
+      <div className="blog-page-head">
+        <h1>
           Search
         </h1>
-        <p className="mt-5 text-lg font-medium leading-7 tracking-tight text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+        <p>
           Search through {allPosts.length} blog posts by title, category,
           tags, or date range.
         </p>

--- a/apps/blog/src/routes/series.tsx
+++ b/apps/blog/src/routes/series.tsx
@@ -18,7 +18,9 @@ export const Route = createFileRoute("/series")({
 });
 
 function SeriesPage() {
-  const hasChild = useMatches().some((m) => m.id === "/series/$slug");
+  const hasChild = useMatches().some(
+    (match) => match.routeId === "/series/$slug"
+  );
   if (hasChild) return <Outlet />;
 
   const { seriesList } = Route.useLoaderData() as { seriesList: Series[] };
@@ -42,7 +44,7 @@ function SeriesPage() {
             key={series.slug}
             series={series}
             tone="light"
-            className="bg-white shadow-none"
+            className="bg-transparent"
           />
         ))}
       </div>

--- a/apps/blog/src/routes/series.tsx
+++ b/apps/blog/src/routes/series.tsx
@@ -17,16 +17,6 @@ export const Route = createFileRoute("/series")({
   component: SeriesPage,
 });
 
-const seriesBackgrounds = [
-  "bg-cactus dark:bg-[#252320]",
-  "bg-oat dark:bg-[#1f1e1b]",
-  "bg-clay dark:bg-[#3f2f1f]",
-  "bg-sky dark:bg-[#2a2824]",
-  "bg-heather dark:bg-[#2a2830]",
-  "bg-fig dark:bg-[#3f1f2f]",
-  "bg-olive dark:bg-[#1f2f1f]",
-];
-
 function SeriesPage() {
   const hasChild = useMatches().some((m) => m.id === "/series/$slug");
   if (hasChild) return <Outlet />;
@@ -34,30 +24,27 @@ function SeriesPage() {
   const { seriesList } = Route.useLoaderData() as { seriesList: Series[] };
 
   return (
-    <div className="min-h-screen bg-[var(--background-primary)] px-5 pb-14 pt-10 dark:bg-[#0d0e0c] sm:px-8 sm:pt-14 lg:px-10 lg:pt-20">
-      <div className="mx-auto mb-10 max-w-[1280px]">
+    <div className="min-h-screen bg-[var(--background-primary)] px-5 pb-14 sm:px-8 lg:px-10">
+      <div className="mx-auto mb-10 max-w-[1180px]">
         <div className="max-w-3xl">
-          <h1 className="mb-5 font-serif text-4xl tracking-[-0.5px] text-[var(--ink)] dark:text-[var(--on-dark)] sm:text-5xl lg:text-[56px] lg:tracking-[-1px]">
-            Series
-          </h1>
-          <p className="max-w-2xl text-[15px] leading-relaxed text-[var(--body)] dark:text-[var(--muted)] sm:text-base">
-            Longer threads and linked notes grouped into focused reading paths.
-          </p>
+          <div className="blog-page-head">
+            <h1>Series</h1>
+            <p>
+              Longer threads and linked notes grouped into focused reading
+              paths.
+            </p>
+          </div>
         </div>
       </div>
       <div className="mx-auto grid max-w-5xl grid-cols-1 gap-5">
-        {seriesList.map((series: Series, index: number) => {
-          const bgClass = seriesBackgrounds[index % seriesBackgrounds.length];
-
-          return (
-            <SeriesBox
-              key={series.slug}
-              series={series}
-              tone="light"
-              className={bgClass}
-            />
-          );
-        })}
+        {seriesList.map((series: Series) => (
+          <SeriesBox
+            key={series.slug}
+            series={series}
+            tone="light"
+            className="bg-white shadow-none"
+          />
+        ))}
       </div>
     </div>
   );

--- a/apps/blog/src/routes/series/$slug.tsx
+++ b/apps/blog/src/routes/series/$slug.tsx
@@ -1,6 +1,8 @@
+import Container from "@duyet/components/Container";
 import type { Series } from "@duyet/interfaces";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { SeriesBox } from "@/components/layout";
+import { BackLink } from "@/components/ui/BackLink";
 import { getAllSeries, getSeries } from "@/lib/posts";
 
 export const Route = createFileRoute("/series/$slug")({
@@ -24,11 +26,32 @@ function SeriesDetailPage() {
 
   if (!series) {
     return (
-      <div className="py-12 text-center">
-        <p className="text-lg text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">Series not found.</p>
-      </div>
+      <Container className="mx-auto max-w-[960px] px-5 py-12 text-center sm:px-8 lg:px-10">
+        <p className="text-lg text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+          Series not found.
+        </p>
+      </Container>
     );
   }
 
-  return <SeriesBox className="mt-0 border-0 pb-10 pt-10" series={series} />;
+  return (
+    <Container className="mx-auto max-w-[960px] px-5 sm:px-8 lg:px-10">
+      <header className="blog-page-head border-b border-[var(--border-faint)] pb-8">
+        <div className="mb-4">
+          <BackLink href="/series/" text="All Series" />
+        </div>
+        <h1 className="text-4xl font-semibold tracking-tight text-[var(--foreground)] dark:text-[var(--on-dark)] sm:text-5xl">
+          {series.name}
+        </h1>
+        <p className="mt-4 text-sm font-medium text-[#1a1a1a]/55 dark:text-[#f8f8f2]/55">
+          {series.posts.length} {series.posts.length === 1 ? "post" : "posts"}
+        </p>
+      </header>
+      <SeriesBox
+        className="mt-10 border-y-0 pb-10 pt-0"
+        series={series}
+        showTitle={false}
+      />
+    </Container>
+  );
 }

--- a/apps/blog/src/routes/tag/$tag.tsx
+++ b/apps/blog/src/routes/tag/$tag.tsx
@@ -4,7 +4,6 @@ import { getSlug } from "@duyet/libs/getSlug";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { TagHero } from "@/components/layout";
 import { YearPost } from "@/components/post";
-import { getTagColorClass, getTagMetadata } from "@/lib/tag-metadata";
 import { getAllTags, getPostsByTag } from "@/lib/posts";
 
 function findTagBySlug(tags: TagCount, slug: string): string | undefined {
@@ -45,17 +44,12 @@ export const Route = createFileRoute("/tag/$tag")({
 
 function PostsByTag() {
   const { tag } = Route.useParams();
-  const { posts, tags } = Route.useLoaderData() as {
+  const { posts } = Route.useLoaderData() as {
     posts: Post[];
     tags: TagCount;
   };
 
-  const resolvedTag = findTagBySlug(tags, tag);
   const displayName = slugToDisplay(tag);
-
-  const tagIndex = Object.keys(tags)
-    .sort((a, b) => tags[b] - tags[a])
-    .indexOf(resolvedTag || tag);
 
   const postsByYear = posts.reduce((acc: Record<number, Post[]>, post) => {
     const year = new Date(post.date).getFullYear();
@@ -69,14 +63,11 @@ function PostsByTag() {
   const postCount = posts.length;
   const yearCount = Object.keys(postsByYear).length;
 
-  const metadata = getTagMetadata(displayName, postCount, tagIndex);
-  const colorClass = getTagColorClass(metadata.color, "light");
-
   return (
     <Container className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
       <TagHero
         tagName={displayName}
-        colorClass={colorClass}
+        colorClass=""
         postCount={postCount}
         yearCount={yearCount}
       />

--- a/apps/blog/src/routes/tags.tsx
+++ b/apps/blog/src/routes/tags.tsx
@@ -1,9 +1,7 @@
-import { ContentCard } from "@duyet/components";
 import Container from "@duyet/components/Container";
 import type { TagCount } from "@duyet/interfaces";
 import { getSlug } from "@duyet/libs/getSlug";
-import { createFileRoute } from "@tanstack/react-router";
-import { getTagMetadata } from "@/lib/tag-metadata";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { getAllTags } from "@/lib/posts";
 
 export const Route = createFileRoute("/tags")({
@@ -27,11 +25,11 @@ function Tags() {
 
   return (
     <Container className="max-w-[1280px] px-5 sm:px-8 lg:px-10">
-      <div className="mb-12 max-w-[820px] pt-10 sm:pt-14 lg:pt-20">
-        <h1 className="text-4xl font-semibold tracking-tight text-[#1a1a1a] dark:text-[#f8f8f2] sm:text-5xl lg:text-6xl">
+      <div className="blog-page-head mb-12 max-w-[820px]">
+        <h1>
           Topics
         </h1>
-        <p className="mt-5 text-lg font-medium leading-7 tracking-tight text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70">
+        <p>
           Explore my writing organized by{" "}
           <strong className="font-semibold text-[#1a1a1a] dark:text-[#f8f8f2]">
             {tagEntries.length} diverse topics
@@ -42,22 +40,18 @@ function Tags() {
         </p>
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {tagEntries.map(([tag, count], index) => {
-          const metadata = getTagMetadata(tag, count, index);
-
-          return (
-            <ContentCard
-              key={tag}
-              title={tag}
-              href={`/tag/${getSlug(tag)}/`}
-              description={metadata.description}
-              color={metadata.color}
-              illustration={metadata.illustration}
-              tags={[`${count} ${count === 1 ? "post" : "posts"}`]}
-            />
-          );
-        })}
+      <div className="blog-link-grid">
+        {tagEntries.map(([tag, count]) => (
+          <Link key={tag} to="/tag/$tag/" params={{ tag: getSlug(tag) }}>
+            <div>
+              <h2>{tag}</h2>
+              <p>Posts filed under this topic.</p>
+            </div>
+            <span className="meta">
+              {count} {count === 1 ? "post" : "posts"}
+            </span>
+          </Link>
+        ))}
       </div>
     </Container>
   );

--- a/apps/blog/styles/blog-design.css
+++ b/apps/blog/styles/blog-design.css
@@ -1,0 +1,397 @@
+.masthead {
+  padding: 56px 0 28px;
+  border-bottom: 1px solid var(--border-faint);
+  position: relative;
+}
+
+.masthead .eyebrow {
+  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, monospace);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.masthead .eyebrow::before {
+  content: "";
+  width: 20px;
+  height: 1px;
+  background: var(--border-strong);
+  flex-shrink: 0;
+}
+
+.masthead h1 {
+  font-family: var(--font-inter);
+  font-weight: 650;
+  font-size: clamp(34px, 4.5vw, 54px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 12px;
+  color: var(--ink);
+}
+
+.masthead h1 em {
+  font-style: normal;
+  color: var(--muted);
+}
+
+.masthead .intro {
+  font-size: 15px;
+  color: var(--body);
+  margin: 20px 0 0;
+  max-width: 620px;
+  line-height: 1.55;
+}
+
+.masthead .intro a {
+  color: var(--ink);
+  text-decoration-color: var(--border-subtle);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.15s ease;
+}
+
+.masthead .intro a:hover {
+  text-decoration-color: var(--ink);
+}
+
+.pill-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 24px 0 0;
+}
+
+.pill-nav a {
+  font-size: 13px;
+  padding: 7px 12px;
+  border: 1px solid var(--border-faint);
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--body);
+  background: #ffffff;
+  transition: border-color 120ms, color 120ms, background 120ms;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pill-nav a .pill-count {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  color: var(--muted-soft);
+}
+
+.pill-nav a:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.pill-nav a:hover .pill-count {
+  color: var(--primary);
+}
+
+.pill-nav a.pill-active {
+  border-color: var(--ink);
+  background: var(--surface-soft);
+  color: var(--ink);
+}
+
+.blog-page-head {
+  padding-top: 48px;
+}
+
+.blog-page-head h1 {
+  color: var(--ink);
+  font-size: clamp(34px, 4.5vw, 54px);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+
+.blog-page-head p {
+  color: var(--body);
+  font-size: 15px;
+  line-height: 1.65;
+  margin-top: 18px;
+  max-width: 660px;
+}
+
+.sec-head {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin-bottom: 10px;
+}
+
+.sec-head .sec-idx {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 13px;
+  color: var(--primary);
+  font-weight: 600;
+  width: 34px;
+  flex-shrink: 0;
+}
+
+.sec-head h2 {
+  font-family: var(--font-inter);
+  font-weight: 650;
+  font-size: 27px;
+  margin: 0;
+  letter-spacing: -0.012em;
+  color: var(--ink);
+}
+
+.sec-head .sec-count {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--muted-soft);
+  background: var(--surface-soft);
+  padding: 2px 10px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.sec-intro {
+  font-size: 14.5px;
+  color: var(--body);
+  max-width: 700px;
+  margin: 0 0 24px 50px;
+  line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+  .sec-intro { margin-left: 0; }
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  gap: 0;
+  border-top: 1px solid var(--border-faint);
+  border-left: 1px solid var(--border-faint);
+}
+
+@media (max-width: 640px) {
+  .card-grid {
+    border-left: 0;
+  }
+}
+
+.card-grid .card {
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-right: 1px solid var(--border-faint);
+  border-bottom: 1px solid var(--border-faint);
+  border-radius: 0;
+  text-decoration: none;
+  color: inherit;
+  transition: background 150ms ease, color 150ms ease;
+  overflow: hidden;
+}
+
+.card-grid .card:hover {
+  background: var(--surface-soft);
+}
+
+.card-grid .card-thumb {
+  height: 120px;
+  background: var(--surface-soft);
+  border-bottom: 1.5px solid var(--border-faint);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  transition: background 150ms ease;
+}
+
+.card-grid .card:hover .card-thumb {
+  background: var(--surface-card);
+}
+
+.card-grid .card-body {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 210px;
+}
+
+.card-grid .card-title {
+  font-family: var(--font-inter);
+  font-size: 18px;
+  font-weight: 650;
+  line-height: 1.22;
+  color: var(--ink);
+  margin-bottom: 7px;
+  letter-spacing: -0.008em;
+}
+
+.card-grid .card-desc {
+  font-size: 13.5px;
+  color: var(--body);
+  line-height: 1.55;
+  margin-bottom: 16px;
+  flex: 1;
+}
+
+.card-grid .card-footer {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--muted-soft);
+  border-top: 1px solid var(--border-faint);
+  padding-top: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.card-grid .card-footer .card-arrow {
+  transition: transform 150ms ease;
+  color: var(--border-subtle);
+}
+
+.card-grid .card:hover .card-footer {
+  color: var(--ink);
+}
+
+.card-grid .card:hover .card-footer .card-arrow {
+  transform: translateX(3px);
+  color: var(--ink);
+}
+
+.post-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted);
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
+
+.blog-link-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  border-top: 1px solid var(--border-faint);
+  border-left: 1px solid var(--border-faint);
+}
+
+.blog-link-grid a {
+  display: flex;
+  min-width: 0;
+  min-height: 150px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 18px;
+  border-right: 1px solid var(--border-faint);
+  border-bottom: 1px solid var(--border-faint);
+  padding: 18px;
+  color: var(--ink);
+  text-decoration: none;
+  transition: background 150ms ease;
+}
+
+.blog-link-grid a:hover {
+  background: var(--surface-soft);
+}
+
+.blog-link-grid h2,
+.blog-link-grid h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+
+.blog-link-grid p {
+  color: var(--body);
+  font-size: 13.5px;
+  line-height: 1.55;
+  margin: 10px 0 0;
+}
+
+.blog-link-grid .meta {
+  color: var(--muted);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+}
+
+@media (max-width: 640px) {
+  .blog-link-grid {
+    border-left: 0;
+  }
+}
+
+.tag-badge {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border-radius: 8px;
+  background: var(--surface-soft);
+  color: var(--muted);
+  border: 1px solid var(--border-faint);
+  transition: background 150ms, color 150ms;
+}
+
+.tag-badge:hover {
+  background: var(--ink);
+  color: white;
+  border-color: var(--ink);
+}
+
+/* ── Footer ─────────────────────────────── */
+
+.blog-footer {
+  margin-top: 80px;
+  border-top: 1.5px solid var(--border-subtle);
+  padding: 32px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 20px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: var(--muted-soft);
+}
+
+.blog-footer .blog-footer-brand {
+  font-family: var(--font-inter);
+  font-style: normal;
+  color: var(--body);
+  font-size: 15px;
+}
+
+.blog-footer a {
+  color: var(--ink);
+  text-decoration-color: var(--hairline);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.15s ease;
+}
+
+.blog-footer a:hover {
+  text-decoration-color: var(--ink);
+}
+
+/* ── Responsive Sections ────────────────── */
+
+.blog-section {
+  margin-top: 64px;
+  scroll-margin-top: 28px;
+}
+
+/* ── Focus & Accessibility ──────────────── */
+
+.blog-focus-ring:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}

--- a/apps/home/src/components/WorkStackSection.tsx
+++ b/apps/home/src/components/WorkStackSection.tsx
@@ -38,9 +38,9 @@ const skills = [
 
 export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
   return (
-    <div className="space-y-12 py-4 lg:space-y-14">
+    <div className="space-y-10 py-2 lg:space-y-12">
       <section>
-        <div className="grid gap-8 lg:grid-cols-[0.7fr_1fr] lg:items-start">
+        <div className="grid gap-6 lg:grid-cols-[0.65fr_1fr] lg:items-start">
           <div className="max-w-md">
             <p className="mb-3 text-sm font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
               Focus
@@ -50,16 +50,16 @@ export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
             </h2>
           </div>
 
-          <div className="divide-y divide-[var(--border)] border-y border-[var(--border)]">
+          <div className="divide-y divide-[var(--hairline)] border-y border-[var(--hairline)]">
             {focusAreas.map((item) => (
               <div
                 key={item.label}
-                className="grid gap-2 py-5 md:grid-cols-[180px_1fr] md:gap-8"
+                className="grid gap-2 py-4 md:grid-cols-[180px_1fr] md:gap-8"
               >
                 <p className="text-sm font-semibold text-[var(--foreground)]">
                   {item.label}
                 </p>
-                <p className="text-base leading-7 text-[var(--muted-foreground)]">
+                <p className="text-sm leading-6 text-[var(--muted-foreground)]">
                   {item.value}
                 </p>
               </div>
@@ -93,7 +93,7 @@ export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
           </a>
         </div>
 
-        <div className="mt-8 flex flex-wrap gap-x-5 gap-y-2 border-y border-[var(--hairline)] py-5">
+        <div className="mt-6 flex flex-wrap gap-x-5 gap-y-2 border-y border-[var(--hairline)] py-4">
           {skills.map((skill) => (
             <span
               key={skill}
@@ -107,4 +107,3 @@ export function WorkStackSection({ repositoryUrl }: WorkStackSectionProps) {
     </div>
   );
 }
-

--- a/apps/home/src/data/projects.ts
+++ b/apps/home/src/data/projects.ts
@@ -27,14 +27,6 @@ const projectUrls = {
 
 export const apps: AppItem[] = [
   {
-    name: "Duyet Serif",
-    href: projectUrls.fonts,
-    host: hostOf(projectUrls.fonts),
-    utmContent: "fonts_bento",
-    description: "Curated collection of beautiful Vietnamese-compatible fonts",
-    tone: "bg-[#7a705d]",
-  },
-  {
     name: "ClickHouse Monitoring",
     href: projectUrls.clickhouseMonitoring,
     host: hostOf(projectUrls.clickhouseMonitoring),
@@ -45,23 +37,12 @@ export const apps: AppItem[] = [
     tone: "bg-[#8b633f]",
   },
   {
-    name: "Rust Tieng Viet",
-    href: duyetUrls.external.rust ?? "https://rust-tieng-viet.github.io",
-    host: hostOf(
-      duyetUrls.external.rust ?? "https://rust-tieng-viet.github.io"
-    ),
-    utmContent: "rust_bento",
-    description: "Rust programming language documentation in Vietnamese",
-    screenshot: "/screenshots/rust-art.png",
-    tone: "bg-[#6a5578]",
-  },
-  {
-    name: "MCP Tools",
-    href: duyetUrls.external.mcp ?? "https://mcp.duyet.net",
-    host: hostOf(duyetUrls.external.mcp ?? "https://mcp.duyet.net"),
-    utmContent: "mcp_bento",
-    description: "Model Context Protocol tools and integrations",
-    screenshot: "/screenshots/mcp-tools-art.png",
+    name: "ShareHTML",
+    href: projectUrls.shareHtml,
+    host: hostOf(projectUrls.shareHtml),
+    utmContent: "sharehtml_bento",
+    description:
+      "Share HTML, Markdown, and code files. Built for Human and AI Agent. Self-hosted on Cloudflare Workers.",
     tone: "bg-[#5f6257]",
   },
   {
@@ -72,6 +53,24 @@ export const apps: AppItem[] = [
     description: "AI chat interface with Cloudflare Workers AI and streaming",
     screenshot: "/screenshots/ai-agents.png",
     tone: "bg-[#536f91]",
+  },
+  {
+    name: "Agent State",
+    href: projectUrls.agentState,
+    host: hostOf(projectUrls.agentState),
+    utmContent: "agentstate_bento",
+    description: "AI agent state management and debugging tools",
+    screenshot: "/screenshots/agentstate-art.svg",
+    tone: "bg-[#536f91]",
+  },
+  {
+    name: "MCP Tools",
+    href: duyetUrls.external.mcp ?? "https://mcp.duyet.net",
+    host: hostOf(duyetUrls.external.mcp ?? "https://mcp.duyet.net"),
+    utmContent: "mcp_bento",
+    description: "Model Context Protocol tools and integrations",
+    screenshot: "/screenshots/mcp-tools-art.png",
+    tone: "bg-[#5f6257]",
   },
   {
     name: "Claude Codex Plugins",
@@ -92,15 +91,6 @@ export const apps: AppItem[] = [
     tone: "bg-[#7f524e]",
   },
   {
-    name: "Agent State",
-    href: projectUrls.agentState,
-    host: hostOf(projectUrls.agentState),
-    utmContent: "agentstate_bento",
-    description: "AI agent state management and debugging tools",
-    screenshot: "/screenshots/agentstate-art.svg",
-    tone: "bg-[#536f91]",
-  },
-  {
     name: "PageView",
     href: projectUrls.pageview,
     host: hostOf(projectUrls.pageview),
@@ -110,14 +100,6 @@ export const apps: AppItem[] = [
     tone: "bg-[#7a705d]",
   },
   {
-    name: "ShareHTML",
-    href: projectUrls.shareHtml,
-    host: hostOf(projectUrls.shareHtml),
-    utmContent: "sharehtml_bento",
-    description: "Publish and share HTML documents with simple hosted links",
-    tone: "bg-[#5f6257]",
-  },
-  {
     name: "LLM Timeline",
     href: "/",
     host: hostOf(projectUrls.llmTimeline),
@@ -125,5 +107,24 @@ export const apps: AppItem[] = [
     description: "Interactive timeline of LLM models from 2017-2025",
     screenshot: "/screenshots/llm-timeline.png",
     tone: "bg-[#4f6f62]",
+  },
+  {
+    name: "Rust Tieng Viet",
+    href: duyetUrls.external.rust ?? "https://rust-tieng-viet.github.io",
+    host: hostOf(
+      duyetUrls.external.rust ?? "https://rust-tieng-viet.github.io"
+    ),
+    utmContent: "rust_bento",
+    description: "Rust programming language documentation in Vietnamese",
+    screenshot: "/screenshots/rust-art.png",
+    tone: "bg-[#6a5578]",
+  },
+  {
+    name: "Duyet Serif",
+    href: projectUrls.fonts,
+    host: hostOf(projectUrls.fonts),
+    utmContent: "fonts_bento",
+    description: "Curated collection of beautiful Vietnamese-compatible fonts",
+    tone: "bg-[#7a705d]",
   },
 ];

--- a/apps/home/src/data/projects.ts
+++ b/apps/home/src/data/projects.ts
@@ -13,6 +13,7 @@ export interface AppItem {
 const hostOf = (url: string) => new URL(url).host;
 
 const projectUrls = {
+  clickhouseMonitoring: "https://chmonitor.dev",
   llmTimeline: "https://llm-timeline.duyet.net",
   agents: "https://agents.duyet.net/agents",
   claw: "https://claw.duyet.net",
@@ -35,12 +36,11 @@ export const apps: AppItem[] = [
   },
   {
     name: "ClickHouse Monitoring",
-    href: duyetUrls.external.clickhouse ?? "https://clickhouse.duyet.net",
-    host: hostOf(
-      duyetUrls.external.clickhouse ?? "https://clickhouse.duyet.net"
-    ),
+    href: projectUrls.clickhouseMonitoring,
+    host: hostOf(projectUrls.clickhouseMonitoring),
     utmContent: "ch_monitor_bento",
-    description: "Real-time monitoring dashboard for ClickHouse clusters",
+    description:
+      "ClickHouse monitoring with AI agent support for finding insights, monitoring clusters, and triaging activity",
     screenshot: "/screenshots/ch-monitor.png",
     tone: "bg-[#8b633f]",
   },

--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -1,9 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import {
-  Github as GithubIcon,
-  LinkedIn as LinkedInIcon,
-} from "@duyet/components/Icons";
-import { ArrowRight, BookOpen, FileUser, Radio } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { addUtmParams } from "../../app/lib/utm";
 import { SiteFooter, SiteHeader } from "../components/SiteChrome";
 import { WorkStackSection } from "../components/WorkStackSection";
@@ -98,14 +94,12 @@ const links = [
     description:
       "Experience building scalable data infrastructure, AI applications, and production systems.",
     url: addUtmParams("https://cv.duyet.net", "about_page", "resume_card"),
-    icon: FileUser,
   },
   {
     title: "GitHub",
     description:
       "Open source work across Python, Rust, TypeScript, analytics, and developer tooling.",
     url: addUtmParams("https://github.com/duyet", "about_page", "github_card"),
-    icon: GithubIcon,
   },
   {
     title: "LinkedIn",
@@ -116,21 +110,19 @@ const links = [
       "about_page",
       "linkedin_card"
     ),
-    icon: LinkedInIcon,
   },
   {
     title: "Blog",
     description:
       "Technical writing on data engineering, distributed systems, AI agents, and open source.",
     url: addUtmParams("https://blog.duyet.net", "about_page", "blog_card"),
-    icon: BookOpen,
   },
 ];
 
 function AboutPage() {
   return (
-      <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
-        <SiteHeader />
+    <div className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
+      <SiteHeader />
 
       <main className="relative z-10 bg-[var(--background)] pb-16">
         <section className="mx-auto max-w-[1180px] px-5 py-12 sm:px-8 md:py-16 lg:px-10 lg:py-20">
@@ -164,52 +156,45 @@ function AboutPage() {
 
         <section className="mx-auto max-w-[1180px] px-5 sm:px-8 lg:px-10">
           <div className="border-y border-[var(--hairline)]">
-            {links.map((item) => {
-              const Icon = item.icon;
-              return (
-                <a
-                  key={item.title}
-                  href={item.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group grid gap-4 border-t border-[var(--hairline)] py-5 text-[var(--foreground)] transition-colors first:border-t-0 hover:text-[var(--muted-foreground)] md:grid-cols-[32px_160px_1fr] md:items-start"
-                >
-                  <Icon className="h-5 w-5 shrink-0 text-[var(--muted-foreground)] md:mt-1" />
-                  <h2 className="text-lg font-semibold">
-                    {item.title}
-                  </h2>
-                  <p className="text-sm leading-6 text-[var(--muted-foreground)]">
-                    {item.description}
-                  </p>
-                </a>
-              );
-            })}
+            {links.map((item) => (
+              <a
+                key={item.title}
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group grid gap-2 border-t border-[var(--hairline)] py-5 text-[var(--foreground)] transition-colors first:border-t-0 hover:text-[var(--muted-foreground)] md:grid-cols-[160px_1fr] md:gap-8 md:items-start"
+              >
+                <h2 className="text-lg font-semibold">
+                  {item.title}
+                </h2>
+                <p className="text-sm leading-6 text-[var(--muted-foreground)]">
+                  {item.description}
+                </p>
+              </a>
+            ))}
           </div>
         </section>
 
-        <WorkStackSection
-          repositoryUrl={addUtmParams(
-            "https://github.com/duyet",
-            "about_page",
-            "skills_github"
-          )}
-        />
+        <section className="mx-auto mt-14 max-w-[1180px] px-5 sm:px-8 lg:px-10">
+          <WorkStackSection
+            repositoryUrl={addUtmParams(
+              "https://github.com/duyet",
+              "about_page",
+              "skills_github"
+            )}
+          />
+        </section>
 
         <section className="mx-auto mt-14 max-w-[1180px] px-5 pb-16 sm:px-8 lg:px-10">
           <div className="grid gap-5 border-y border-[var(--hairline)] py-6 md:grid-cols-[1fr_auto] md:items-center">
-            <div className="flex items-start gap-4">
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center text-[var(--foreground)]">
-                <Radio className="h-5 w-5" />
-              </span>
-              <div>
-                <h2 className="text-xl font-semibold tracking-tight">
-                  Follow the work
-                </h2>
-                <p className="mt-1 text-base font-medium text-[var(--muted-foreground)]">
-                  Blog posts, project notes, analytics, and small tools across
-                  the Duyet network.
-                </p>
-              </div>
+            <div>
+              <h2 className="text-xl font-semibold tracking-tight">
+                Follow the work
+              </h2>
+              <p className="mt-1 text-base font-medium text-[var(--muted-foreground)]">
+                Blog posts, project notes, analytics, and small tools across
+                the Duyet network.
+              </p>
             </div>
             <a
               href={addUtmParams(

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -1,12 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import {
-  ArrowRight,
-  ChartNoAxesCombined,
-  FileUser,
-  Newspaper,
-  Server,
-  UserRound,
-} from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { Suspense } from "react";
 import type { ReactNode } from "react";
 import { addUtmParams } from "../../app/lib/utm";
@@ -25,14 +18,12 @@ const capabilities = [
     description:
       "Deep dives into data engineering architecture, distributed systems, AI agents, and lessons learned from scaling open source.",
     href: addUtmParams("https://blog.duyet.net", "homepage", "blog_card"),
-    icon: Newspaper,
   },
   {
     title: "Resume",
     description:
       "Scalable data infrastructure, intelligent applications, and production systems that stay fast as usage grows.",
     href: addUtmParams("https://cv.duyet.net", "homepage", "resume_card"),
-    icon: FileUser,
   },
   {
     title: "Insights",
@@ -43,14 +34,12 @@ const capabilities = [
       "homepage",
       "insights_card"
     ),
-    icon: ChartNoAxesCombined,
   },
   {
     title: "About",
     description:
       "Clear project surfaces for Rust, ClickHouse, MCP tools, AI agents, and the small systems that make them useful.",
     href: "/about",
-    icon: UserRound,
   },
 ];
 
@@ -66,14 +55,14 @@ function HomePage() {
 
         <main className="relative z-10">
           {/* Hero Section */}
-          <section className="mx-auto max-w-[1180px] px-5 py-14 sm:px-8 md:py-20 lg:px-10">
-            <div className="grid gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)] lg:items-center">
-              <div className="space-y-[var(--gap-md)]">
-                <div className="space-y-4">
+          <section className="mx-auto max-w-[1180px] px-5 py-10 sm:px-8 md:py-14 lg:px-10 lg:py-16">
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)] lg:items-start">
+              <div className="space-y-6">
+                <div className="space-y-3">
                   <p className="text-sm font-semibold uppercase tracking-[0.12em] text-[var(--muted-foreground)]">
                     Duyet Le
                   </p>
-                  <h1 className="max-w-3xl text-balance text-4xl font-semibold leading-[1.06] sm:text-5xl lg:text-6xl">
+                  <h1 className="max-w-3xl text-balance text-4xl font-semibold leading-[1.06] sm:text-5xl lg:text-[64px]">
                     Data engineer building practical AI systems
                   </h1>
                 </div>
@@ -108,11 +97,14 @@ function HomePage() {
                     ["Data systems", "Pipelines, warehouses, observability"],
                     ["AI products", "Agents, routing, evaluation"],
                     ["Open source", "Rust, TypeScript, Cloudflare"],
-                  ].map(([label, value]) => (
+                  ].map(([label, value], index) => (
                     <div
                       key={label}
-                      className="grid grid-cols-[140px_1fr] gap-8 border-t border-[var(--hairline)] py-4 first:border-t-0"
+                      className="grid grid-cols-[32px_140px_1fr] gap-6 border-t border-[var(--hairline)] py-4 first:border-t-0"
                     >
+                      <p className="font-mono text-xs text-[var(--muted-soft)]">
+                        {String(index + 1).padStart(2, "0")}
+                      </p>
                       <p className="text-sm font-semibold text-[var(--foreground)]">
                         {label}
                       </p>
@@ -127,8 +119,8 @@ function HomePage() {
           </section>
 
           {/* Capabilities Section */}
-          <section className="mx-auto max-w-[1180px] px-5 py-10 sm:px-8 lg:px-10 lg:py-14">
-            <div className="mb-6">
+          <section className="mx-auto max-w-[1180px] px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+            <div className="mb-5">
               <h2 className="text-2xl font-semibold sm:text-3xl">
                 Network
               </h2>
@@ -142,7 +134,7 @@ function HomePage() {
           </section>
 
           {/* WorkStack Band */}
-          <section className="border-y border-[var(--hairline)] bg-[var(--background-secondary)] py-12 lg:py-16">
+          <section className="border-y border-[var(--hairline)] bg-[var(--background-secondary)] py-10 lg:py-12">
             <div className="mx-auto max-w-[1180px] px-5 sm:px-8 lg:px-10">
               <WorkStackSection
                 repositoryUrl={addUtmParams(
@@ -157,7 +149,7 @@ function HomePage() {
           {/* Apps Section */}
           <section
             id="apps"
-            className="mx-auto max-w-[1180px] px-5 py-10 sm:px-8 lg:px-10 lg:py-14"
+            className="mx-auto max-w-[1180px] px-5 py-8 sm:px-8 lg:px-10 lg:py-10"
           >
             <div className="mb-6 flex flex-col justify-between gap-4 md:flex-row md:items-end">
               <div>
@@ -168,10 +160,14 @@ function HomePage() {
                   A curated collection of production tools, experimental
                   interfaces, and data systems managed by <span className="text-[var(--foreground)]">@duyetbot</span>.
                 </p>
+                <p className="mt-2 max-w-xl text-xs leading-5 text-[var(--muted-soft)]">
+                  duyet.net is now managed by the duyetbot agent and can change
+                  at any time.
+                </p>
               </div>
             </div>
 
-            <div className="grid grid-cols-1 gap-x-10 border-y border-[var(--hairline)] md:grid-cols-2 lg:grid-cols-3">
+            <div className="border-y border-[var(--hairline)]">
               {apps.map((item) => (
                 <AppRow key={item.name} item={item} />
               ))}
@@ -189,7 +185,7 @@ function HomePage() {
           </section>
 
           {/* Contact Section */}
-          <section className="mx-auto max-w-[1180px] px-5 py-10 sm:px-8 lg:px-10 lg:py-14">
+          <section className="mx-auto max-w-[1180px] px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
             <div className="flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
               <div className="max-w-xl">
                 <h2 className="text-2xl font-semibold sm:text-3xl">
@@ -254,19 +250,19 @@ function AppRow({
   return (
     <AppLink
       item={item}
-      className="group flex items-start gap-4 border-t border-[var(--hairline)] py-5 text-[var(--foreground)] transition-colors first:border-t-0 hover:text-[var(--muted-foreground)]"
+      className="group grid gap-2 border-t border-[var(--hairline)] py-4 text-[var(--foreground)] transition-colors first:border-t-0 hover:text-[var(--muted-foreground)] sm:grid-cols-[180px_1fr_180px] sm:gap-8"
     >
-      <div className="flex h-7 w-7 shrink-0 items-center justify-center text-[var(--muted-foreground)]">
-        <Server className="h-4 w-4" />
-      </div>
       <div className="min-w-0">
         <h3 className="text-base font-semibold leading-snug">
           {item.name}
         </h3>
-        <p className="mt-1 text-sm leading-6 text-[var(--muted-foreground)] line-clamp-2">
-          {item.description}
-        </p>
       </div>
+      <p className="text-sm leading-6 text-[var(--muted-foreground)] sm:max-w-2xl">
+        {item.description}
+      </p>
+      <p className="truncate font-mono text-xs text-[var(--muted-soft)] sm:text-right">
+        {item.host}
+      </p>
     </AppLink>
   );
 }
@@ -275,19 +271,14 @@ function CapabilityRow({
   title,
   description,
   href,
-  icon: Icon,
 }: {
   title: string;
   description: string;
   href: string;
-  icon: typeof Newspaper;
 }) {
   const isExternal = href.startsWith("http");
   const children = (
-    <div className="grid gap-4 py-6 md:grid-cols-[32px_180px_1fr] md:items-start">
-      <div className="pt-1">
-        <Icon className="h-5 w-5 shrink-0 text-[var(--muted-foreground)]" />
-      </div>
+    <div className="grid gap-2 py-5 md:grid-cols-[180px_1fr] md:gap-8 md:items-start">
       <h3 className="text-lg font-semibold">{title}</h3>
       <p className="text-sm leading-6 text-[var(--muted-foreground)]">
         {description}

--- a/apps/home/src/routes/p/$project.tsx
+++ b/apps/home/src/routes/p/$project.tsx
@@ -39,18 +39,19 @@ const products: Product[] = [
   {
     slug: "chm",
     name: "ClickHouse Monitoring",
-    eyebrow: "Operational dashboard",
-    summary: "A ClickHouse cluster monitoring surface for fast daily triage.",
+    eyebrow: "AI-assisted monitoring",
+    summary:
+      "A ClickHouse cluster monitoring surface with agent support for finding insights and triaging activity.",
     image: "/screenshots/ch-monitor.png",
-    url: "https://clickhouse.duyet.net",
+    url: "https://chmonitor.dev",
     year: "2026",
     role: "Product design, frontend, observability",
     industry: "Data infrastructure",
     overview:
-      "The monitoring app keeps cluster health, query activity, and operational signals in a compact interface built for repeated use.",
+      "The monitoring app keeps cluster health, query activity, and operational signals in a compact interface, with AI agent support for finding insights and monitoring changes.",
     highlights: [
       "Dense but readable dashboards for ClickHouse operations.",
-      "Focused query and cluster views without marketing-page chrome.",
+      "AI agent workflows for surfacing insights from cluster and query activity.",
       "Responsive layouts that keep metrics scannable on smaller screens.",
     ],
   },

--- a/packages/components/AppCommandPalette.tsx
+++ b/packages/components/AppCommandPalette.tsx
@@ -194,7 +194,7 @@ export function AppCommandPalette({ className }: AppCommandPaletteProps) {
           <Search className="h-4 w-4" />
         </button>
       </DialogTrigger>
-      <DialogContent className="w-[min(620px,calc(100vw-2rem))] overflow-hidden rounded-2xl border border-[#1a1a1a]/10 bg-white p-0 text-[#1a1a1a] shadow-none dark:border-[#1a1a1a]/10 dark:bg-white dark:text-[#1a1a1a] dark:shadow-none">
+      <DialogContent className="w-[min(860px,calc(100vw-2rem))] overflow-hidden rounded-2xl border border-[#1a1a1a]/10 bg-white p-0 text-[#1a1a1a] shadow-none dark:border-[#1a1a1a]/10 dark:bg-white dark:text-[#1a1a1a] dark:shadow-none">
         <DialogTitle className="sr-only">Command Palette</DialogTitle>
         <DialogDescription className="sr-only">
           Search across Duyet apps, pages, and subdomains.
@@ -202,9 +202,9 @@ export function AppCommandPalette({ className }: AppCommandPaletteProps) {
         <Command className="bg-transparent">
           <CommandInput
             placeholder="Search pages and apps..."
-            className="text-lg font-medium placeholder:text-[#1a1a1a]/50 dark:placeholder:text-[#1a1a1a]/50"
+            className="h-16 text-2xl font-medium placeholder:text-[#1a1a1a]/45 dark:placeholder:text-[#1a1a1a]/45"
           />
-          <CommandList className="max-h-[460px] p-2">
+          <CommandList className="max-h-[640px] p-3">
             <CommandEmpty>No app found.</CommandEmpty>
             <CommandGroup heading="Duyet apps">
               {appItems.slice(0, 11).map((item) => (
@@ -215,15 +215,15 @@ export function AppCommandPalette({ className }: AppCommandPaletteProps) {
                     setOpen(false);
                     window.location.href = item.href;
                   }}
-                  className="items-start rounded-xl border border-transparent px-3 py-3 data-[selected=true]:border-[#1a1a1a]/10 data-[selected=true]:bg-[#f7f7f7] data-[selected=true]:text-[#1a1a1a] dark:data-[selected=true]:border-[#1a1a1a]/10 dark:data-[selected=true]:bg-[#f7f7f7] dark:data-[selected=true]:text-[#1a1a1a]"
+                  className="items-start rounded-xl border border-transparent px-5 py-4 data-[selected=true]:border-[#1a1a1a]/10 data-[selected=true]:bg-[#f7f7f7] data-[selected=true]:text-[#1a1a1a] dark:data-[selected=true]:border-[#1a1a1a]/10 dark:data-[selected=true]:bg-[#f7f7f7] dark:data-[selected=true]:text-[#1a1a1a]"
                 >
-                  <div className="flex min-w-0 items-start gap-3">
-                    <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#1a1a1a]/10 bg-white">
-                      <item.icon className="h-4 w-4 text-[#1a1a1a]/80" />
+                  <div className="flex min-w-0 items-start gap-4">
+                    <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[#1a1a1a]/10 bg-white">
+                      <item.icon className="h-5 w-5 text-[#1a1a1a]/80" />
                     </span>
                     <div className="min-w-0">
-                      <div className="text-sm font-semibold tracking-tight">{item.label}</div>
-                      <div className="truncate text-xs text-[#1a1a1a]/55 dark:text-[#1a1a1a]/55">
+                      <div className="text-base font-semibold tracking-tight sm:text-lg">{item.label}</div>
+                      <div className="truncate text-sm text-[#1a1a1a]/55 dark:text-[#1a1a1a]/55">
                         {item.description}
                       </div>
                     </div>
@@ -241,15 +241,15 @@ export function AppCommandPalette({ className }: AppCommandPaletteProps) {
                     setOpen(false);
                     window.location.href = item.href;
                   }}
-                  className="items-start rounded-xl border border-transparent px-3 py-3 data-[selected=true]:border-[#1a1a1a]/10 data-[selected=true]:bg-[#f7f7f7] data-[selected=true]:text-[#1a1a1a] dark:data-[selected=true]:border-[#1a1a1a]/10 dark:data-[selected=true]:bg-[#f7f7f7] dark:data-[selected=true]:text-[#1a1a1a]"
+                  className="items-start rounded-xl border border-transparent px-5 py-4 data-[selected=true]:border-[#1a1a1a]/10 data-[selected=true]:bg-[#f7f7f7] data-[selected=true]:text-[#1a1a1a] dark:data-[selected=true]:border-[#1a1a1a]/10 dark:data-[selected=true]:bg-[#f7f7f7] dark:data-[selected=true]:text-[#1a1a1a]"
                 >
-                  <div className="flex min-w-0 items-start gap-3">
-                    <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[#1a1a1a]/10 bg-white">
-                      <item.icon className="h-4 w-4 text-[#1a1a1a]/80" />
+                  <div className="flex min-w-0 items-start gap-4">
+                    <span className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[#1a1a1a]/10 bg-white">
+                      <item.icon className="h-5 w-5 text-[#1a1a1a]/80" />
                     </span>
                     <div className="min-w-0">
-                      <div className="text-sm font-semibold tracking-tight">{item.label}</div>
-                      <div className="truncate text-xs text-[#1a1a1a]/55 dark:text-[#1a1a1a]/55">
+                      <div className="text-base font-semibold tracking-tight sm:text-lg">{item.label}</div>
+                      <div className="truncate text-sm text-[#1a1a1a]/55 dark:text-[#1a1a1a]/55">
                         {item.description}
                       </div>
                     </div>

--- a/packages/components/header/index.tsx
+++ b/packages/components/header/index.tsx
@@ -115,16 +115,19 @@ export default function Header({
       {/* Mobile nav panel */}
       <div
         className={cn(
-          "md:hidden overflow-hidden transition-all duration-200 ease-out",
-          mobileOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
+          "md:hidden fixed inset-x-0 top-16 z-40 min-h-[calc(100dvh-4rem)] bg-[var(--background)] px-5 py-8 transition-all duration-200 ease-out sm:px-8",
+          mobileOpen
+            ? "pointer-events-auto translate-y-0 opacity-100"
+            : "pointer-events-none -translate-y-2 opacity-0"
         )}
+        aria-hidden={!mobileOpen}
       >
-        <div className="border-t border-[var(--hairline)] dark:border-white/8 px-5 py-3">
+        <div className="border-y border-[var(--hairline)] py-4 dark:border-white/8">
           <MenuNav
             urls={urls}
             navigationItems={navigationItems}
             onItemClick={() => setMobileOpen(false)}
-            className="flex-col items-start gap-1"
+            className="flex-col items-stretch gap-0"
           />
         </div>
       </div>

--- a/packages/components/header/index.tsx
+++ b/packages/components/header/index.tsx
@@ -6,8 +6,8 @@ import { duyetProfile } from "@duyet/profile";
 import type { UrlsConfig } from "@duyet/urls";
 import { duyetUrls } from "@duyet/urls";
 import { Menu as MenuIcon, X as CloseIcon } from "lucide-react";
-import type { ReactNode } from "react";
-import { useState } from "react";
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import MenuNav, { type NavigationItem } from "../Menu";
 import { AuthButtons } from "./AuthButtons";
 import { HeaderBranding } from "./HeaderBranding";
@@ -42,11 +42,29 @@ export default function Header({
   containerClassName,
 }: HeaderProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const headerRef = useRef<HTMLElement>(null);
+  const [headerHeight, setHeaderHeight] = useState(64);
   const displayShortText = shortText ?? profile.personal.shortName;
   const displayLongText = longText ?? profile.personal.title;
 
+  useEffect(() => {
+    const header = headerRef.current;
+    if (!header) return;
+
+    const updateHeaderHeight = () => {
+      setHeaderHeight(header.getBoundingClientRect().height);
+    };
+
+    updateHeaderHeight();
+    const observer = new ResizeObserver(updateHeaderHeight);
+    observer.observe(header);
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <header
+      ref={headerRef}
       className={cn(
         "z-50 bg-[var(--background)]",
         "border-b border-[var(--border)] dark:border-white/8",
@@ -115,11 +133,16 @@ export default function Header({
       {/* Mobile nav panel */}
       <div
         className={cn(
-          "md:hidden fixed inset-x-0 top-16 z-40 min-h-[calc(100dvh-4rem)] bg-[var(--background)] px-5 py-8 transition-all duration-200 ease-out sm:px-8",
+          "md:hidden fixed inset-x-0 top-[var(--mobile-menu-offset)] z-40 min-h-[calc(100dvh-var(--mobile-menu-offset))] bg-[var(--background)] px-5 py-8 transition-all duration-200 ease-out sm:px-8",
           mobileOpen
             ? "pointer-events-auto translate-y-0 opacity-100"
             : "pointer-events-none -translate-y-2 opacity-0"
         )}
+        style={
+          {
+            "--mobile-menu-offset": `${headerHeight}px`,
+          } as CSSProperties
+        }
         aria-hidden={!mobileOpen}
       >
         <div className="border-y border-[var(--hairline)] py-4 dark:border-white/8">


### PR DESCRIPTION
## Summary
- simplify the home/about UI further with lighter row layouts and tighter spacing
- update ClickHouse Monitoring to chmonitor.dev with AI agent support copy
- add the duyetbot management note and make the mobile header menu full-screen

## Verification
- bunx biome lint apps/home/src/data/projects.ts 'apps/home/src/routes/p/$project.tsx' apps/home/src/routes/about.tsx apps/home/src/routes/index.tsx apps/home/src/components/WorkStackSection.tsx packages/components/header/index.tsx packages/components/Menu.tsx
- bun run check-types (apps/home)
- bun run build (apps/home)
- browser check: mobile menu opens at 390px with no horizontal overflow
- browser check: /projects shows chmonitor.dev and AI agent copy
- browser check: /about Focus/Stack has mobile left padding
