### PR TITLE
fix(deps): patch clerk shared vulnerability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -528,6 +528,7 @@
     },
   },
   "overrides": {
+    "@clerk/shared": "3.47.5",
     "@tanstack/history": "1.162.0",
     "@tanstack/react-router": "1.170.1",
     "@tanstack/react-start": "1.168.2",
@@ -2787,8 +2788,6 @@
 
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "@clerk/clerk-react/@clerk/shared": ["@clerk/shared@3.47.3", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-jG0wMIZuuc8zaKieg9Os8ocTphG+llluRukUUdyVnu4+ZI1syVf+dkpDP3ZK69yLavTX3D0KAmkmQqTPzQV/Nw=="],
-
     "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
@@ -3072,10 +3071,6 @@
     "@ai-sdk/react/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.66", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.19", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A=="],
 
     "@ai-sdk/react/ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
-
-    "@clerk/clerk-react/@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
-
-    "@clerk/clerk-react/@clerk/shared/swr": ["swr@2.3.4", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg=="],
 
     "@duyet/urls/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,2 @@
 [install]
-# TODO(#1126): restore to 172800 once @tanstack/react-start 1.168.x / react-router 1.170.x
-# age past 2 days (published 2026-05-15/16; expected restore window 2026-05-17/18).
-minimumReleaseAge = 0
+minimumReleaseAge = 172800

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "workers-ai-provider@3.1.2": "patches/workers-ai-provider@3.1.2.patch"
   },
   "overrides": {
+    "@clerk/shared": "3.47.5",
     "@tanstack/history": "1.162.0",
     "@tanstack/react-router": "1.170.1",
     "@tanstack/react-start": "1.168.2",


### PR DESCRIPTION
## Summary
- force @clerk/shared to 3.47.5 so @clerk/clerk-react no longer resolves the vulnerable 3.47.3 copy
- refresh bun.lock to remove the nested stale Clerk shared package
- restore Bun install minimumReleaseAge to 172800 now that the temporary TanStack window has passed

## Verification
- bun pm why @clerk/shared shows only @clerk/shared@3.47.5
- rg scan found no node-ipc references
- rg scan found no TanStack incident IOCs: @tanstack/setup, router_init.js, 79ac49eedf774dd4b0cfa308722bc463cfe5885c, github:tanstack/router
- bunx biome lint package.json bunfig.toml
- TMPDIR=$PWD/.bun-tmp TEMP=$PWD/.bun-tmp TMP=$PWD/.bun-tmp BUN_INSTALL_CACHE_DIR=$PWD/.bun-cache bun install --frozen-lockfile

## Summary by Sourcery

Update dependency constraints and installation policy to address a Clerk shared vulnerability and restore standard Bun install behavior.

Bug Fixes:
- Override @clerk/shared to version 3.47.5 so downstream packages no longer resolve the vulnerable 3.47.3 release.

Enhancements:
- Refresh bun.lock to align with the updated @clerk/shared override and remove the stale nested package.
- Restore Bun install minimumReleaseAge to 172800 to re-enable the standard package age gate after the temporary TanStack exception.