### PR TITLE
docs: record code smell dependency scan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ For scoped reviews after the last run timestamp:
 - If <LAST_RUN_ISO> is UTC (`...Z`), pass an explicit UTC offset to avoid local-time drift (example: `git log --since='2026-05-15 21:01:30 +0000' --name-only --pretty=format:'%H%n%s%n%b'`).
 - `git symbolic-ref --short -q HEAD || echo "DETACHED"` before PR work so automation can branch off detached worktrees safely
 - `git show --unified=3 <commit_sha>`
+- `bun pm why <package>` to verify dependency overrides resolve to the intended package version
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence
 - `rg -n "setup-bun@" .github/workflows -g'*.yml'` to verify valid action pins after CI workflow updates
 - `rg -n "setup-bun@v" .github/workflows -g'*.yml'` to catch unpinned Bun setup actions

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -89,3 +89,14 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - CI audit: push workflows on `master` for the scanned commits are green for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.
   - Evidence: `gh run list --branch master --event push --limit 12 --json databaseId,headSha,status,conclusion,name,updatedAt`.
 - Workflow docs update: added detached-HEAD preflight and touched-file inventory commands to `CLAUDE.md` for safer automation loops.
+
+### 2026-05-21
+
+- Commit window scan after the previous durable entry covered `c7a5a04bb3111fb2e65938d26cf5b6ba7f66e07e`, `2130ac8947e05dfa6ec9e12148bb2e045e2248f9`, and `3ee2c9fd27dde339dbcbd9b62eb021c325b14350`.
+- Code smell review (info): no grounded runtime bug found. The deploy-preview author filter now excludes `COLLABORATOR`, and the Clerk override resolves all consumers to `@clerk/shared@3.47.5`.
+  - Evidence: `bun pm why @clerk/shared` returned only `@clerk/shared@3.47.5`; `rg -n "@clerk/shared@3\.47\.[0-4]|@clerk/shared@3\.47\.5|@clerk/shared\"" package.json bun.lock` found no vulnerable `3.47.0` through `3.47.4` lock entries.
+- Dead-code review (confident): no new dead-code candidates because the scanned non-doc code changes are workflow config and dependency metadata only.
+  - Evidence: `git show --name-only --pretty=format: 2130ac89 3ee2c9fd | sed '/^$/d' | sort -u` returned `.github/workflows/cf-deploy-preview.yml`, `bun.lock`, `bunfig.toml`, and `package.json`.
+- CI audit: latest `master` push workflows for `3ee2c9fd27dde339dbcbd9b62eb021c325b14350` are green for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.
+  - Evidence: `gh run list --branch master --event push --limit 15 --json databaseId,headSha,status,conclusion,name,updatedAt,url`.
+- Workflow docs update: added `bun pm why <package>` to `CLAUDE.md` so future dependency-security scans verify override resolution before trusting `package.json` alone.

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -93,10 +93,10 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 ### 2026-05-21
 
 - Commit window scan after the previous durable entry covered `c7a5a04bb3111fb2e65938d26cf5b6ba7f66e07e`, `2130ac8947e05dfa6ec9e12148bb2e045e2248f9`, and `3ee2c9fd27dde339dbcbd9b62eb021c325b14350`.
-- Code smell review (info): no grounded runtime bug found. The deploy-preview author filter now excludes `COLLABORATOR`, and the Clerk override resolves all consumers to `@clerk/shared@3.47.5`.
+- Code smell review (info): no grounded runtime bugs found. The deploy-preview author filter now excludes `COLLABORATOR`, and the Clerk override resolves all consumers to `@clerk/shared@3.47.5`.
   - Evidence: `bun pm why @clerk/shared` returned only `@clerk/shared@3.47.5`; `rg -n "@clerk/shared@3\.47\.[0-4]|@clerk/shared@3\.47\.5|@clerk/shared\"" package.json bun.lock` found no vulnerable `3.47.0` through `3.47.4` lock entries.
-- Dead-code review (confident): no new dead-code candidates because the scanned non-doc code changes are workflow config and dependency metadata only.
-  - Evidence: `git show --name-only --pretty=format: 2130ac89 3ee2c9fd | sed '/^$/d' | sort -u` returned `.github/workflows/cf-deploy-preview.yml`, `bun.lock`, `bunfig.toml`, and `package.json`.
+- Dead-code review (confident): no new dead-code candidates because the scanned changes are docs, workflow config, and dependency metadata only.
+  - Evidence: `git show --name-only --pretty=format: c7a5a04b 2130ac89 3ee2c9fd | sed '/^$/d' | sort -u` returned `.github/workflows/cf-deploy-preview.yml`, `CLAUDE.md`, `docs/ai/core-memory.md`, `bun.lock`, `bunfig.toml`, and `package.json`.
 - CI audit: latest `master` push workflows for `3ee2c9fd27dde339dbcbd9b62eb021c325b14350` are green for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.
   - Evidence: `gh run list --branch master --event push --limit 15 --json databaseId,headSha,status,conclusion,name,updatedAt,url`.
 - Workflow docs update: added `bun pm why <package>` to `CLAUDE.md` so future dependency-security scans verify override resolution before trusting `package.json` alone.


### PR DESCRIPTION
## Summary
- record the 2026-05-21 code-smell/dead-code scan in durable core memory
- add `bun pm why <package>` to the automation checklist for dependency override verification

## Findings
- critical: none found from concrete evidence
- warning: none requiring runtime code changes
- info: recent Clerk override resolves to `@clerk/shared@3.47.5`; recent deploy-preview author filter excludes `COLLABORATOR`; no dead-code candidates in non-doc changed files

## Verification
- `git diff --check`
- `bun pm why @clerk/shared`
- `rg -n "@clerk/shared@3\.47\.[0-4]|@clerk/shared@3\.47\.5|@clerk/shared\"" package.json bun.lock`
- `bunx biome lint CLAUDE.md docs/ai/core-memory.md` was attempted; Biome ignored both Markdown paths (`No files were processed`).

## Summary by Sourcery

Document the latest dependency/code-smell scan results and update automation guidance for verifying dependency overrides.

Enhancements:
- Extend the CLAUDE automation checklist to include using `bun pm why <package>` for verifying dependency override resolution.

Documentation:
- Record the 2026-05-21 code-smell and dead-code scan outcomes in the durable core memory documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal development automation instructions for verifying dependency overrides and package resolution integrity.
  * Expanded process documentation with comprehensive code quality review outcomes, static code analysis findings, dead code detection results, and continuous integration pipeline audit status, including specific verification methods and historical change references for audit trails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/monorepo/pull/1146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->