### PR TITLE
fix(ui): restore shared home navigation defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ For scoped reviews after the last run timestamp:
 - `git log --since='<LAST_RUN_ISO>' --no-merges --name-only --pretty=format: | sed '/^$/d' | sort -u` to inventory touched files before symbol checks
 - If <LAST_RUN_ISO> is UTC (`...Z`), pass an explicit UTC offset to avoid local-time drift (example: `git log --since='2026-05-15 21:01:30 +0000' --name-only --pretty=format:'%H%n%s%n%b'`).
 - `git symbolic-ref --short -q HEAD || echo "DETACHED"` before PR work so automation can branch off detached worktrees safely
+- If a linked worktree reports `Operation not permitted` under `.git/worktrees/...`, use the canonical checkout after `git status --short --branch` and stage only touched paths
 - `git show --unified=3 <commit_sha>`
 - `bun pm why <package>` to verify dependency overrides resolve to the intended package version
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ For scoped reviews after the last run timestamp:
 - `git log --since='<LAST_RUN_ISO>' --no-merges --name-only --pretty=format: | sed '/^$/d' | sort -u` to inventory touched files before symbol checks
 - If <LAST_RUN_ISO> is UTC (`...Z`), pass an explicit UTC offset to avoid local-time drift (example: `git log --since='2026-05-15 21:01:30 +0000' --name-only --pretty=format:'%H%n%s%n%b'`).
 - `git symbolic-ref --short -q HEAD || echo "DETACHED"` before PR work so automation can branch off detached worktrees safely
-- If a linked worktree reports `Operation not permitted` under `.git/worktrees/...`, use the canonical checkout after `git status --short --branch` and stage only touched paths
+- See `docs/ai/internal-knowledge.md` for linked-worktree permission fallback details
 - `git show --unified=3 <commit_sha>`
 - `bun pm why <package>` to verify dependency overrides resolve to the intended package version
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence

