### PR TITLE
docs(ci): add detached-head and file-inventory scan commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@ For scoped reviews after the last run timestamp:
 
 - `git log --since='<LAST_RUN_ISO>' --name-only --pretty=format:'%H%n%s%n%b'` (or `--since='24h ago'`)
 - `git log --since='<LAST_RUN_ISO>' --no-merges --name-only --pretty=format:'%H%n%s%n%b'` when merge commits make change attribution noisy
+- `git log --since='<LAST_RUN_ISO>' --no-merges --name-only --pretty=format: | sed '/^$/d' | sort -u` to inventory touched files before symbol checks
 - If <LAST_RUN_ISO> is UTC (`...Z`), pass an explicit UTC offset to avoid local-time drift (example: `git log --since='2026-05-15 21:01:30 +0000' --name-only --pretty=format:'%H%n%s%n%b'`).
+- `git symbolic-ref --short -q HEAD || echo "DETACHED"` before PR work so automation can branch off detached worktrees safely
 - `git show --unified=3 <commit_sha>`
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence
 - `rg -n "setup-bun@" .github/workflows -g'*.yml'` to verify valid action pins after CI workflow updates

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -78,3 +78,14 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - CI audit: latest `master` push workflows for `fea49fec` and `76c213b1` are `success` for `Lint`, `Test`, and deploy jobs.
   - Evidence: `gh run list --branch master --event push --limit 20 --json databaseId,headSha,status,conclusion,name,updatedAt`.
 - Workflow docs update: added `git log --since='<LAST_RUN_ISO>' --no-merges ...` to `CLAUDE.md` to reduce false positives from merge-only metadata during maintenance scans.
+
+### 2026-05-19
+
+- Commit window scan since `2026-05-17 21:01:50 +0000` covered: `2ec7fbee94832378699541a8b7b321e100b6c77e`, `5354427407973bab8a2d6837812db75810b1412b`, and `ea4fd318b419ea263caa4d23bf1f33db34aed351`.
+- Code smell review (info): no grounded functional bug/regression in current `HEAD` from this window; targeted lint passed on touched app/package files.
+  - Evidence: `bunx biome lint <touched paths>` returned `Checked 22 files in 40ms. No fixes applied.`
+- Dead-code review (confident): no zero-reference symbols in touched non-test files; removed-file fallout from `apps/homelab/components/ThemeProvider.tsx` is clean after import-path scans.
+  - Evidence: `rg -n "homelab/components/ThemeProvider|from \"@/components/ThemeProvider\"|useTheme\\(" apps packages --glob '!**/*.test.*' --glob '!**/*.spec.*' --glob '!**/__tests__/**'`.
+- CI audit: push workflows on `master` for the scanned commits are green for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.
+  - Evidence: `gh run list --branch master --event push --limit 12 --json databaseId,headSha,status,conclusion,name,updatedAt`.
+- Workflow docs update: added detached-HEAD preflight and touched-file inventory commands to `CLAUDE.md` for safer automation loops.


### PR DESCRIPTION
## Summary
- run code-smell/dead-code/perf audit for commits since `2026-05-17 21:01:50 +0000`
- confirm no actionable runtime bug or dead-code candidate in touched non-test files
- add two proven automation commands to `CLAUDE.md`
- append durable 2026-05-19 maintenance evidence to `docs/ai/core-memory.md`

## Evidence
- commits scanned: `2ec7fbee`, `53544274`, `ea4fd318`
- lint check: `bunx biome lint <touched paths>` -> `Checked 22 files in 40ms. No fixes applied.`
- dead-code checks: `rg` scans for removed homelab ThemeProvider path and `useTheme` imports show active references only
- CI state: `gh run list --branch master --event push --limit 12 ...` shows success for Lint/Test/Deploy workflows on scanned commits

## Notes
- no dated `docs/reviews/code-smell-dead-code-<DATE>.md` files were created or found
