### PR TITLE
docs(ci): add no-merges scan hint and 2026-05-18 maintenance memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Put durable repository knowledge in `docs/ai/internal-knowledge.md` instead of e
 For scoped reviews after the last run timestamp:
 
 - `git log --since='<LAST_RUN_ISO>' --name-only --pretty=format:'%H%n%s%n%b'` (or `--since='24h ago'`)
+- `git log --since='<LAST_RUN_ISO>' --no-merges --name-only --pretty=format:'%H%n%s%n%b'` when merge commits make change attribution noisy
 - If <LAST_RUN_ISO> is UTC (`...Z`), pass an explicit UTC offset to avoid local-time drift (example: `git log --since='2026-05-15 21:01:30 +0000' --name-only --pretty=format:'%H%n%s%n%b'`).
 - `git show --unified=3 <commit_sha>`
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -63,3 +63,18 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - Dead-code review (confident): no new dead code candidates from this commit window because changes are workflow/docs-only; no new app/package symbols were introduced.
 - CI audit: push workflows on `master` for `3491ef35` and `857e4552` are `success` for both `Lint` and `Test`.
 - Performance audit: no measurements or traces changed in this window, so no grounded regression claim; continue tracking workflow-duration deltas for CI-cost signals.
+
+### 2026-05-18
+
+- Commit window scan since `2026-05-16 21:00:13 +0000` included agent-api/ui/home/CI changes; reviewed non-merge commits for actionable code smell and dead code.
+- Code smell review (info): no proven runtime bug in current `HEAD` from this window. Targeted lint passed for touched source files:
+  - `apps/agent-api/src/{index.ts,agent.ts,public-messages.ts,routing.ts}`
+  - `apps/agent-ui/src/{App.tsx,agent-api-transport.ts}`
+  - `apps/home/src/components/SiteChrome.tsx`
+  - `packages/components/{AppCommandPalette.tsx,header/index.tsx,header/AuthButtons.tsx}`
+  - Evidence: `bunx biome lint <paths>` returned `Checked 10 files ... No fixes applied.`
+- Dead-code review (confident): no new zero-reference symbols in current touched surfaces.
+  - Evidence: repo-wide non-test reference checks for `toPublicMessageMetadata`, `hasReasoningParts`, `stripReasoningParts`, `AppCommandPalette`, and `SiteChrome` returned active references outside declarations.
+- CI audit: latest `master` push workflows for `fea49fec` and `76c213b1` are `success` for `Lint`, `Test`, and deploy jobs.
+  - Evidence: `gh run list --branch master --event push --limit 20 --json databaseId,headSha,status,conclusion,name,updatedAt`.
+- Workflow docs update: added `git log --since='<LAST_RUN_ISO>' --no-merges ...` to `CLAUDE.md` to reduce false positives from merge-only metadata during maintenance scans.


### PR DESCRIPTION
Maintenance docs sync for the 2026-05-18 code-smell/dead-code scan.