### PR TITLE
chore(ci,docs): pin blog wasm actions and record maintenance scan

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -254,7 +254,7 @@ jobs:
 
       - name: Setup Rust toolchain (blog WASM markdown)
         if: matrix.app == 'blog'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
@@ -272,7 +272,7 @@ jobs:
 
       - name: Install wasm-pack
         if: matrix.app == 'blog'
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
         with:
           version: latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ For scoped reviews after the last run timestamp:
 - `git show --unified=3 <commit_sha>`
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence
 - `rg -n "setup-bun@" .github/workflows -g'*.yml'` to verify valid action pins after CI workflow updates
+- `rg -n "dtolnay/rust-toolchain@|jetli/wasm-pack-action@" .github/workflows -g'*.yml'` to verify Rust/WASM action refs are SHA-pinned after deploy-workflow changes
 - Keep durable findings in `docs/ai/core-memory.md` and list reference docs in `docs/INDEX.md`
 - Do not create dated `docs/reviews/code-smell-dead-code-<DATE>.md` files
 - `gh run list --branch master --event push --limit 10 --json databaseId,headSha,status,conclusion,name,updatedAt` to confirm post-merge `master` CI is green

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -37,3 +37,13 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - Dead-export cleanup (confident): `SearchParams` in `apps/blog/src/routes/search.tsx` is now file-local because no cross-file non-test references exist.
   - Evidence: `rg -n "\bSearchParams\b" apps packages --glob '!**/*.test.*' --glob '!**/*.spec.*' --glob '!**/__tests__/**'`.
 - Performance audit: no measured regressions found in commits since `2026-05-13T10:13:12Z`; latest `master` push workflows for `ff0f95cb` (`Lint`, `Test`, `Deploy to Cloudflare Pages`) are `success`.
+
+### 2026-05-15
+
+- CI hardening (warning -> fixed): deploy workflow added floating third-party action refs for blog WASM build. Pinned both refs to immutable SHAs:
+  - `.github/workflows/cf-deploy.yml`: `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8` (stable)
+  - `.github/workflows/cf-deploy.yml`: `jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa` (v0.4.0)
+  - Evidence: `git ls-remote https://github.com/dtolnay/rust-toolchain refs/heads/stable`, `git ls-remote https://github.com/jetli/wasm-pack-action refs/tags/v0.4.0`
+- Dead-code review (confident): no new dead code candidates in non-test files modified since `2026-05-13T21:00:54Z`; only content files plus `cf-deploy.yml`, `scripts/wasm-build.ts`, and blog static headers/redirects changed.
+  - Evidence: `git log --since='2026-05-13T21:00:54Z' --name-only --pretty=format: | sed '/^$/d' | sort -u`, plus repo-wide non-test symbol checks for touched symbols.
+- Performance audit: no measured regressions available in this commit window; recommend relying on post-merge `master` workflow durations for the first signal on added blog WASM build cost.


### PR DESCRIPTION
## Summary
- pin newly added blog WASM actions in `cf-deploy.yml` to immutable SHAs
- add a CLAUDE automation check command for Rust/WASM action pinning
- record this run's evidence and outcomes in `docs/ai/core-memory.md`

## Findings addressed
- warning: floating third-party refs introduced in deploy workflow
  - `.github/workflows/cf-deploy.yml`: `dtolnay/rust-toolchain@stable` -> `@29eef336d9b2848a0b548edc03f92a220660cdb8`
  - `.github/workflows/cf-deploy.yml`: `jetli/wasm-pack-action@v0.4.0` -> `@0d096b08b4e5a7de8c28de67e11e945404e9eefa`
  - evidence: `git ls-remote` for `refs/heads/stable` and `refs/tags/v0.4.0`
- dead code scan: no new confident candidates in non-test files modified since `2026-05-13T21:00:54Z`
- performance regressions: no measurements in this window; monitor post-merge workflow durations for blog WASM step cost

## Verification
- `git diff --check`
- `rg -n "dtolnay/rust-toolchain@|jetli/wasm-pack-action@" .github/workflows/cf-deploy.yml CLAUDE.md`
- `git log --since='2026-05-13T21:00:54Z' --name-only --pretty=format: | sed '/^$/d' | sort -u`

## Summary by Sourcery

Harden the blog deploy workflow by pinning Rust/WASM GitHub Actions to immutable SHAs and record the associated maintenance scan outcomes.

CI:
- Pin Rust toolchain and wasm-pack actions in the Cloudflare deploy workflow to specific commit SHAs for the blog WASM build.

Documentation:
- Append a new core-memory entry documenting the CI hardening, dead-code review, and performance audit for the latest maintenance run.
- Extend CLAUDE automation guidance with a check command to verify Rust/WASM GitHub Action references are SHA-pinned in workflows.