### PR TITLE
chore(ci,docs): pin wasm-pack version and update maintenance memory

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -274,7 +274,7 @@ jobs:
         if: matrix.app == 'blog'
         uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
         with:
-          version: latest
+          version: v0.15.0
 
       - name: Build WASM packages (markdown converter)
         if: matrix.app == 'blog'

--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -254,7 +254,7 @@ jobs:
 
       - name: Setup Rust toolchain (blog WASM markdown)
         if: matrix.app == 'blog'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
@@ -272,7 +272,7 @@ jobs:
 
       - name: Install wasm-pack
         if: matrix.app == 'blog'
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
         with:
           version: latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ For scoped reviews after the last run timestamp:
 - `git show --unified=3 <commit_sha>`
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence
 - `rg -n "setup-bun@" .github/workflows -g'*.yml'` to verify valid action pins after CI workflow updates
+- `rg -n "dtolnay/rust-toolchain@|jetli/wasm-pack-action@" .github/workflows -g'*.yml'` to verify Rust/WASM action refs are SHA-pinned after deploy-workflow changes
 - Keep durable findings in `docs/ai/core-memory.md` and list reference docs in `docs/INDEX.md`
 - Do not create dated `docs/reviews/code-smell-dead-code-<DATE>.md` files
 - `gh run list --branch master --event push --limit 10 --json databaseId,headSha,status,conclusion,name,updatedAt` to confirm post-merge `master` CI is green

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ For scoped reviews after the last run timestamp:
 - `git show --unified=3 <commit_sha>`
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence
 - `rg -n "setup-bun@" .github/workflows -g'*.yml'` to verify valid action pins after CI workflow updates
-- `rg -n "dtolnay/rust-toolchain@|jetli/wasm-pack-action@" .github/workflows -g'*.yml'` to verify Rust/WASM action refs are SHA-pinned after deploy-workflow changes
+- `rg -n "dtolnay/rust-toolchain@|jetli/wasm-pack-action@|version: latest" .github/workflows -g'*.yml'` to verify Rust/WASM action refs and wasm-pack version pins after deploy-workflow changes
 - Keep durable findings in `docs/ai/core-memory.md` and list reference docs in `docs/INDEX.md`
 - Do not create dated `docs/reviews/code-smell-dead-code-<DATE>.md` files
 - `gh run list --branch master --event push --limit 10 --json databaseId,headSha,status,conclusion,name,updatedAt` to confirm post-merge `master` CI is green

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -37,3 +37,13 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - Dead-export cleanup (confident): `SearchParams` in `apps/blog/src/routes/search.tsx` is now file-local because no cross-file non-test references exist.
   - Evidence: `rg -n "\bSearchParams\b" apps packages --glob '!**/*.test.*' --glob '!**/*.spec.*' --glob '!**/__tests__/**'`.
 - Performance audit: no measured regressions found in commits since `2026-05-13T10:13:12Z`; latest `master` push workflows for `ff0f95cb` (`Lint`, `Test`, `Deploy to Cloudflare Pages`) are `success`.
+
+### 2026-05-15
+
+- CI hardening (warning -> fixed): deploy workflow added floating third-party action refs for blog WASM build. Pinned both refs to immutable SHAs:
+  - `.github/workflows/cf-deploy.yml`: `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8` (stable)
+  - `.github/workflows/cf-deploy.yml`: `jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa` (v0.4.0)
+  - Evidence: `git ls-remote https://github.com/dtolnay/rust-toolchain refs/heads/stable`, `git ls-remote https://github.com/jetli/wasm-pack-action refs/tags/v0.4.0`
+- Dead-code review (confident): no new dead code candidates in non-test files modified since `2026-05-13T21:00:54Z`; only content files plus `cf-deploy.yml`, `scripts/wasm-build.ts`, and blog static headers/redirects changed.
+  - Evidence: `git log --since='2026-05-13T21:00:54Z' --name-only --pretty=format: | sed '/^$/d' | sort -u`, plus repo-wide non-test symbol checks for touched symbols.
+- Performance audit: no measured regressions available in this commit window; recommend relying on post-merge `master` workflow durations for the first signal on added blog WASM build cost.

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -47,3 +47,12 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - Dead-code review (confident): no new dead code candidates in non-test files modified since `2026-05-13T21:00:54Z`; only content files plus `cf-deploy.yml`, `scripts/wasm-build.ts`, and blog static headers/redirects changed.
   - Evidence: `git log --since='2026-05-13T21:00:54Z' --name-only --pretty=format: | sed '/^$/d' | sort -u`, plus repo-wide non-test symbol checks for touched symbols.
 - Performance audit: no measured regressions available in this commit window; recommend relying on post-merge `master` workflow durations for the first signal on added blog WASM build cost.
+
+### 2026-05-16
+
+- CI hardening (warning -> fixed): replaced floating `wasm-pack` installer version in blog deploy workflow.
+  - `.github/workflows/cf-deploy.yml`: `version: latest` -> `version: v0.15.0`
+  - Evidence: `rg -n "jetli/wasm-pack-action@|version: latest|version: v0.15.0" .github/workflows/cf-deploy.yml` plus `gh api repos/rustwasm/wasm-pack/releases/latest --jq '.tag_name'`.
+- Dead-code review (confident): no new dead code in non-test files changed in the fallback 24-hour window.
+  - Evidence: `git log --since='24 hours ago' --name-only --pretty=format: | sed '/^$/d' | sort -u` and repo-wide non-test symbol checks in touched code files.
+- Performance audit: no measured regression signal in this window; latest `master` push workflows remained `success` for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.


### PR DESCRIPTION
## Summary
- pin blog deploy wasm-pack installer to an explicit version (`v0.15.0`) instead of `latest`
- update `CLAUDE.md` automation command to detect floating wasm-pack installer versions
- append durable 2026-05-16 maintenance findings to `docs/ai/core-memory.md`

## Findings covered in this run
- warning: floating installer version in `.github/workflows/cf-deploy.yml` (`version: latest`)
- dead code: no confident new candidates in non-test files changed in fallback 24h window
- performance: no measured regression signal in current window; recent `master` runs for Lint/Test/Deploy are successful

## Verification
- `git diff --check -- .github/workflows/cf-deploy.yml CLAUDE.md docs/ai/core-memory.md`
- `rg -n "jetli/wasm-pack-action@|version: latest|version: v0.15.0" .github/workflows/cf-deploy.yml`
- `gh api repos/rustwasm/wasm-pack/releases/latest --jq '.tag_name'`

## Summary by Sourcery

Pin Rust/WASM tooling in the blog Cloudflare deploy workflow and record the related CI maintenance findings in durable docs.

Enhancements:
- Pin Rust toolchain and wasm-pack GitHub Actions to immutable SHAs in the blog deploy workflow and switch wasm-pack to a fixed released version.
- Document new CI hardening and dead-code/performance audit results in the durable core-memory log.

Documentation:
- Extend CLAUDE automation instructions to include checks for Rust/WASM action references and wasm-pack version pins.