### PR TITLE
chore(docs): record UTC-safe maintenance scan workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Put durable repository knowledge in `docs/ai/internal-knowledge.md` instead of e
 For scoped reviews after the last run timestamp:
 
 - `git log --since='<LAST_RUN_ISO>' --name-only --pretty=format:'%H%n%s%n%b'` (or `--since='24h ago'`)
+- If <LAST_RUN_ISO> is UTC (`...Z`), pass an explicit UTC offset to avoid local-time drift (example: `git log --since='2026-05-15 21:01:30 +0000' --name-only --pretty=format:'%H%n%s%n%b'`).
 - `git show --unified=3 <commit_sha>`
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence
 - `rg -n "setup-bun@" .github/workflows -g'*.yml'` to verify valid action pins after CI workflow updates

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -55,3 +55,11 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - Dead-code review (confident): no new dead code in non-test files changed in the fallback 24-hour window.
   - Evidence: `git log --since='24 hours ago' --name-only --pretty=format: | sed '/^$/d' | sort -u` and repo-wide non-test symbol checks in touched code files.
 - Performance audit: no measured regression signal in this window; latest `master` push workflows remained `success` for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.
+
+### 2026-05-17
+
+- Commit window scan since `2026-05-15 21:01:30 +0000` found only CI/docs maintenance commits: `4fbc8f676000056a9affb2018c3fd7a874c858dd`, `3491ef35d6ac64e9a006ebffa09a6027db6c96b3`, and `857e45529dfc1a9158504037e8b36d326c585f72`.
+- Code smell review (info): no functional anti-patterns or bug signals in changed files (`.github/workflows/cf-deploy.yml`, `CLAUDE.md`, `docs/ai/core-memory.md`).
+- Dead-code review (confident): no new dead code candidates from this commit window because changes are workflow/docs-only; no new app/package symbols were introduced.
+- CI audit: push workflows on `master` for `3491ef35` and `857e4552` are `success` for both `Lint` and `Test`.
+- Performance audit: no measurements or traces changed in this window, so no grounded regression claim; continue tracking workflow-duration deltas for CI-cost signals.


### PR DESCRIPTION
## Summary
- add a UTC-safe `git log --since` note in `CLAUDE.md` for automation scans
- append the 2026-05-17 code-smell/dead-code/CI audit outcome to `docs/ai/core-memory.md`
- keep changes docs-only and preserve existing durable maintenance entries

## Evidence window
- Last run: `2026-05-15T21:01:30.415Z`
- Commits scanned since then: `4fbc8f676000056a9affb2018c3fd7a874c858dd`, `3491ef35d6ac64e9a006ebffa09a6027db6c96b3`, `857e45529dfc1a9158504037e8b36d326c585f72`
- CI signals checked: `gh run list --branch master --event push --limit 10 --json ...`

## Verification
- `git diff --check`

## Summary by Sourcery

Record the latest maintenance scan outcome and clarify UTC-safe git log usage for future automation reviews.

Documentation:
- Append a 2026-05-17 maintenance audit entry to the AI core memory log documenting recent code-smell, dead-code, CI, and performance findings.
- Update CLAUDE review instructions to recommend UTC-offset git log --since usage when using ISO timestamps to avoid local-time drift.