### PR TITLE
fix(ci): restrict preview deploy secrets to owner/member PR authors

### DIFF
--- a/.github/workflows/cf-deploy-preview.yml
+++ b/.github/workflows/cf-deploy-preview.yml
@@ -200,7 +200,7 @@ jobs:
   deploy-preview:
     name: Deploy ${{ matrix.app }}
     needs: [detect-changes, typecheck, unittest, lint]
-    if: ${{ needs.detect-changes.outputs.matrix != '{"include":[]}' && github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR') }}
+    if: ${{ needs.detect-changes.outputs.matrix != '{"include":[]}' && github.event.pull_request.head.repo.full_name == github.repository && (github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Motivation
- Close a security gap where same-repository PRs authored by `COLLABORATOR` could trigger the `deploy-preview` job that checks out and builds PR-controlled code while providing production secrets to the job.

### Description
- Remove `COLLABORATOR` from the author allowlist in the `deploy-preview` job `if` condition in ` .github/workflows/cf-deploy-preview.yml` so only `OWNER` and `MEMBER` authors can run the job. 
- Preserve all existing build and deploy steps and behavior for `OWNER` and `MEMBER` PR authors; no other workflow changes were made.

### Testing
- Ran `bunx biome lint .github/workflows/cf-deploy-preview.yml` and the lint step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a097521bccc83328a2f16332965b593)