### PR TITLE
feat(blog): redesign home layout

### DIFF
--- a/apps/blog/_posts/2026/05/building-ai-agents-cloudflare.mdx
+++ b/apps/blog/_posts/2026/05/building-ai-agents-cloudflare.mdx
@@ -17,8 +17,6 @@ Cloudflare has one of the most generous free plans I've seen for building websit
 
 Start with [agents.cloudflare.com](https://agents.cloudflare.com). It already lists almost everything you need.
 
-![npm i agents](/media/2026/05/building-ai-agents-cloudflare/npm-i-agents.svg)
-
 Cloudflare's `agents` SDK is a good one, alongside the [AI SDK](https://github.com/vercel/ai).
 
 Each agent runs as a TypeScript class on a Durable Object, with its own SQL database, WebSocket connections, scheduling, state, and lifecycle.

--- a/apps/blog/components/post/FeaturedPost.tsx
+++ b/apps/blog/components/post/FeaturedPost.tsx
@@ -29,7 +29,7 @@ export function FeaturedPost({
         {post.thumbnail ? (
           <img
             src={post.thumbnail}
-            alt={post.title}
+            alt=""
             width={1200}
             height={675}
             loading="eager"

--- a/apps/blog/components/post/FeaturedPost.tsx
+++ b/apps/blog/components/post/FeaturedPost.tsx
@@ -2,13 +2,17 @@ import type { Post } from "@duyet/interfaces";
 import { dateFormat } from "@duyet/libs/date";
 import { cn } from "@duyet/libs/utils";
 import { Link } from "@tanstack/react-router";
+import type { ReactElement } from "react";
 
 interface FeaturedPostProps {
   post: Post;
   className?: string;
 }
 
-export function FeaturedPost({ post, className }: FeaturedPostProps) {
+export function FeaturedPost({
+  post,
+  className,
+}: FeaturedPostProps): ReactElement {
   const [, year, month, slug] = post.slug.split("/");
   const date = dateFormat(post.date, "MMMM d, yyyy");
 
@@ -23,7 +27,13 @@ export function FeaturedPost({ post, className }: FeaturedPostProps) {
     >
       <div className="blog-featured-media">
         {post.thumbnail ? (
-          <img src={post.thumbnail} alt="" loading="eager" />
+          <img
+            src={post.thumbnail}
+            alt={post.title}
+            width={1200}
+            height={675}
+            loading="eager"
+          />
         ) : (
           <div className="blog-featured-fallback" aria-hidden="true">
             <span>{post.category}</span>
@@ -31,7 +41,7 @@ export function FeaturedPost({ post, className }: FeaturedPostProps) {
           </div>
         )}
         <div className="blog-featured-scrim" aria-hidden="true" />
-        <h2>{post.title}</h2>
+        <h1>{post.title}</h1>
       </div>
 
       <div className="blog-featured-copy">

--- a/apps/blog/components/post/FeaturedPost.tsx
+++ b/apps/blog/components/post/FeaturedPost.tsx
@@ -10,41 +10,39 @@ interface FeaturedPostProps {
 
 export function FeaturedPost({ post, className }: FeaturedPostProps) {
   const [, year, month, slug] = post.slug.split("/");
+  const date = dateFormat(post.date, "MMMM d, yyyy");
 
   return (
     <Link
       to="/$year/$month/$slug/"
       params={{ year, month, slug }}
       className={cn(
-        "group block border-y border-[var(--border-faint)] py-7 transition-colors hover:bg-[var(--surface-soft)] sm:py-8",
+        "blog-featured-post group block",
         className
       )}
     >
-      <div className="flex flex-wrap items-center gap-2 text-[12px] font-medium uppercase tracking-[0.08em] text-[var(--muted)]">
-        <span>{post.category}</span>
-        <span>/</span>
-        <time>{dateFormat(post.date, "MMMM d, yyyy")}</time>
+      <div className="blog-featured-media">
+        {post.thumbnail ? (
+          <img src={post.thumbnail} alt="" loading="eager" />
+        ) : (
+          <div className="blog-featured-fallback" aria-hidden="true">
+            <span>{post.category}</span>
+            <span>{date}</span>
+          </div>
+        )}
+        <div className="blog-featured-scrim" aria-hidden="true" />
+        <h2>{post.title}</h2>
       </div>
-      <h2
-        className={cn(
-          "mt-4 max-w-4xl text-[30px] font-semibold leading-[1.12] tracking-[-0.02em] sm:text-[38px]",
-          "text-[var(--ink)]",
-          "group-hover:text-[var(--body)]",
-          "transition-colors"
-        )}
-      >
-        {post.title}
-      </h2>
-      {post.excerpt && (
-        <p className="mt-4 max-w-3xl text-[15px] leading-[1.65] text-[var(--body)]">
-          {post.excerpt}
-        </p>
-      )}
-      <div className="mt-5 flex items-center gap-2 text-[13px] text-[var(--muted)]">
-        {post.readingTime && (
-          <span>{post.readingTime} min read</span>
-        )}
-        <span className="transition-transform group-hover:translate-x-1">→</span>
+
+      <div className="blog-featured-copy">
+        <div className="blog-featured-title" aria-hidden="true">
+          {post.title}
+        </div>
+        <div className="blog-featured-meta">
+          <span>{post.category}</span>
+          <time>{date}</time>
+        </div>
+        {post.excerpt && <p>{post.excerpt}</p>}
       </div>
     </Link>
   );

--- a/apps/blog/components/post/YearPost.tsx
+++ b/apps/blog/components/post/YearPost.tsx
@@ -13,25 +13,23 @@ export function YearPost({ year, posts, className }: YearPostProps) {
   if (!posts.length) return null;
 
   return (
-    <div className={cn(className)}>
-      <h2 className="mb-4 text-[26px] font-semibold tracking-[-0.02em] text-[var(--foreground)]">
-        {year}
-      </h2>
+    <div className={cn("year-post-group", className)}>
+      <h2>{year}</h2>
 
-      <div className="divide-y divide-[var(--border-faint)] border-y border-[var(--border-faint)]">
+      <div className="year-post-list">
         {posts.map((post: Post) => {
           const [, year, month, slug] = post.slug.split("/");
           return (
             <Link
-              className="group flex flex-col gap-1 py-4 transition-colors hover:bg-[var(--surface-soft)] sm:flex-row sm:items-center sm:gap-4 sm:px-3"
+              className="year-post-row group"
               to="/$year/$month/$slug/"
               params={{ year, month, slug }}
               key={post.slug}
             >
-              <div className="min-w-0 flex-1 break-words text-[15px] font-medium leading-[1.45] text-[var(--foreground)] transition-colors group-hover:text-[var(--body)]">
+              <div className="year-post-title">
                 {post.title}
               </div>
-              <time className="flex-shrink-0 whitespace-nowrap text-[12px] font-medium text-[var(--muted-foreground)]">
+              <time>
                 {dateFormat(post.date, "MMM dd")}
               </time>
             </Link>

--- a/apps/blog/components/post/YearPost.tsx
+++ b/apps/blog/components/post/YearPost.tsx
@@ -2,6 +2,7 @@ import type { Post } from "@duyet/interfaces";
 import { dateFormat } from "@duyet/libs/date";
 import { cn } from "@duyet/libs/utils";
 import { Link } from "@tanstack/react-router";
+import type { ReactElement } from "react";
 
 export interface YearPostProps {
   year: number;
@@ -9,7 +10,11 @@ export interface YearPostProps {
   className?: string;
 }
 
-export function YearPost({ year, posts, className }: YearPostProps) {
+export function YearPost({
+  year,
+  posts,
+  className,
+}: YearPostProps): ReactElement | null {
   if (!posts.length) return null;
 
   return (

--- a/apps/blog/scripts/generate-posts-data.ts
+++ b/apps/blog/scripts/generate-posts-data.ts
@@ -43,6 +43,7 @@ const metaFields = [
   "series",
   "readingTime",
   "snippet",
+  "thumbnail",
   "author",
 ];
 

--- a/apps/blog/src/routes/__root.tsx
+++ b/apps/blog/src/routes/__root.tsx
@@ -113,8 +113,8 @@ function RootComponent() {
               longText="Duyet Le"
               navigationItems={blogNavigation}
               showAuthButtons
-              className="blog-site-header"
-              containerClassName="blog-site-header-inner"
+              className="blog-site-header border-b-0"
+              containerClassName="blog-site-header-inner max-w-[1440px] py-4 lg:px-12"
               actions={<AppCommandPalette />}
             />
             <main className="relative z-10 pb-16">

--- a/apps/blog/src/routes/__root.tsx
+++ b/apps/blog/src/routes/__root.tsx
@@ -113,6 +113,8 @@ function RootComponent() {
               longText="Duyet Le"
               navigationItems={blogNavigation}
               showAuthButtons
+              className="blog-site-header"
+              containerClassName="blog-site-header-inner"
               actions={<AppCommandPalette />}
             />
             <main className="relative z-10 pb-16">

--- a/apps/blog/src/routes/__root.tsx
+++ b/apps/blog/src/routes/__root.tsx
@@ -132,10 +132,10 @@ function RootComponent() {
 }
 
 const blogNavigation: NavigationItem[] = [
-  { name: "Blog", href: duyetUrls.apps.blog },
-  { name: "Archives", href: `${duyetUrls.apps.blog}/archives/` },
-  { name: "Featured", href: `${duyetUrls.apps.blog}/featured/` },
-  { name: "Series", href: `${duyetUrls.apps.blog}/series/` },
-  { name: "Tags", href: `${duyetUrls.apps.blog}/tags/` },
-  { name: "Home", href: duyetUrls.apps.home },
+  { name: "Home", href: "/" },
+  { name: "Archives", href: "/archives/" },
+  { name: "Featured", href: "/featured/" },
+  { name: "Series", href: "/series/" },
+  { name: "Tags", href: "/tags/" },
+  { name: "Duyet.net", href: duyetUrls.apps.home },
 ];

--- a/apps/blog/src/routes/category.tsx
+++ b/apps/blog/src/routes/category.tsx
@@ -24,7 +24,9 @@ export const Route = createFileRoute("/category")({
 });
 
 function Categories() {
-  const hasChild = useMatches().some((m) => m.id === "/category/$category");
+  const hasChild = useMatches().some(
+    (match) => match.routeId === "/category/$category"
+  );
   if (hasChild) return <Outlet />;
 
   const { categories } = Route.useLoaderData() as { categories: CategoryCount };

--- a/apps/blog/src/routes/index.tsx
+++ b/apps/blog/src/routes/index.tsx
@@ -1,9 +1,11 @@
 import Container from "@duyet/components/Container";
+import { dateFormat } from "@duyet/libs/date";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { FeaturedPost } from "@/components/post/FeaturedPost";
 import { YearPost } from "@/components/post/YearPost";
 import { getPostsByAllYear } from "@/lib/posts";
 import type { Post } from "@duyet/interfaces";
+import type { ReactElement } from "react";
 
 export const Route = createFileRoute("/")({
   loader: async () => {
@@ -13,7 +15,7 @@ export const Route = createFileRoute("/")({
   component: HomePage,
 });
 
-function HomePage() {
+function HomePage(): ReactElement {
   const { postsByYear } = Route.useLoaderData();
 
   const allPosts: Post[] = Object.entries(postsByYear)
@@ -94,7 +96,7 @@ const focusAreas = [
   },
 ];
 
-function RecentPostLink({ post }: { post: Post }) {
+function RecentPostLink({ post }: { post: Post }): ReactElement {
   const [, year, month, slug] = post.slug.split("/");
 
   return (
@@ -124,9 +126,5 @@ function groupByYear(posts: Post[]): [number, Post[]][] {
 }
 
 function formatPostDate(date: Date | string): string {
-  return new Intl.DateTimeFormat("en", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(new Date(date));
+  return dateFormat(date instanceof Date ? date : new Date(date), "MMM d, yyyy");
 }

--- a/apps/blog/src/routes/index.tsx
+++ b/apps/blog/src/routes/index.tsx
@@ -1,21 +1,14 @@
 import Container from "@duyet/components/Container";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { PostCard } from "@/components/post/PostCard";
 import { FeaturedPost } from "@/components/post/FeaturedPost";
 import { YearPost } from "@/components/post/YearPost";
-import { BlogHeader } from "@/components/layout/BlogHeader";
-import { BlogPillNav } from "@/components/layout/BlogPillNav";
-import { getAllSeries, getAllTags, getPostsByAllYear } from "@/lib/posts";
+import { getPostsByAllYear } from "@/lib/posts";
 import type { Post } from "@duyet/interfaces";
 
 export const Route = createFileRoute("/")({
   loader: async () => {
-    const [postsByYear, seriesList, allTags] = await Promise.all([
-      getPostsByAllYear(),
-      getAllSeries(),
-      getAllTags(),
-    ]);
-    return { postsByYear, seriesList, allTags };
+    const postsByYear = await getPostsByAllYear();
+    return { postsByYear };
   },
   component: HomePage,
 });
@@ -28,57 +21,95 @@ function HomePage() {
     .flatMap(([, posts]) => posts);
 
   const featured = allPosts[0];
-  const recentCards = allPosts.slice(1, 7);
+  const railPosts = allPosts.slice(1, 5);
   const allByYear = groupByYear(allPosts);
 
-  const categoryPills = [
-    { label: "Latest", href: "/feed/" },
-    { label: "Topics", href: "/tags/" },
-    { label: "Featured", href: "/featured/" },
-    { label: "Series", href: "/series/" },
-    { label: "Archives", href: "/archives/" },
-  ];
-
   return (
-    <Container className="mx-auto max-w-[1200px] px-5 sm:px-8 lg:px-10">
-      <BlogHeader
-        eyebrow="Blog"
-        title="Notes on data,"
-        titleEmphasis="systems and engineering"
-        intro={
-          <>
-            {allPosts.length} posts on data engineering, distributed systems,
-            and open source. Explore{" "}
-            <Link to="/feed/">latest</Link>,{" "}
-            <Link to="/tags/">topics</Link>, or{" "}
-            <Link to="/featured/">featured</Link>.
-          </>
-        }
-      >
-        <BlogPillNav items={categoryPills} />
-      </BlogHeader>
+    <Container className="blog-home-shell mx-auto max-w-[1440px] px-5 sm:px-8 lg:px-12">
+      <section className="blog-focus-grid" aria-label="Blog focus areas">
+        {focusAreas.map((area) => (
+          <Link key={area.title} to={area.href} className="blog-focus-card">
+            <h2>{area.title}</h2>
+            <p>{area.description}</p>
+          </Link>
+        ))}
+      </section>
 
       {featured && (
-        <div className="mt-14">
+        <section className="blog-home-feature" aria-label="Latest writing">
           <FeaturedPost post={featured} />
-        </div>
+
+          {railPosts.length > 0 && (
+            <aside className="blog-recent-rail" aria-label="Recent posts">
+              {railPosts.map((post) => (
+                <RecentPostLink key={post.slug} post={post} />
+              ))}
+            </aside>
+          )}
+        </section>
       )}
 
-      {recentCards.length > 0 && (
-        <div className="mt-10 card-grid">
-          {recentCards.map((post) => (
-            <PostCard key={post.slug} post={post} />
+      <section className="blog-archive-section" aria-label="All posts">
+        <div className="blog-section-heading">
+          <p>{allPosts.length} published notes</p>
+          <h2>Archive</h2>
+        </div>
+
+        <div className="blog-archive-years">
+          {allByYear.map(([year, posts]) => (
+            <YearPost key={year} year={year} posts={posts} />
           ))}
         </div>
-      )}
-
-      {/* All posts grouped by year */}
-      {allByYear.map(([year, posts]) => (
-        <YearPost key={year} year={year} posts={posts} className="mt-14" />
-      ))}
+      </section>
 
       <div className="pb-24" />
     </Container>
+  );
+}
+
+const focusAreas = [
+  {
+    title: "AI Systems",
+    description:
+      "Agents, model tooling, and the practical edges of building with LLMs.",
+    href: "/category/ai/",
+  },
+  {
+    title: "Data Engineering",
+    description:
+      "Pipelines, warehouses, data platforms, and the operational work around them.",
+    href: "/category/data-engineering/",
+  },
+  {
+    title: "ClickHouse",
+    description:
+      "Notes from running analytical databases, Kubernetes, UDFs, and observability.",
+    href: "/tag/clickhouse/",
+  },
+  {
+    title: "Rust & Tools",
+    description:
+      "Systems programming, developer workflows, and small tools that survive real use.",
+    href: "/category/rust/",
+  },
+];
+
+function RecentPostLink({ post }: { post: Post }) {
+  const [, year, month, slug] = post.slug.split("/");
+
+  return (
+    <Link
+      to="/$year/$month/$slug/"
+      params={{ year, month, slug }}
+      className="blog-recent-item"
+    >
+      <div className="blog-recent-meta">
+        <span>{post.category}</span>
+        <time>{formatPostDate(post.date)}</time>
+      </div>
+      <h3>{post.title}</h3>
+      {post.excerpt && <p>{post.excerpt}</p>}
+    </Link>
   );
 }
 
@@ -90,4 +121,12 @@ function groupByYear(posts: Post[]): [number, Post[]][] {
     map.get(y)!.push(post);
   }
   return [...map.entries()].sort(([a], [b]) => b - a);
+}
+
+function formatPostDate(date: Date | string): string {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(date));
 }

--- a/apps/blog/styles/blog-design.css
+++ b/apps/blog/styles/blog-design.css
@@ -1,3 +1,432 @@
+.blog-site-header {
+  position: sticky;
+  top: 0;
+  border-bottom: 0 !important;
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(16px);
+}
+
+.blog-site-header-inner {
+  max-width: 1440px !important;
+  padding-top: 16px !important;
+  padding-bottom: 16px !important;
+}
+
+.blog-site-header a {
+  text-decoration: none;
+}
+
+.blog-site-header nav a {
+  border-radius: 8px;
+}
+
+.blog-home-shell {
+  padding-top: 34px;
+}
+
+.blog-focus-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 54px;
+  border-bottom: 1px solid var(--border-faint);
+  padding: 34px 0 58px;
+}
+
+.blog-focus-card {
+  display: block;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-focus-card h2 {
+  margin: 0 0 10px;
+  color: var(--ink);
+  font-family: var(--font-inter);
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.012em;
+  line-height: 1.16;
+}
+
+.blog-focus-card p {
+  margin: 0;
+  color: var(--body);
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.blog-focus-card:hover h2 {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.blog-home-feature {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(320px, 0.95fr);
+  gap: 46px;
+  align-items: start;
+  padding-top: 48px;
+}
+
+.blog-featured-post {
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-featured-media {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 8px;
+  background: var(--surface-soft);
+}
+
+.blog-featured-media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 180ms ease;
+}
+
+.blog-featured-post:hover .blog-featured-media img {
+  transform: scale(1.015);
+}
+
+.blog-featured-scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0) 30%,
+    rgba(0, 0, 0, 0.46) 63%,
+    rgba(0, 0, 0, 0.82) 100%
+  );
+}
+
+.blog-featured-media h2 {
+  position: absolute;
+  right: 38px;
+  bottom: 32px;
+  left: 38px;
+  max-width: 850px;
+  margin: 0;
+  color: #fff;
+  font-family: var(--font-inter);
+  font-size: 58px;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.03;
+}
+
+.blog-featured-fallback {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 28px;
+  color: var(--muted);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background:
+    linear-gradient(90deg, var(--border-faint) 1px, transparent 1px),
+    linear-gradient(var(--border-faint) 1px, transparent 1px),
+    var(--surface-soft);
+  background-size: 34px 34px;
+}
+
+.blog-featured-copy {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1fr);
+  gap: 34px;
+  padding-top: 28px;
+}
+
+.blog-featured-title {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-inter);
+  font-size: 40px;
+  font-weight: 750;
+  letter-spacing: 0;
+  line-height: 1.08;
+}
+
+.blog-featured-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  align-items: baseline;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.blog-featured-meta span {
+  color: var(--ink);
+}
+
+.blog-featured-meta span::after {
+  content: "";
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  margin-left: 9px;
+  border-radius: 999px;
+  vertical-align: 0.15em;
+  background: var(--border-subtle);
+}
+
+.blog-featured-copy p {
+  grid-column: 2;
+  margin: 10px 0 0;
+  color: var(--body);
+  font-size: 16px;
+  line-height: 1.48;
+}
+
+.blog-recent-rail {
+  border-top: 1px solid var(--border-faint);
+}
+
+.blog-recent-item {
+  display: block;
+  padding: 22px 0 24px;
+  border-bottom: 1px solid var(--border-faint);
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-recent-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  align-items: baseline;
+  color: var(--muted);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.blog-recent-meta span {
+  color: var(--ink);
+}
+
+.blog-recent-item h3 {
+  margin: 12px 0 0;
+  color: var(--ink);
+  font-family: var(--font-inter);
+  font-size: 24px;
+  font-weight: 750;
+  letter-spacing: 0;
+  line-height: 1.16;
+}
+
+.blog-recent-item p {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+  margin: 12px 0 0;
+  color: var(--body);
+  font-size: 15px;
+  line-height: 1.45;
+}
+
+.blog-recent-item:hover h3,
+.blog-recent-item:focus-visible h3 {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.blog-archive-section {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 68px;
+  margin-top: 76px;
+  border-top: 1px solid var(--border-faint);
+  padding-top: 46px;
+}
+
+.blog-section-heading p {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+}
+
+.blog-section-heading h2 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-inter);
+  font-size: 44px;
+  font-weight: 760;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.blog-archive-years {
+  display: grid;
+  gap: 34px;
+}
+
+.year-post-group {
+  display: grid;
+  grid-template-columns: 82px minmax(0, 1fr);
+  gap: 28px;
+}
+
+.year-post-group h2 {
+  margin: 2px 0 0;
+  color: var(--ink);
+  font-family: var(--font-inter);
+  font-size: 26px;
+  font-weight: 760;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.year-post-list {
+  border-top: 1px solid var(--border-faint);
+}
+
+.year-post-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: baseline;
+  padding: 13px 0;
+  border-bottom: 1px solid var(--border-faint);
+  color: inherit;
+  text-decoration: none;
+}
+
+.year-post-title {
+  min-width: 0;
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 560;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.year-post-row time {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.year-post-row:hover .year-post-title,
+.year-post-row:focus-visible .year-post-title {
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+@media (max-width: 1080px) {
+  .blog-focus-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 32px;
+  }
+
+  .blog-home-feature {
+    grid-template-columns: 1fr;
+  }
+
+  .blog-recent-rail {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0 28px;
+  }
+}
+
+@media (max-width: 760px) {
+  .blog-home-shell {
+    padding-top: 18px;
+  }
+
+  .blog-focus-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 24px 0 36px;
+  }
+
+  .blog-focus-card h2 {
+    font-size: 22px;
+  }
+
+  .blog-home-feature {
+    gap: 32px;
+    padding-top: 32px;
+  }
+
+  .blog-featured-media {
+    aspect-ratio: 4 / 3;
+  }
+
+  .blog-featured-media h2 {
+    right: 22px;
+    bottom: 22px;
+    left: 22px;
+    font-size: 34px;
+    line-height: 1.04;
+  }
+
+  .blog-featured-copy {
+    display: block;
+    padding-top: 20px;
+  }
+
+  .blog-featured-title {
+    font-size: 31px;
+  }
+
+  .blog-featured-meta {
+    margin-top: 14px;
+  }
+
+  .blog-featured-copy p {
+    margin-top: 10px;
+  }
+
+  .blog-recent-rail {
+    display: block;
+  }
+
+  .blog-archive-section {
+    display: block;
+    margin-top: 54px;
+    padding-top: 34px;
+  }
+
+  .blog-section-heading {
+    margin-bottom: 30px;
+  }
+
+  .blog-section-heading h2 {
+    font-size: 36px;
+  }
+
+  .year-post-group {
+    display: block;
+  }
+
+  .year-post-group h2 {
+    margin-bottom: 14px;
+  }
+
+  .year-post-row {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+}
+
 .masthead {
   padding: 56px 0 28px;
   border-bottom: 1px solid var(--border-faint);

--- a/apps/blog/styles/blog-design.css
+++ b/apps/blog/styles/blog-design.css
@@ -1,15 +1,9 @@
 .blog-site-header {
   position: sticky;
   top: 0;
-  border-bottom: 0 !important;
+  background: var(--background);
   background: color-mix(in srgb, var(--background) 94%, transparent);
   backdrop-filter: blur(16px);
-}
-
-.blog-site-header-inner {
-  max-width: 1440px !important;
-  padding-top: 16px !important;
-  padding-bottom: 16px !important;
 }
 
 .blog-site-header a {
@@ -106,7 +100,7 @@
   );
 }
 
-.blog-featured-media h2 {
+.blog-featured-media h1 {
   position: absolute;
   right: 38px;
   bottom: 32px;
@@ -370,7 +364,7 @@
     aspect-ratio: 4 / 3;
   }
 
-  .blog-featured-media h2 {
+  .blog-featured-media h1 {
     right: 22px;
     bottom: 22px;
     left: 22px;

--- a/packages/components/Menu.tsx
+++ b/packages/components/Menu.tsx
@@ -10,7 +10,7 @@ export type NavigationItem = {
 
 export function createDefaultNavigation(urls: UrlsConfig): NavigationItem[] {
   return [
-    { name: "Home", href: urls.apps.home },
+    { name: "Home", href: "/" },
     { name: "About", href: `${urls.apps.home}/about` },
     { name: "Photos", href: urls.apps.photos },
     { name: "Insights", href: urls.apps.insights },

--- a/packages/components/Menu.tsx
+++ b/packages/components/Menu.tsx
@@ -8,9 +8,11 @@ export type NavigationItem = {
   href: string;
 };
 
+export const HOME = { name: "Home", href: "/" };
+
 export function createDefaultNavigation(urls: UrlsConfig): NavigationItem[] {
   return [
-    { name: "Home", href: "/" },
+    HOME,
     { name: "About", href: `${urls.apps.home}/about` },
     { name: "Photos", href: urls.apps.photos },
     { name: "Insights", href: urls.apps.insights },
@@ -18,7 +20,6 @@ export function createDefaultNavigation(urls: UrlsConfig): NavigationItem[] {
   ];
 }
 
-export const HOME = { name: "Home", href: duyetUrls.apps.home };
 export const ABOUT = { name: "About", href: `${duyetUrls.apps.home}/about` };
 export const INSIGHTS = { name: "Insights", href: duyetUrls.apps.insights };
 export const PHOTOS = { name: "Photos", href: duyetUrls.apps.photos };

--- a/packages/components/header/index.tsx
+++ b/packages/components/header/index.tsx
@@ -20,6 +20,7 @@ interface HeaderProps {
   longText?: string;
   center?: boolean;
   navigationItems?: NavigationItem[];
+  homeUrl?: string;
   actions?: ReactNode;
   showAuthButtons?: boolean;
   authButtonsWrapWithProvider?: boolean;
@@ -36,6 +37,7 @@ export default function Header({
   longText,
   center = false,
   navigationItems,
+  homeUrl = "/",
   actions,
   showAuthButtons = true,
   authButtonsWrapWithProvider = true,
@@ -81,7 +83,7 @@ export default function Header({
         )}
       >
         <HeaderBranding
-          homeUrl={urls.apps.home}
+          homeUrl={homeUrl}
           shortText={displayShortText}
           longText={displayLongText}
           logo={logo}

--- a/packages/libs/getPost.ts
+++ b/packages/libs/getPost.ts
@@ -175,6 +175,10 @@ export function getPostByPath(fullPath: string, fields: string[] = []): Post {
       post.snippet = data.snippet || "";
     }
 
+    if (field === "thumbnail") {
+      post.thumbnail = data.thumbnail || undefined;
+    }
+
     if (field === "featured") {
       post.featured = Boolean(data.featured) || false;
     }


### PR DESCRIPTION
## Summary
- redesign the blog home page around an editorial topic strip, large featured post, recent-post rail, and compact archive
- restyle the blog header and featured/archive components to match the new layout
- keep existing post data, thumbnails, routes, and generated public files unchanged

## Verification
- bunx biome lint apps/blog/src/routes/index.tsx apps/blog/components/post/FeaturedPost.tsx apps/blog/components/post/YearPost.tsx apps/blog/src/routes/__root.tsx apps/blog/styles/blog-design.css
- bun run check-types
- bun run build
- git diff --check
- Playwright screenshots: 1440x1000 desktop, 390x1100 mobile, 390x1100 full-page mobile
- curl -I http://localhost:3001/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned blog home page with featured post section, focus areas grid, and recent posts rail
  * Featured posts now display thumbnails with improved visual layout
  * Archive section for browsing posts by year

* **Style**
  * Updated header styling with backdrop blur effect
  * Improved responsive design across all screen sizes
  * Enhanced typography and visual presentation throughout blog layout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/monorepo/pull/1143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->