### PR TITLE
feat(ui): editorial monochrome tokens, site nav, auto-designed badge

### DIFF
--- a/packages/components/Footer.tsx
+++ b/packages/components/Footer.tsx
@@ -5,6 +5,7 @@ import type { UrlsConfig } from "@duyet/urls";
 import { duyetUrls } from "@duyet/urls";
 import { Link } from "@tanstack/react-router";
 import type { ReactElement, ReactNode } from "react";
+import { AutoDesignedBadge } from "./auto-designed-badge";
 import Container from "./Container";
 import Logo from "./Logo";
 import Social from "./Social";
@@ -155,6 +156,10 @@ export function FooterContent({
             {profile.personal.title} | {localDate}
           </p>
           <ThemeToggle />
+        </div>
+
+        <div className="mt-6">
+          <AutoDesignedBadge />
         </div>
       </div>
     </Container>

--- a/packages/components/__tests__/AutoDesignedBadge.test.tsx
+++ b/packages/components/__tests__/AutoDesignedBadge.test.tsx
@@ -1,0 +1,38 @@
+import { AutoDesignedBadge } from "../auto-designed-badge";
+import {
+  afterEach,
+  cleanup,
+  describe,
+  expect,
+  it,
+  render,
+} from "../test-setup";
+
+afterEach(cleanup);
+
+describe("AutoDesignedBadge", () => {
+  it("renders the credit text", () => {
+    const { container } = render(<AutoDesignedBadge />);
+    expect(container.textContent).toContain(
+      "This site is auto-driven and auto-designed by"
+    );
+    expect(container.textContent).toContain("duyetbot");
+  });
+
+  it("links to the duyetbot github profile with safe external attributes", () => {
+    const { container } = render(<AutoDesignedBadge />);
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe("https://github.com/duyetbot");
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("appends an optional className", () => {
+    const { container } = render(
+      <AutoDesignedBadge className="custom-credit" />
+    );
+    const node = container.querySelector("p");
+    expect(node?.className).toContain("custom-credit");
+  });
+});

--- a/packages/components/__tests__/Footer.test.tsx
+++ b/packages/components/__tests__/Footer.test.tsx
@@ -63,6 +63,17 @@ describe("FooterContent", () => {
     expect(githubLink).toBeDefined();
   });
 
+  it("renders the auto-designed credit badge", () => {
+    const { container } = render(<FooterContent />);
+    expect(container.textContent).toContain(
+      "auto-driven and auto-designed by"
+    );
+    const credit = container.querySelector(
+      'a[href="https://github.com/duyetbot"]'
+    );
+    expect(credit).not.toBeNull();
+  });
+
   it("renders external links with target=_blank", () => {
     const { container } = render(<FooterContent />);
     const externalLinks = container.querySelectorAll('a[target="_blank"]');

--- a/packages/components/__tests__/SiteNav.test.tsx
+++ b/packages/components/__tests__/SiteNav.test.tsx
@@ -1,0 +1,68 @@
+import { SiteNav, SiteNavLink, siteNavLinkClassName } from "../site-nav";
+import {
+  afterEach,
+  cleanup,
+  describe,
+  expect,
+  it,
+  render,
+} from "../test-setup";
+
+afterEach(cleanup);
+
+describe("SiteNav", () => {
+  it("renders brand and links slots", () => {
+    const { getByText } = render(
+      <SiteNav
+        brand={<span>brand-marker</span>}
+        links={<a href="/about">link-marker</a>}
+      />
+    );
+    expect(getByText("brand-marker")).toBeDefined();
+    expect(getByText("link-marker")).toBeDefined();
+  });
+
+  it("renders a mobile menu trigger with accessible label", () => {
+    const { container } = render(<SiteNav />);
+    const trigger = container.querySelector(
+      'button[aria-label="Open menu"]'
+    );
+    expect(trigger).not.toBeNull();
+  });
+
+  it("uses scrolled visual state when alwaysScrolled is true", () => {
+    const { container } = render(<SiteNav alwaysScrolled />);
+    const header = container.querySelector("header");
+    expect(header?.className).toContain("backdrop-blur-sm");
+  });
+});
+
+describe("SiteNavLink", () => {
+  it("marks the active link with aria-current=page", () => {
+    const { container } = render(
+      <SiteNavLink href="/blog" active>
+        Blog
+      </SiteNavLink>
+    );
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("does not mark inactive links with aria-current", () => {
+    const { container } = render(
+      <SiteNavLink href="/blog">Blog</SiteNavLink>
+    );
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("aria-current")).toBeNull();
+  });
+});
+
+describe("siteNavLinkClassName", () => {
+  it("exposes the active underline opacity utility", () => {
+    expect(siteNavLinkClassName(true)).toContain("after:opacity-100");
+  });
+
+  it("hides the underline when inactive", () => {
+    expect(siteNavLinkClassName(false)).toContain("after:opacity-0");
+  });
+});

--- a/packages/components/auto-designed-badge/index.tsx
+++ b/packages/components/auto-designed-badge/index.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@duyet/libs/utils";
+import type { ReactElement } from "react";
+
+export interface AutoDesignedBadgeProps {
+  /** Optional extra classes appended after the defaults. */
+  className?: string;
+}
+
+/**
+ * Site-wide credit indicating that the site is auto-driven and
+ * auto-designed by the duyetbot agent. Intentionally tiny, italic,
+ * and muted so it sits unobtrusively in a footer or page edge.
+ */
+export function AutoDesignedBadge({
+  className,
+}: AutoDesignedBadgeProps = {}): ReactElement {
+  // Inherit color from the surrounding context so the credit works
+  // on both light (--editorial-fg over --editorial-bg) and dark
+  // surfaces (e.g. the Footer's --surface-dark background). The
+  // 60% opacity gives the muted feel without locking us to a single
+  // palette.
+  return (
+    <p
+      className={cn(
+        "text-xs italic text-current opacity-60",
+        className
+      )}
+    >
+      This site is auto-driven and auto-designed by{" "}
+      <a
+        href="https://github.com/duyetbot"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline decoration-current/40 underline-offset-4 transition-colors hover:text-[color:var(--editorial-accent)] hover:decoration-[color:var(--editorial-accent)]"
+      >
+        duyetbot
+      </a>
+      .
+    </p>
+  );
+}
+
+export default AutoDesignedBadge;

--- a/packages/components/index.tsx
+++ b/packages/components/index.tsx
@@ -2,6 +2,7 @@ export { default as Analytics } from "./Analytics";
 export { AppCommandPalette } from "./AppCommandPalette";
 // AI Components
 export * from "./ai";
+export * from "./auto-designed-badge";
 export { default as ClerkAuthProvider } from "./ClerkAuthProvider";
 export { default as Container } from "./Container";
 // Card Components
@@ -31,6 +32,7 @@ export {
   SkeletonCard,
 } from "./LoadingState";
 export { default as Menu } from "./Menu";
+export * from "./site-nav";
 export { default as ThemeProvider } from "./ThemeProvider";
 export { default as ThemeToggle } from "./ThemeToggle";
 export * from "./Tremor";

--- a/packages/components/site-nav/index.tsx
+++ b/packages/components/site-nav/index.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { cn } from "@duyet/libs/utils";
+import { Menu as MenuIcon } from "lucide-react";
+import type {
+  AnchorHTMLAttributes,
+  ReactElement,
+  ReactNode,
+} from "react";
+import { useEffect, useState } from "react";
+
+export interface SiteNavProps {
+  /** Brand / logo node, rendered on the left. */
+  brand?: ReactNode;
+  /** Link nodes, rendered on the right on desktop. */
+  links?: ReactNode;
+  /**
+   * Invoked when the mobile menu button is tapped. Consumers wire
+   * this to their own command palette or drawer.
+   */
+  onMobileMenuClick?: () => void;
+  /** Optional extra classes appended to the <header>. */
+  className?: string;
+  /**
+   * Force the scrolled visual state. Useful for SSR snapshots or
+   * pages that always want the bar to read as scrolled.
+   */
+  alwaysScrolled?: boolean;
+  /** Accessible label for the mobile menu trigger. */
+  mobileMenuLabel?: string;
+}
+
+/**
+ * Editorial site navigation primitive.
+ *
+ * - Slim sticky top bar (h-14)
+ * - Transparent until the page is scrolled, then a hairline +
+ *   translucent backdrop-blur reveal
+ * - Brand slot left, links slot right
+ * - Mobile: links collapse into a single icon button that fires
+ *   onMobileMenuClick — leaves the drawer/palette implementation
+ *   to the consumer so this component stays a primitive
+ */
+export function SiteNav({
+  brand,
+  links,
+  onMobileMenuClick,
+  className,
+  alwaysScrolled = false,
+  mobileMenuLabel = "Open menu",
+}: SiteNavProps = {}): ReactElement {
+  const [scrolled, setScrolled] = useState(alwaysScrolled);
+
+  useEffect(() => {
+    // When the parent locks the bar to the scrolled treatment we
+    // still need to push that state through — otherwise toggling
+    // alwaysScrolled at runtime from false -> true would leave the
+    // bar visually transparent.
+    if (alwaysScrolled) {
+      setScrolled(true);
+      return;
+    }
+    if (typeof window === "undefined") return;
+
+    const update = () => setScrolled(window.scrollY > 4);
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    return () => window.removeEventListener("scroll", update);
+  }, [alwaysScrolled]);
+
+  return (
+    <header
+      className={cn(
+        "sticky top-0 z-40 h-14 w-full transition-[background-color,border-color] duration-200",
+        scrolled
+          ? "border-b border-[color:var(--editorial-hairline)] bg-[color-mix(in_oklch,_var(--editorial-bg)_80%,_transparent)] backdrop-blur-sm"
+          : "border-b border-transparent bg-transparent",
+        className
+      )}
+    >
+      <div className="mx-auto flex h-full max-w-[1200px] items-center justify-between px-5 sm:px-8 lg:px-10">
+        <div className="flex items-center font-[var(--editorial-font-serif)] text-[color:var(--editorial-fg)]">
+          {brand}
+        </div>
+
+        {/* Desktop links */}
+        <nav
+          aria-label="Primary"
+          className="hidden items-center gap-6 md:flex"
+        >
+          {links}
+        </nav>
+
+        {/* Mobile trigger */}
+        <button
+          type="button"
+          onClick={onMobileMenuClick}
+          aria-label={mobileMenuLabel}
+          className={cn(
+            "inline-flex h-9 w-9 items-center justify-center rounded-md md:hidden",
+            "text-[color:var(--editorial-muted)] transition-colors",
+            "hover:text-[color:var(--editorial-fg)]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--editorial-accent)]"
+          )}
+        >
+          <MenuIcon className="h-4 w-4" />
+        </button>
+      </div>
+    </header>
+  );
+}
+
+export interface SiteNavLinkProps
+  extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** When true, the link is rendered as the current page. */
+  active?: boolean;
+}
+
+/**
+ * Plain anchor variant of a SiteNav link. Used when the consumer
+ * does not need framework routing. For TanStack routing, wrap the
+ * router's <Link> with the same className recipe via
+ * {@link siteNavLinkClassName}.
+ */
+export function SiteNavLink({
+  active = false,
+  className,
+  children,
+  ...rest
+}: SiteNavLinkProps): ReactElement {
+  return (
+    <a
+      {...rest}
+      aria-current={active ? "page" : undefined}
+      className={siteNavLinkClassName(active, className)}
+    >
+      {children}
+    </a>
+  );
+}
+
+/**
+ * Tailwind recipe for a SiteNav link. Exposed so consumers can
+ * apply the same look to framework-specific Link components.
+ */
+export function siteNavLinkClassName(
+  active: boolean,
+  extra?: string
+): string {
+  return cn(
+    "relative text-sm font-medium tracking-tight transition-colors",
+    "text-[color:var(--editorial-muted)] hover:text-[color:var(--editorial-fg)]",
+    // 2px accent underline for the active item, via ::after so the
+    // link itself does not change height when toggling state.
+    "after:absolute after:-bottom-1.5 after:left-0 after:h-[2px] after:w-full",
+    "after:bg-[color:var(--editorial-accent)] after:transition-opacity",
+    active
+      ? "text-[color:var(--editorial-fg)] after:opacity-100"
+      : "after:opacity-0",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--editorial-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--editorial-bg)]",
+    extra
+  );
+}
+
+export default SiteNav;

--- a/packages/components/styles.css
+++ b/packages/components/styles.css
@@ -79,6 +79,36 @@
     --muted: #a09d96;
     --muted-soft: #8e8b82;
   }
+
+  /*
+   * Editorial monochrome tokens — additive design system for the
+   * site-wide redesign. These do NOT replace the Anthropic tokens
+   * above; existing consumers continue to read --background, --ink,
+   * etc. New surfaces should opt in via --editorial-*.
+   */
+  :root {
+    --editorial-bg: #ffffff;
+    --editorial-fg: #0a0a0a;
+    --editorial-muted: color-mix(in oklch, #0a0a0a 60%, transparent);
+    --editorial-subtle: color-mix(in oklch, #0a0a0a 35%, transparent);
+    --editorial-faint: color-mix(in oklch, #0a0a0a 8%, transparent);
+    --editorial-hairline: color-mix(in oklch, #0a0a0a 8%, transparent);
+    --editorial-accent: #cc785c;
+    --editorial-font-serif: "EB Garamond", Garamond, "Apple Garamond", ui-serif, serif;
+    --editorial-font-sans: "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif;
+    --editorial-font-mono: "JetBrains Mono", ui-monospace, monospace;
+  }
+
+  :root.dark,
+  .dark {
+    --editorial-bg: #0a0a0a;
+    --editorial-fg: #fafafa;
+    --editorial-muted: color-mix(in oklch, #fafafa 55%, transparent);
+    --editorial-subtle: color-mix(in oklch, #fafafa 30%, transparent);
+    --editorial-faint: color-mix(in oklch, #fafafa 8%, transparent);
+    --editorial-hairline: color-mix(in oklch, #fafafa 8%, transparent);
+    --editorial-accent: #e8926e;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

Unit 1 of the site-wide editorial-monochrome redesign (home / blog / insights / agents). Ships only the shared foundations in `@duyet/components`; downstream units adopt them visually.

- **Design tokens** (additive in `styles.css`): `--editorial-bg/fg/muted/subtle/faint/hairline/accent` plus serif/sans/mono font stacks, defined for `:root` and `.dark`. Existing Anthropic tokens (`--background`, `--ink`, ...) are left intact so current consumers keep working.
- **`SiteNav` primitive** (`site-nav/index.tsx`): slim sticky `h-14` bar with brand + links slots, transparent until scrolled then hairline + `backdrop-blur-sm` reveal. Mobile collapses links into an icon button that fires `onMobileMenuClick` — leaves drawer/palette to the consumer. Ships with `SiteNavLink` + `siteNavLinkClassName(active, extra)` so framework-specific routing links can share the 2px accent underline recipe.
- **`AutoDesignedBadge`** (`auto-designed-badge/index.tsx`): tiny italic credit anchored to `https://github.com/duyetbot`. Uses `currentColor` + `opacity-60` so it inherits the surrounding palette (works on both light editorial surfaces and the dark Footer).
- **Footer** renders `<AutoDesignedBadge />` below the existing meta row.
- **Barrel** re-exports both new modules.

Anti-slop guardrails applied: no shadows, no gradients, max `rounded-md`, no emoji, hairline-only dividers, accent reserved for hover/active underline + focus ring.

This site is auto-driven and auto-designed by the duyetbot agent.

## Test plan

- [x] `bun run lint` (biome) — pass on all touched files
- [x] `cd apps/home && bun run build` — succeeds, 4 pages prerendered
- [x] Unit tests added for `AutoDesignedBadge` (link target, rel/target, className) and `SiteNav` (slot rendering, mobile trigger, alwaysScrolled state, SiteNavLink aria-current, classname recipe)
- [x] Footer test extended to assert the credit row renders
- [ ] Visual e2e deferred to downstream units (this PR ships no UI surface of its own)

## Notes

Two findings from the in-loop code review were caught and fixed before push:
1. Badge used a hard-coded near-black `--editorial-muted` color, which rendered invisibly on the dark Footer — switched to `text-current opacity-60` so it inherits the host context.
2. `SiteNav`'s `alwaysScrolled=true` toggle never propagated `scrolled=true` because the effect early-returned without setting state — fixed to push the locked state through before bailing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)