### PR TITLE
fix(ci): pin wasm deploy tooling and scope turbo secret

### DIFF
--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -32,7 +32,6 @@ on:
           - ai-percentage
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   TURBO_REMOTE_ONLY: true
 
@@ -157,6 +156,8 @@ jobs:
 
       - name: Type check
         run: bun run turbo check-types
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   unittest:
     name: Unit tests
@@ -216,6 +217,8 @@ jobs:
 
       - name: Lint
         run: bun run lint
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   deploy:
     name: Deploy ${{ matrix.app }}
@@ -240,7 +243,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2.2.0
 
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0  # v5.0.0
         with:
           path: |
             ~/.bun/install/cache
@@ -254,13 +257,13 @@ jobs:
 
       - name: Setup Rust toolchain (blog WASM markdown)
         if: matrix.app == 'blog'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry & build
         if: matrix.app == 'blog'
-        uses: actions/cache@v5
+        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0  # v5.0.0
         with:
           path: |
             ~/.cargo/registry
@@ -272,9 +275,9 @@ jobs:
 
       - name: Install wasm-pack
         if: matrix.app == 'blog'
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa  # v0.4.0
         with:
-          version: latest
+          version: 0.13.1
 
       - name: Build WASM packages (markdown converter)
         if: matrix.app == 'blog'
@@ -334,6 +337,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           # Production environment variables (Vite apps use VITE_ prefix)
           NODE_ENV: production
           VITE_DUYET_HOME_URL: https://duyet.net

--- a/scripts/wasm-build.ts
+++ b/scripts/wasm-build.ts
@@ -43,6 +43,7 @@ for (const crate of crates) {
     "--target", "web",
     "--out-dir", outPath,
     "--out-name", outName,
+    "--locked",
     ...(release ? ["--release"] : []),
     cratePath,
   ]


### PR DESCRIPTION
### Motivation
- Close a CI/CD supply-chain gap introduced by the blog WASM build path that used mutable action/tool references and ran before the secret-bearing deploy step. 
- Reduce blast radius of workflow-level secrets that previously propagated to pre-deploy steps. 
- Make WASM builds reproducible in CI by ensuring Cargo uses the committed `Cargo.lock` during `wasm-pack` runs.

### Description
- Pinned mutable workflow actions in `cf-deploy.yml` for the blog WASM path by replacing moving refs with immutable identifiers for `actions/cache`, `dtolnay/rust-toolchain`, and `jetli/wasm-pack-action` and pinned the `wasm-pack` installer to `0.13.1` instead of `latest`.
- Removed the workflow-level `TURBO_TOKEN` exposure and scoped `TURBO_TOKEN` to the steps that need it (added as step-level `env` on `Type check`, `Lint`, and to the deploy step env block).
- Added `--locked` to the `wasm-pack build` invocation in `scripts/wasm-build.ts` so Cargo resolves using the repository `Cargo.lock` in CI.
- Files changed: ` .github/workflows/cf-deploy.yml` and `scripts/wasm-build.ts`.

### Testing
- Ran `bunx biome lint .github/workflows/cf-deploy.yml scripts/wasm-build.ts`, which completed with no fixes applied (success).
- Ran `bunx biome lint scripts/wasm-build.ts` separately, which also succeeded.
- A workspace test run (pre-commit hook that runs `bun run test`) was attempted and failed due to an existing workspace issue in `apps/data-sync` (`Cannot find package 'graphql'`), so full workspace tests did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a068fb89e0083328ff538a13a9fbdac)

## Summary by Sourcery

Tighten CI/CD security and reproducibility for blog WASM builds while scoping Turbo cache secrets to only required steps.

Build:
- Pin cache, Rust toolchain, and wasm-pack GitHub Actions in the Cloudflare deploy workflow and lock wasm-pack to version 0.13.1.
- Restrict TURBO_TOKEN from a workflow-level env to specific type-check, lint, and deploy steps in the cf-deploy workflow.
- Ensure wasm-pack builds use the repository Cargo.lock by adding the --locked flag to the wasm-build script.