### PR TITLE
style(blog): editorial reader experience for post pages

### DIFF
--- a/apps/blog/components/layout/SeriesBox.tsx
+++ b/apps/blog/components/layout/SeriesBox.tsx
@@ -1,5 +1,6 @@
 import type { Series } from "@duyet/interfaces";
 import { cn } from "@duyet/libs/utils";
+import "@/styles/post-reader.css";
 
 export function SeriesBox({
   series,
@@ -17,75 +18,40 @@ export function SeriesBox({
   if (!series) return null;
   const { name, posts } = series;
 
-  // Tone parameter kept for API compatibility with downstream consumers
+  // Tone parameter kept for API compatibility with downstream consumers.
   void tone;
 
   return (
-    <div
-      className={cn(
-        "border-y border-[var(--border-faint)] py-6 dark:border-white/10",
-        className
-      )}
+    <aside
+      aria-label={`Series: ${name}`}
+      className={cn("series-block", className)}
     >
+      <p className="series-label">Part of the series</p>
+
       {showTitle && (
-        <h2
-          className={cn(
-            "mb-6 text-2xl font-semibold tracking-[-0.02em] text-[var(--ink)] dark:text-[var(--on-dark)]"
-          )}
-        >
-          Series:{" "}
-          <a
-            className="underline-offset-4 transition-colors hover:text-[var(--body)] hover:underline"
-            href={`/series/${series.slug}/`}
-          >
-            {name}
-          </a>
+        <h2 className="series-title">
+          <a href={`/series/${series.slug}/`}>{name}</a>
         </h2>
       )}
 
-      <div className="grid grid-cols-1 gap-3">
-        {posts.map(({ slug, title, excerpt }) => {
+      <ol>
+        {posts.map(({ slug, title }) => {
           const isCurrent = current === slug;
           return (
-            <div
-              className={cn(
-                "border-t border-[var(--border-faint)] py-4 transition-colors hover:bg-[var(--surface-soft)]",
-                isCurrent && "bg-[var(--surface-soft)]"
-              )}
+            <li
+              className={cn(isCurrent && "is-current")}
               key={slug}
+              aria-current={isCurrent ? "page" : undefined}
             >
-              <div className="flex-1">
-                {isCurrent ? (
-                  <span
-                    className={cn(
-                      "line-clamp-1 text-base font-medium text-[var(--ink)] dark:text-[var(--on-dark)]"
-                    )}
-                  >
-                    {title}
-                  </span>
-                ) : (
-                  <a
-                    className={cn(
-                      "line-clamp-1 text-base font-medium text-[var(--body-strong)] transition-colors hover:text-[var(--body)] dark:text-[var(--on-dark-soft)] dark:hover:text-[var(--on-dark)]"
-                    )}
-                    href={`${slug}/`}
-                  >
-                    {title}
-                  </a>
-                )}
-
-                <p
-                  className={cn(
-                    "line-clamp-1 mt-1 text-sm text-[var(--muted)] dark:text-[var(--on-dark-soft)]"
-                  )}
-                >
-                  {excerpt}
-                </p>
-              </div>
-            </div>
+              {isCurrent ? (
+                <span>{title}</span>
+              ) : (
+                <a href={`${slug}/`}>{title}</a>
+              )}
+            </li>
           );
         })}
-      </div>
-    </div>
+      </ol>
+    </aside>
   );
 }

--- a/apps/blog/src/routes/$year/$month/$slug.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug.tsx
@@ -8,6 +8,7 @@ import { SeriesBox } from "@/components/layout/SeriesBox";
 import { ReadingProgress } from "@/components/post/ReadingProgress";
 import { TableOfContents } from "@/components/post/TableOfContents";
 import { getPostBySlug, getSeries } from "@/lib/posts";
+import "@/styles/post-reader.css";
 import Content from "./-content";
 import Meta from "./-meta";
 
@@ -115,24 +116,18 @@ function PostPage() {
   };
 
   return (
-    <div className="overflow-x-hidden pb-20">
+    <div className="post-reader overflow-x-hidden pb-24">
       <Container className="mx-auto max-w-[1280px] px-5 sm:px-8 lg:px-10">
         <ReadingProgress />
 
         <div className="mx-auto flex justify-center gap-10 xl:max-w-[1280px]">
-          <div className="min-w-0 max-w-3xl flex-1">
+          <div className="post-body min-w-0 flex-1">
             <Content post={post} />
 
-            <div className="my-12 border-t border-[var(--border-faint)] dark:border-white/10" />
-
-            <Meta post={post} series={series} />
+            <Meta post={post} series={series} className="post-meta mt-12" />
 
             {series && (
-              <SeriesBox
-                className="mt-12"
-                series={series}
-                current={post.slug}
-              />
+              <SeriesBox series={series} current={post.slug} />
             )}
           </div>
 

--- a/apps/blog/src/routes/$year/$month/-content.tsx
+++ b/apps/blog/src/routes/$year/$month/-content.tsx
@@ -53,6 +53,18 @@ async function compileMDX(
   return MDXContent as React.ComponentType<MDXContentProps>;
 }
 
+// Shared editorial prose classes — narrow measure, generous leading.
+// CSS in `styles/post-reader.css` (scoped under `.post-reader`) controls
+// font family, sizing, and colour; here we just keep table/pre overflow
+// behaviour and let prose hooks pick up the rest.
+const proseClassName = cn(
+  "prose dark:prose-invert",
+  "max-w-none",
+  "[&>table]:overflow-x-auto [&>table]:sm:-mx-4 [&>table]:lg:-mx-8",
+  "[&>pre]:overflow-x-auto",
+  "prose-table:text-sm prose-table:leading-relaxed prose-table:table-auto"
+);
+
 function MDXRenderer({ source }: { source: string }) {
   if (!mdxCache.has(source)) {
     mdxCache.set(source, compileMDX(source));
@@ -61,23 +73,7 @@ function MDXRenderer({ source }: { source: string }) {
   const MDXContent = use(mdxCache.get(source)!);
 
   return (
-    <article
-      className={cn(
-        "prose dark:prose-invert",
-        "max-w-none",
-        "[&>table]:overflow-x-auto [&>table]:sm:-mx-4 [&>table]:sm:-mx-8 [&>table]:lg:-mx-16 [&>table]:xl:-mx-24",
-        "[&>table]:border-t [&>table]:border-b [&>table]:border-[var(--border)] dark:[&>table]:border-white/10",
-        "[&>pre]:overflow-x-auto [&>pre]:sm:-mx-4 [&>pre]:sm:-mx-8 [&>pre]:lg:-mx-16 [&>pre]:xl:-mx-24",
-        "prose-headings:text-[var(--foreground)]",
-        "prose-headings:font-semibold prose-headings:tracking-tight",
-        "prose-p:text-[#3d3d3a] dark:prose-p:text-[var(--foreground)]/80",
-        "prose-a:text-[var(--ink)] dark:prose-a:text-[var(--on-dark)]",
-        "prose-a:underline prose-a:underline-offset-4",
-        "prose-strong:text-[var(--foreground)]",
-        "prose-code:break-words",
-        "prose-table:text-sm prose-table:leading-relaxed prose-table:table-auto"
-      )}
-    >
+    <article className={proseClassName}>
       <MDXContent components={mdxComponents} />
     </article>
   );
@@ -86,41 +82,19 @@ function MDXRenderer({ source }: { source: string }) {
 export default function Content({ post }: { post: ContentPost }) {
   return (
     <>
-      <header className="mb-10 flex flex-col gap-5 border-b border-[var(--border-faint)] pb-8 pt-10 sm:pt-14 lg:pt-16">
-        <h1
-          className={cn(
-            "mt-2 break-words py-2",
-            "text-[var(--foreground)]",
-            "text-[34px] font-semibold leading-[1.12] tracking-tight",
-            "sm:text-[46px]"
-          )}
-        >
-          {post.title}
-        </h1>
+      <header className="post-header">
+        <h1 className="post-title">{post.title}</h1>
 
-        <OldPostWarning post={post} year={5} className="" />
+        {post.excerpt ? <p className="post-dek">{post.excerpt}</p> : null}
+
+        <OldPostWarning post={post} year={5} className="mt-6" />
       </header>
 
       {post.isMDX && post.mdxSource ? (
         <MDXRenderer source={post.mdxSource} />
       ) : (
         <article
-          className={cn(
-            'prose dark:prose-invert',
-            "max-w-none",
-            "[&>table]:overflow-x-auto [&>table]:sm:-mx-4 [&>table]:sm:-mx-8 [&>table]:lg:-mx-16 [&>table]:xl:-mx-24",
-            "[&>table]:border-t [&>table]:border-b [&>table]:border-[var(--border)] dark:[&>table]:border-white/10",
-            "[&>pre]:overflow-x-auto [&>pre]:sm:-mx-4 [&>pre]:sm:-mx-8 [&>pre]:lg:-mx-16 [&>pre]:xl:-mx-24",
-            "prose-headings:text-[var(--foreground)]",
-            "prose-headings:font-semibold prose-headings:tracking-tight",
-            "prose-p:text-[#3d3d3a] dark:prose-p:text-[var(--foreground)]/80",
-            "prose-p:leading-8",
-            "prose-a:text-[var(--ink)] dark:prose-a:text-[var(--on-dark)]",
-            "prose-a:underline prose-a:underline-offset-4",
-            "prose-strong:text-[var(--foreground)]",
-            "prose-code:break-words",
-            "prose-table:text-sm prose-table:leading-relaxed"
-          )}
+          className={proseClassName}
           dangerouslySetInnerHTML={{ __html: post.content || "No content" }}
         />
       )}

--- a/apps/blog/src/routes/$year/$month/-markdown-menu.tsx
+++ b/apps/blog/src/routes/$year/$month/-markdown-menu.tsx
@@ -97,10 +97,9 @@ export function MarkdownMenu({
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
-          "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm",
-          "border border-[#1a1a1a]/10 dark:border-white/10",
-          "hover:bg-[#f7f7f7] dark:hover:bg-[#1a1a1a]",
-          "text-[#1a1a1a]/70 dark:text-[#f8f8f2]/70",
+          "flex items-center gap-1.5 text-sm",
+          "text-[var(--muted)] dark:text-[#f8f8f2]/55",
+          "hover:text-[var(--ink)] dark:hover:text-[var(--on-dark)]",
           "transition-colors"
         )}
       >
@@ -118,9 +117,8 @@ export function MarkdownMenu({
         <div
           className={cn(
             "absolute right-0 bottom-full mb-2 w-72 z-[9999]",
-            "rounded-xl border border-[var(--border)] dark:border-white/10",
+            "rounded-md border border-[var(--hairline)] dark:border-white/10",
             "bg-[var(--background)] dark:bg-[#1a1a1a]",
-            "shadow-lg",
             "overflow-hidden",
             "py-1"
           )}

--- a/apps/blog/src/routes/$year/$month/-meta.tsx
+++ b/apps/blog/src/routes/$year/$month/-meta.tsx
@@ -18,7 +18,7 @@ export default function Meta({ post, className }: ContentProps) {
 
   return (
     <div className={cn(className)}>
-      <div className="flex flex-wrap items-center gap-x-5 gap-y-3 text-sm font-medium text-[#6c6a64] dark:text-[#f8f8f2]/55">
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-3 text-sm font-medium text-[var(--muted)] dark:text-[#f8f8f2]/55 [font-variant-numeric:tabular-nums]">
         <div className="flex items-center gap-1.5">
           <Calendar className="h-3.5 w-3.5" />
           <time dateTime={new Date(post.date).toISOString()}>
@@ -28,7 +28,7 @@ export default function Meta({ post, className }: ContentProps) {
               day: "numeric",
             })}
           </time>
-          <span className="text-[var(--border)] dark:text-white/20">·</span>
+          <span className="text-[var(--hairline)] dark:text-white/20">·</span>
           <span>{distanceToNow(new Date(post.date))}</span>
         </div>
 

--- a/apps/blog/styles/post-reader.css
+++ b/apps/blog/styles/post-reader.css
@@ -1,0 +1,337 @@
+/* Post reader editorial layout — scoped to .post-reader on the post route.
+ * Owned by the Unit-4 redesign. Reaches across the prose tree to override
+ * global blog styles for the reader experience only; list pages and the
+ * shell remain untouched.
+ */
+
+.post-reader {
+  /* Reader-local fonts. Fall back to global tokens so we don't need to
+   * mutate globals.css. */
+  --reader-serif: "EB Garamond", Garamond, "Apple Garamond", ui-serif, serif;
+  --reader-sans: "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif;
+  --reader-mono: "JetBrains Mono", "JetBrains Mono Variable", ui-monospace,
+    "SF Mono", Menlo, Monaco, Consolas, monospace;
+
+  /* Local fallbacks for tokens Unit 3 owns globally. */
+  --reader-faint: var(--surface-soft, #f7f7f5);
+  --reader-hairline: var(--hairline, rgba(20, 20, 19, 0.08));
+  --reader-muted: var(--muted, #6c6a64);
+  --reader-ink: var(--ink, #141413);
+  --reader-accent: var(--accent, #cc785c);
+}
+
+.dark .post-reader {
+  --reader-faint: rgba(255, 255, 255, 0.04);
+}
+
+/* ----------- Lede header ------------------------------------------ */
+
+.post-reader .post-header {
+  margin: 0 auto 56px;
+  padding-top: 24px;
+}
+
+.post-reader .post-title {
+  margin: 0;
+  font-family: var(--reader-serif);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  font-size: clamp(2.4rem, 4.6vw, 3.6rem);
+  color: var(--reader-ink);
+  text-wrap: balance;
+}
+
+.dark .post-reader .post-title {
+  color: var(--on-dark, #faf9f5);
+}
+
+.post-reader .post-dek {
+  margin: 18px 0 0;
+  font-family: var(--reader-serif);
+  font-weight: 400;
+  font-style: italic;
+  font-size: 1.25rem;
+  line-height: 1.45;
+  color: var(--reader-muted);
+  text-wrap: pretty;
+}
+
+.post-reader .post-meta {
+  margin-top: 28px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ----------- Prose: narrow measure, generous leading -------------- */
+
+.post-reader .post-body {
+  max-width: 68ch;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.post-reader .prose {
+  font-family: var(--reader-sans);
+  font-size: 1.0625rem;
+  line-height: 2;
+  color: var(--body, #3d3d3a);
+}
+
+.dark .post-reader .prose {
+  color: rgba(248, 248, 242, 0.82);
+}
+
+.post-reader .prose p {
+  line-height: 2;
+  margin-bottom: 1.25em;
+}
+
+/* Serif headings inside the article body */
+.post-reader .prose :where(h2, h3, h4) {
+  font-family: var(--reader-serif);
+  font-weight: 500;
+  letter-spacing: -0.012em;
+  color: var(--reader-ink);
+}
+
+.dark .post-reader .prose :where(h2, h3, h4) {
+  color: var(--on-dark, #faf9f5);
+}
+
+.post-reader .prose h2 {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  margin-top: 2.4em;
+  margin-bottom: 0.6em;
+  /* Strip the global border-bottom — let whitespace separate. */
+  border-bottom: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.post-reader .prose h3 {
+  font-size: 1.35rem;
+  line-height: 1.3;
+  margin-top: 2em;
+  margin-bottom: 0.5em;
+}
+
+.post-reader .prose h4 {
+  font-size: 1.1rem;
+  line-height: 1.35;
+  margin-top: 1.6em;
+  margin-bottom: 0.4em;
+}
+
+/* Links: subtle by default, accent underline on hover. */
+.post-reader .prose a {
+  color: var(--reader-ink);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-decoration-color: var(--reader-hairline);
+  text-underline-offset: 4px;
+  transition: text-decoration-color 150ms ease-out;
+}
+
+.post-reader .prose a:hover {
+  text-decoration-color: var(--reader-accent);
+}
+
+.dark .post-reader .prose a {
+  color: var(--on-dark, #faf9f5);
+}
+
+/* Blockquote: hairline rule, no italic-fest. */
+.post-reader .prose blockquote {
+  border-left: 1px solid var(--reader-hairline);
+  padding-left: 1.25em;
+  margin: 1.5em 0;
+  color: var(--reader-muted);
+  font-style: normal;
+}
+
+/* Footnotes / asides muted and smaller. */
+.post-reader .prose aside,
+.post-reader .prose .footnotes,
+.post-reader .prose section.footnotes {
+  font-size: 0.875em;
+  color: var(--reader-muted);
+  border-top: 1px solid var(--reader-hairline);
+  margin-top: 3em;
+  padding-top: 1.5em;
+}
+
+/* ----------- Code blocks: flat, no rounded, no shadow ------------- */
+
+.post-reader .prose :where(pre),
+.post-reader article pre {
+  background-color: var(--reader-faint) !important;
+  border: 0 !important;
+  border-left: 2px solid var(--reader-hairline) !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  padding: 1em 1.25em;
+  margin: 2em 0;
+  font-family: var(--reader-mono);
+  font-size: 0.875em;
+  line-height: 1.7;
+}
+
+.dark .post-reader .prose :where(pre),
+.dark .post-reader article pre {
+  background-color: rgba(255, 255, 255, 0.04) !important;
+  border-left-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+.post-reader .prose :where(pre) code {
+  background: transparent !important;
+  padding: 0 !important;
+  font-size: inherit;
+}
+
+/* Inline code: subtle faint bg, sharp corners. */
+.post-reader .prose :where(code):not(:where(pre code)) {
+  background-color: var(--reader-faint) !important;
+  color: var(--reader-ink) !important;
+  border-radius: 2px !important;
+  padding: 0.1em 0.35em !important;
+  font-family: var(--reader-mono);
+  font-size: 0.875em;
+  font-weight: 400;
+}
+
+.dark .post-reader .prose :where(code):not(:where(pre code)) {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+  color: var(--on-dark, #faf9f5) !important;
+}
+
+/* ----------- Meta strip: tabular nums for dates ------------------- */
+
+.post-reader .post-meta time,
+.post-reader .post-meta .meta-number {
+  font-variant-numeric: tabular-nums;
+}
+
+/* ----------- Fade-up on first paint ------------------------------- */
+
+@keyframes post-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .post-reader .post-header,
+  .post-reader .post-body {
+    animation: post-fade-up 320ms ease-out both;
+  }
+  .post-reader .post-body {
+    animation-delay: 60ms;
+  }
+}
+
+/* Series block: borderless editorial list. */
+
+.series-block {
+  margin-top: 56px;
+  padding: 28px 0;
+  border-top: 1px solid var(--reader-hairline);
+  border-bottom: 1px solid var(--reader-hairline);
+}
+
+.series-block .series-label {
+  margin: 0 0 6px;
+  font-family: var(--reader-sans);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--reader-muted);
+}
+
+.series-block .series-title {
+  margin: 0 0 18px;
+  font-family: var(--reader-serif);
+  font-weight: 500;
+  font-size: 1.4rem;
+  line-height: 1.2;
+  letter-spacing: -0.012em;
+  color: var(--reader-ink);
+}
+
+.dark .series-block .series-title {
+  color: var(--on-dark, #faf9f5);
+}
+
+.series-block .series-title a {
+  color: inherit;
+  text-decoration: none;
+  background-image: linear-gradient(
+    transparent calc(100% - 1px),
+    var(--reader-hairline) 1px
+  );
+  background-size: 100% 100%;
+  transition: background-image 150ms ease-out;
+}
+
+.series-block .series-title a:hover {
+  background-image: linear-gradient(
+    transparent calc(100% - 1px),
+    var(--reader-accent) 1px
+  );
+}
+
+.series-block ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  counter-reset: series-counter;
+}
+
+.series-block li {
+  display: grid;
+  grid-template-columns: 2.25rem 1fr;
+  gap: 0 4px;
+  padding: 6px 0;
+  counter-increment: series-counter;
+  font-family: var(--reader-sans);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.series-block li::before {
+  content: counter(series-counter, decimal-leading-zero);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.75rem;
+  color: var(--reader-muted);
+  padding-top: 0.25em;
+}
+
+.series-block li a {
+  color: var(--reader-muted);
+  text-decoration: none;
+  transition: color 150ms ease-out;
+}
+
+.series-block li a:hover {
+  color: var(--reader-ink);
+}
+
+.dark .series-block li a:hover {
+  color: var(--on-dark, #faf9f5);
+}
+
+.series-block li.is-current span,
+.series-block li.is-current {
+  color: var(--reader-ink);
+  font-weight: 600;
+}
+
+.dark .series-block li.is-current,
+.dark .series-block li.is-current span {
+  color: var(--on-dark, #faf9f5);
+}


### PR DESCRIPTION
## Summary

Restyles the blog post reader (`/$year/$month/$slug`) to match the
editorial monochrome system being rolled out across the site.

- Narrow `68ch` measure, generous leading, serif Garamond H1, dek
  pulled from the post excerpt, tabular-num meta strip
- Article H2/H3/H4 set in serif; body in Inter
- Code blocks flattened (left hairline accent, no rounded box,
  no shadow, no colour) — inline code on a faint tint with sharp
  corners
- `SeriesBox` redrawn as a borderless editorial list (uppercase
  tracking-wider label, serif series title, ordered list with the
  current item marked, single hairline above/below)
- Copy-page button switches from pill to ghost text-button; menu
  panel drops the shadow and uses `rounded-md`
- All new tokens live in `apps/blog/styles/post-reader.css` scoped
  under `.post-reader` and `.series-block` so list pages and
  `globals.css` (owned by Unit 3) are untouched

## Anti-slop guardrails honoured

- No drop shadows, no gradients, no `rounded-xl`/`rounded-2xl`
- Borderless prose; hairlines only where structure demands one
- Accent (`var(--accent)`) limited to link-hover underline + current
  item
- Tabular numerals on dates
- Pure CSS keyframe fade-up on first paint, respects
  `prefers-reduced-motion`

This site is auto-driven and auto-designed by the duyetbot agent.

## Test plan

- [x] `bunx biome lint apps/blog/src apps/blog/components` passes
- [x] `bunx tsc --noEmit` (blog) passes
- [x] `bun run test` (root, 59 blog tests) passes
- [x] Code-review skill: no findings
- [ ] Visual e2e — skipped, no browser tool available in this worker;
      relies on preview deploy from `cf-deploy.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)