--- a/apps/blog/src/routes/__root.tsx
+++ b/apps/blog/src/routes/__root.tsx
@@ -112,6 +112,7 @@ function RootComponent() {
               shortText="Duyet Le"
               longText="Duyet Le"
               navigationItems={blogNavigation}
+              homeUrl="/"
               showAuthButtons
               className="blog-site-header border-b-0"
               containerClassName="blog-site-header-inner max-w-[1440px] py-4 lg:px-12"

--- a/apps/home/src/components/SiteChrome.tsx
+++ b/apps/home/src/components/SiteChrome.tsx
@@ -29,6 +29,7 @@ export function SiteHeader() {
         shortText="Duyet Le"
         longText="Duyet Le"
         navigationItems={navigationItems}
+        homeUrl="/"
         showAuthButtons
         authButtonsWrapWithProvider={false}
         onMobileMenuClick={() => setPaletteOpen(true)}

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -104,9 +104,9 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 ### 2026-05-22
 
 - Commit window scan since `2026-05-20 21:00:37 +0000` covered `a16873c0e35b50f179da1a30d49d0a33853fcd3b` and `64ffdb43eeaef62b4e3bb031d576b0f0e41a774b`.
-- Code smell review (warning -> fixed): the blog redesign changed shared `HOME` and `Header` defaults to `/`, which made default headers on subdomain apps link their Home/brand affordances to the current app root instead of `https://duyet.net`. Restored shared defaults to `urls.apps.home` and kept the blog-local root explicit with `homeUrl="/"`.
+- Code smell review (warning -> fixed): the blog redesign changed shared `HOME` and `Header` defaults to `/`, which made default headers on subdomain apps link their Home/brand affordances to the current app root instead of `https://duyet.net`. Restored shared defaults to `urls.apps.home`; kept blog and home app roots explicit with `homeUrl="/"` for local SPA behavior.
   - Evidence: `rg -n "\bHOME\b|homeUrl|createDefaultNavigation" apps packages --glob '!**/*.test.*' --glob '!**/*.spec.*' --glob '!**/__tests__/**'` showed default `Header` consumers in apps without explicit `navigationItems`, plus CV importing shared `HOME`.
 - Dead-code review (confident): no zero-reference removal was justified; `HOME`, `homeUrl`, and `createDefaultNavigation` remain referenced by shared headers and app roots.
 - CI audit: latest `master` push workflows for `64ffdb43eeaef62b4e3bb031d576b0f0e41a774b` are green for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.
   - Evidence: `gh run list --branch master --event push --limit 10 --json databaseId,headSha,status,conclusion,name,updatedAt,url`.
-- Workflow docs update: recorded the linked-worktree `.git/worktrees/...` permission fallback in `CLAUDE.md`; `AGENTS.md` is a symlink to this file.
+- Workflow docs update: recorded the linked-worktree `.git/worktrees/...` permission fallback in `docs/ai/internal-knowledge.md`; `AGENTS.md` is a symlink to `CLAUDE.md`, and `CLAUDE.md` is the canonical instruction entrypoint.

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -100,3 +100,13 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - CI audit: latest `master` push workflows for `3ee2c9fd27dde339dbcbd9b62eb021c325b14350` are green for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.
   - Evidence: `gh run list --branch master --event push --limit 15 --json databaseId,headSha,status,conclusion,name,updatedAt,url`.
 - Workflow docs update: added `bun pm why <package>` to `CLAUDE.md` so future dependency-security scans verify override resolution before trusting `package.json` alone.
+
+### 2026-05-22
+
+- Commit window scan since `2026-05-20 21:00:37 +0000` covered `a16873c0e35b50f179da1a30d49d0a33853fcd3b` and `64ffdb43eeaef62b4e3bb031d576b0f0e41a774b`.
+- Code smell review (warning -> fixed): the blog redesign changed shared `HOME` and `Header` defaults to `/`, which made default headers on subdomain apps link their Home/brand affordances to the current app root instead of `https://duyet.net`. Restored shared defaults to `urls.apps.home` and kept the blog-local root explicit with `homeUrl="/"`.
+  - Evidence: `rg -n "\bHOME\b|homeUrl|createDefaultNavigation" apps packages --glob '!**/*.test.*' --glob '!**/*.spec.*' --glob '!**/__tests__/**'` showed default `Header` consumers in apps without explicit `navigationItems`, plus CV importing shared `HOME`.
+- Dead-code review (confident): no zero-reference removal was justified; `HOME`, `homeUrl`, and `createDefaultNavigation` remain referenced by shared headers and app roots.
+- CI audit: latest `master` push workflows for `64ffdb43eeaef62b4e3bb031d576b0f0e41a774b` are green for `Lint`, `Test`, and `Deploy to Cloudflare Pages`.
+  - Evidence: `gh run list --branch master --event push --limit 10 --json databaseId,headSha,status,conclusion,name,updatedAt,url`.
+- Workflow docs update: recorded the linked-worktree `.git/worktrees/...` permission fallback in `CLAUDE.md`; `AGENTS.md` is a symlink to this file.

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -10,6 +10,7 @@ This repository is the Bun/Turborepo monorepo for duyet.net public apps, shared 
 - Preserve existing UX and public routes unless the request explicitly changes them.
 - Use Bun commands from the relevant package or app directory. Check the local `package.json` before assuming a script exists.
 - Verify with the narrowest useful command first, then broaden only when needed.
+- If a linked worktree reports `Operation not permitted` under `.git/worktrees/...`, use the canonical checkout after `git status --short --branch`; stage only touched paths so unrelated local edits stay out of commits.
 
 ## Root Commands
 

--- a/packages/components/Menu.tsx
+++ b/packages/components/Menu.tsx
@@ -8,11 +8,11 @@ export type NavigationItem = {
   href: string;
 };
 
-export const HOME = { name: "Home", href: "/" };
+export const HOME = { name: "Home", href: duyetUrls.apps.home };
 
 export function createDefaultNavigation(urls: UrlsConfig): NavigationItem[] {
   return [
-    HOME,
+    { name: "Home", href: urls.apps.home },
     { name: "About", href: `${urls.apps.home}/about` },
     { name: "Photos", href: urls.apps.photos },
     { name: "Insights", href: urls.apps.insights },

--- a/packages/components/header/index.tsx
+++ b/packages/components/header/index.tsx
@@ -37,7 +37,7 @@ export default function Header({
   longText,
   center = false,
   navigationItems,
-  homeUrl = "/",
+  homeUrl = urls.apps.home,
   actions,
   showAuthButtons = true,
   authButtonsWrapWithProvider = true,


### PR DESCRIPTION
## Summary
- restore shared Home navigation and Header branding defaults to the configured duyet.net home URL
- keep the redesigned blog header explicitly local with `homeUrl="/"`
- record the code-smell finding and linked-worktree fallback in durable maintenance memory

## Verification
- `bunx biome lint packages/components/Menu.tsx packages/components/header/index.tsx apps/blog/src/routes/__root.tsx`
- `bun run check-types` in `apps/blog`
- `git diff --check -- CLAUDE.md docs/ai/core-memory.md packages/components/Menu.tsx packages/components/header/index.tsx apps/blog/src/routes/__root.tsx`
- `rg -n "\\bHOME\\b|homeUrl|createDefaultNavigation" apps packages --glob "!**/*.test.*" --glob "!**/*.spec.*" --glob "!**/__tests__/**"`

## Evidence
- scanned commits since `2026-05-20 21:00:37 +0000`: `a16873c0e35b50f179da1a30d49d0a33853fcd3b`, `64ffdb43eeaef62b4e3bb031d576b0f0e41a774b`
- latest `master` push workflows for `64ffdb43eeaef62b4e3bb031d576b0f0e41a774b` were green before this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated home URL configuration across components to use centralized settings instead of hardcoded values, ensuring consistency throughout the application.

* **Documentation**
  * Added guidance for resolving git worktree permission issues.
  * Updated development findings log with recent project insights and CI audit results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/monorepo/pull/1147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->