### PR TITLE
style(agents): editorial monochrome shell + micro-interaction polish

### DIFF
--- a/apps/agent-assistant/components/assistant-ui/reasoning.tsx
+++ b/apps/agent-assistant/components/assistant-ui/reasoning.tsx
@@ -22,9 +22,9 @@ const ANIMATION_DURATION = 200;
 const reasoningVariants = cva("aui-reasoning-root mb-4 w-full", {
   variants: {
     variant: {
-      outline: "rounded-lg border px-3 py-2",
+      outline: "border-l-2 border-[color:var(--hairline)] pl-3",
       ghost: "",
-      muted: "rounded-lg bg-muted/50 px-3 py-2",
+      muted: "border-l-2 border-[color:var(--hairline)] pl-3",
     },
   },
   defaultVariants: {
@@ -131,7 +131,7 @@ function ReasoningTrigger({
     <CollapsibleTrigger
       data-slot="reasoning-trigger"
       className={cn(
-        "aui-reasoning-trigger group/trigger flex max-w-[75%] items-center gap-2 py-1 text-muted-foreground text-sm transition-colors hover:text-foreground",
+        "aui-reasoning-trigger group/trigger flex max-w-[75%] items-center gap-2 py-1 text-[color:var(--muted-foreground)] text-sm transition-colors hover:text-[color:var(--foreground)]",
         className
       )}
       {...props}
@@ -177,7 +177,7 @@ function ReasoningContent({
     <CollapsibleContent
       data-slot="reasoning-content"
       className={cn(
-        "aui-reasoning-content relative overflow-hidden text-muted-foreground text-sm outline-none",
+        "aui-reasoning-content relative overflow-hidden text-[color:var(--muted-foreground)] text-sm outline-none",
         "group/collapsible-content ease-out",
         "data-[state=closed]:animate-collapsible-up",
         "data-[state=open]:animate-collapsible-down",

--- a/apps/agent-assistant/components/assistant-ui/thread.tsx
+++ b/apps/agent-assistant/components/assistant-ui/thread.tsx
@@ -102,9 +102,9 @@ const ThreadScrollToBottom: FC = () => {
       <TooltipIconButton
         tooltip="Scroll to bottom"
         variant="outline"
-        className="aui-thread-scroll-to-bottom absolute -top-12 z-10 self-center rounded-full p-4 disabled:invisible dark:border-border dark:bg-background dark:hover:bg-accent"
+        className="aui-thread-scroll-to-bottom absolute -top-12 right-4 z-10 rounded-full p-2 border border-[color:var(--hairline)] bg-[color:var(--background)] text-[color:var(--muted-foreground)] transition-[transform,opacity,color] duration-150 ease-out hover:text-[color:var(--foreground)] disabled:invisible disabled:scale-90 disabled:opacity-0"
       >
-        <ArrowDownIcon />
+        <ArrowDownIcon className="size-4" />
       </TooltipIconButton>
     </ThreadPrimitive.ScrollToBottom>
   );
@@ -115,20 +115,18 @@ const ThreadWelcome: FC = () => {
     <div className="aui-thread-welcome-root my-auto flex grow flex-col justify-center items-center py-6">
       <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-center text-center">
         <div className="aui-thread-welcome-message flex size-full flex-col justify-center px-4 items-center">
-          <div className="mb-4 flex size-12 items-center justify-center rounded-2xl bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 shadow-sm animate-pulse">
-            <svg className="size-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 21l8.982-11.795H14l1-6.105-8.982 11.795H9.813z" />
-            </svg>
-          </div>
-          <h1 className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in fill-mode-both font-semibold text-2xl duration-200">
-            Hello, I am duyetbot!
+          <h1
+            className="aui-thread-welcome-message-inner fade-slide-up font-serif text-5xl md:text-6xl tracking-tight text-[color:var(--foreground)]"
+            style={{ fontFamily: "var(--font-serif)" }}
+          >
+            Hello.
           </h1>
-          <p className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-muted-foreground text-sm max-w-sm mt-2 delay-75 duration-200">
-            Your personal, stateful engineering assistant. How can I help you today?
+          <p className="aui-thread-welcome-message-inner fade-slide-up mt-4 max-w-md text-base text-[color:var(--muted-foreground)]">
+            A stateful, personal engineering assistant. Ask anything.
           </p>
         </div>
       </div>
-      <div className="w-full max-w-lg mt-6">
+      <div className="w-full max-w-xl mt-10">
         <ThreadSuggestions />
       </div>
     </div>
@@ -137,7 +135,7 @@ const ThreadWelcome: FC = () => {
 
 const ThreadSuggestions: FC = () => {
   return (
-    <div className="aui-thread-welcome-suggestions grid w-full @md:grid-cols-2 gap-2 pb-4">
+    <div className="aui-thread-welcome-suggestions flex w-full flex-col items-center gap-3 pb-4 @md:flex-row @md:flex-wrap @md:justify-center">
       <ThreadPrimitive.Suggestions>
         {() => <ThreadSuggestionItem />}
       </ThreadPrimitive.Suggestions>
@@ -147,15 +145,15 @@ const ThreadSuggestions: FC = () => {
 
 const ThreadSuggestionItem: FC = () => {
   return (
-    <div className="aui-thread-welcome-suggestion-display fade-in slide-in-from-bottom-2 @md:nth-[n+3]:block nth-[n+3]:hidden animate-in fill-mode-both duration-200">
+    <div className="aui-thread-welcome-suggestion-display fade-slide-up nth-[n+3]:hidden @md:nth-[n+3]:block @md:nth-[n+5]:hidden">
       <SuggestionPrimitive.Trigger send asChild>
-        <Button
-          variant="ghost"
-          className="aui-thread-welcome-suggestion h-auto w-full @md:flex-col flex-wrap items-start justify-start gap-1 rounded-3xl border bg-background px-4 py-3 text-start text-sm transition-colors hover:bg-muted"
+        <button
+          type="button"
+          className="aui-thread-welcome-suggestion inline-flex items-baseline gap-1.5 bg-transparent px-1 py-1 text-sm text-[color:var(--muted-foreground)] underline-offset-4 transition-colors hover:text-[color:var(--foreground)] hover:underline hover:decoration-[color:var(--accent)] focus-visible:underline focus-visible:decoration-[color:var(--accent)] outline-none"
         >
-          <SuggestionPrimitive.Title className="aui-thread-welcome-suggestion-text-1 font-medium" />
-          <SuggestionPrimitive.Description className="aui-thread-welcome-suggestion-text-2 text-muted-foreground empty:hidden" />
-        </Button>
+          <SuggestionPrimitive.Title className="aui-thread-welcome-suggestion-text-1" />
+          <SuggestionPrimitive.Description className="aui-thread-welcome-suggestion-text-2 text-[color:var(--muted-foreground)] empty:hidden" />
+        </button>
       </SuggestionPrimitive.Trigger>
     </div>
   );
@@ -163,16 +161,16 @@ const ThreadSuggestionItem: FC = () => {
 
 const Composer: FC = () => {
   return (
-    <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col">
+    <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col border-t border-[color:var(--hairline)] pt-3">
       <ComposerPrimitive.AttachmentDropzone asChild>
         <div
           data-slot="aui_composer-shell"
-          className="flex w-full flex-col gap-2 rounded-(--composer-radius) border bg-background p-(--composer-padding) transition-shadow focus-within:border-ring/75 focus-within:ring-2 focus-within:ring-ring/20 data-[dragging=true]:border-ring data-[dragging=true]:border-dashed data-[dragging=true]:bg-accent/50"
+          className="flex w-full flex-col gap-2 bg-transparent px-1 py-1 data-[dragging=true]:bg-[color:var(--faint)]"
         >
           <ComposerAttachments />
           <ComposerPrimitive.Input
-            placeholder="Send a message..."
-            className="aui-composer-input max-h-32 min-h-10 w-full resize-none bg-transparent px-1.75 py-1 text-sm outline-none placeholder:text-muted-foreground/80"
+            placeholder="Message duyetbot…"
+            className="aui-composer-input min-h-10 w-full resize-none bg-transparent px-1.5 py-1.5 text-base text-[color:var(--foreground)] outline-none placeholder:text-[color:var(--muted-foreground)] placeholder:transition-opacity focus:placeholder:opacity-60"
             rows={1}
             autoFocus
             aria-label="Message input"
@@ -195,8 +193,8 @@ const ComposerAction: FC = () => {
             side="bottom"
             type="button"
             variant="default"
-            size="icon"
-            className="aui-composer-send size-8 rounded-full"
+            size="icon-sm"
+            className="aui-composer-send size-8 rounded-md transition-transform duration-150 ease-out enabled:hover:scale-100 disabled:scale-[0.98]"
             aria-label="Send message"
           >
             <ArrowUpIcon className="aui-composer-send-icon size-4" />
@@ -208,8 +206,8 @@ const ComposerAction: FC = () => {
           <Button
             type="button"
             variant="default"
-            size="icon"
-            className="aui-composer-cancel size-8 rounded-full"
+            size="icon-sm"
+            className="aui-composer-cancel size-8 rounded-md"
             aria-label="Stop generating"
           >
             <SquareIcon className="aui-composer-cancel-icon size-3 fill-current" />
@@ -313,12 +311,15 @@ const AssistantActionBar: FC = () => {
     <ActionBarPrimitive.Root
       hideWhenRunning
       autohide="not-last"
-      className="aui-assistant-action-bar-root col-start-3 row-start-2 -ms-1 flex gap-1 text-muted-foreground"
+      className="aui-assistant-action-bar-root col-start-3 row-start-2 -ms-1 flex gap-0.5 text-[color:var(--muted-foreground)]"
     >
       <ActionBarPrimitive.Copy asChild>
-        <TooltipIconButton tooltip="Copy">
+        <TooltipIconButton
+          tooltip="Copy"
+          className="rounded-md transition-colors hover:bg-[color:var(--faint)] hover:text-[color:var(--foreground)]"
+        >
           <AuiIf condition={(s) => s.message.isCopied}>
-            <CheckIcon />
+            <CheckIcon className="text-[color:var(--accent)] transition-transform duration-[600ms] ease-out" />
           </AuiIf>
           <AuiIf condition={(s) => !s.message.isCopied}>
             <CopyIcon />
@@ -326,7 +327,10 @@ const AssistantActionBar: FC = () => {
         </TooltipIconButton>
       </ActionBarPrimitive.Copy>
       <ActionBarPrimitive.Reload asChild>
-        <TooltipIconButton tooltip="Refresh">
+        <TooltipIconButton
+          tooltip="Refresh"
+          className="rounded-md transition-colors hover:bg-[color:var(--faint)] hover:text-[color:var(--foreground)]"
+        >
           <RefreshCwIcon />
         </TooltipIconButton>
       </ActionBarPrimitive.Reload>
@@ -334,7 +338,7 @@ const AssistantActionBar: FC = () => {
         <ActionBarMorePrimitive.Trigger asChild>
           <TooltipIconButton
             tooltip="More"
-            className="data-[state=open]:bg-accent"
+            className="rounded-md transition-colors hover:bg-[color:var(--faint)] hover:text-[color:var(--foreground)] data-[state=open]:bg-[color:var(--faint)]"
           >
             <MoreHorizontalIcon />
           </TooltipIconButton>
@@ -342,10 +346,10 @@ const AssistantActionBar: FC = () => {
         <ActionBarMorePrimitive.Content
           side="bottom"
           align="start"
-          className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+          className="aui-action-bar-more-content z-50 min-w-32 overflow-hidden rounded-md border border-[color:var(--hairline)] bg-[color:var(--popover)] p-1 text-[color:var(--popover-foreground)]"
         >
           <ActionBarPrimitive.ExportMarkdown asChild>
-            <ActionBarMorePrimitive.Item className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground">
+            <ActionBarMorePrimitive.Item className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-[color:var(--faint)] focus:bg-[color:var(--faint)]">
               <DownloadIcon className="size-4" />
               Export as Markdown
             </ActionBarMorePrimitive.Item>
@@ -360,13 +364,13 @@ const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
       data-slot="aui_user-message-root"
-      className="fade-in slide-in-from-bottom-1 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
+      className="fade-in slide-in-from-right-2 grid animate-in auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] content-start gap-y-2 px-2 duration-150 [contain-intrinsic-size:auto_60px] [content-visibility:auto] [&:where(>*)]:col-start-2"
       data-role="user"
     >
       <UserMessageAttachments />
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
-        <div className="aui-user-message-content wrap-break-word peer rounded-2xl bg-muted px-4 py-2.5 text-foreground empty:hidden">
+        <div className="aui-user-message-content wrap-break-word peer rounded-md bg-[color:var(--faint)] px-4 py-2.5 text-[color:var(--foreground)] empty:hidden">
           <MessagePrimitive.Parts />
         </div>
         <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
@@ -404,9 +408,9 @@ const EditComposer: FC = () => {
       data-slot="aui_edit-composer-wrapper"
       className="flex flex-col px-2"
     >
-      <ComposerPrimitive.Root className="aui-edit-composer-root ms-auto flex w-full max-w-[85%] flex-col rounded-2xl bg-muted">
+      <ComposerPrimitive.Root className="aui-edit-composer-root ms-auto flex w-full max-w-[85%] flex-col rounded-md bg-[color:var(--faint)]">
         <ComposerPrimitive.Input
-          className="aui-edit-composer-input min-h-14 w-full resize-none bg-transparent p-4 text-foreground text-sm outline-none"
+          className="aui-edit-composer-input min-h-14 w-full resize-none bg-transparent p-4 text-[color:var(--foreground)] text-sm outline-none"
           autoFocus
         />
         <div className="aui-edit-composer-footer mx-3 mb-3 flex items-center gap-2 self-end">

--- a/apps/agent-assistant/components/assistant-ui/tool-group.tsx
+++ b/apps/agent-assistant/components/assistant-ui/tool-group.tsx
@@ -23,9 +23,9 @@ const ANIMATION_DURATION = 200;
 const toolGroupVariants = cva("aui-tool-group-root group/tool-group w-full", {
   variants: {
     variant: {
-      outline: "rounded-lg border py-3",
+      outline: "border-l-2 border-[color:var(--hairline)] pl-3 py-1",
       ghost: "",
-      muted: "rounded-lg border border-muted-foreground/30 bg-muted/30 py-3",
+      muted: "border-l-2 border-[color:var(--hairline)] pl-3 py-1",
     },
   },
   defaultVariants: { variant: "outline" },
@@ -109,9 +109,9 @@ function ToolGroupTrigger({
     <CollapsibleTrigger
       data-slot="tool-group-trigger"
       className={cn(
-        "aui-tool-group-trigger group/trigger flex items-center gap-2 text-sm transition-colors",
-        "group-data-[variant=outline]/tool-group-root:w-full group-data-[variant=outline]/tool-group-root:px-4",
-        "group-data-[variant=muted]/tool-group-root:w-full group-data-[variant=muted]/tool-group-root:px-4",
+        "aui-tool-group-trigger group/trigger flex items-center gap-2 text-sm text-[color:var(--muted-foreground)] transition-colors hover:text-[color:var(--foreground)]",
+        "group-data-[variant=outline]/tool-group-root:w-full",
+        "group-data-[variant=muted]/tool-group-root:w-full",
         className
       )}
       {...props}
@@ -178,8 +178,8 @@ function ToolGroupContent({
       <div
         className={cn(
           "mt-2 flex flex-col gap-2",
-          "group-data-[variant=outline]/tool-group-root:mt-3 group-data-[variant=outline]/tool-group-root:border-t group-data-[variant=outline]/tool-group-root:px-4 group-data-[variant=outline]/tool-group-root:pt-3",
-          "group-data-[variant=muted]/tool-group-root:mt-3 group-data-[variant=muted]/tool-group-root:border-t group-data-[variant=muted]/tool-group-root:px-4 group-data-[variant=muted]/tool-group-root:pt-3"
+          "group-data-[variant=outline]/tool-group-root:mt-2 group-data-[variant=outline]/tool-group-root:pt-2",
+          "group-data-[variant=muted]/tool-group-root:mt-2 group-data-[variant=muted]/tool-group-root:pt-2"
         )}
       >
         {children}

--- a/apps/agent-assistant/components/ui/button.tsx
+++ b/apps/agent-assistant/components/ui/button.tsx
@@ -5,20 +5,22 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[background-color,color,border-color,transform,opacity] duration-150 ease-out outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--ring)] disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-1 aria-invalid:ring-[color:var(--destructive)] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-[color:var(--primary)] text-[color:var(--primary-foreground)] hover:bg-[color:color-mix(in_oklch,var(--primary)_92%,transparent)]",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-[color:var(--destructive)] text-white hover:opacity-90",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border border-[color:var(--hairline)] bg-transparent text-[color:var(--foreground)] hover:bg-[color:var(--faint)]",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-[color:var(--secondary)] text-[color:var(--secondary-foreground)] hover:bg-[color:color-mix(in_oklch,var(--secondary)_70%,transparent)]",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-transparent hover:bg-[color:var(--faint)] hover:text-[color:var(--foreground)]",
+        link:
+          "text-[color:var(--foreground)] underline-offset-4 decoration-[color:var(--accent)] hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/apps/agent-assistant/src/routes/__root.tsx
+++ b/apps/agent-assistant/src/routes/__root.tsx
@@ -2,7 +2,6 @@ import "@duyet/components/styles.css";
 import "../styles.css";
 
 import Analytics from "@duyet/components/Analytics";
-import Footer from "@duyet/components/Footer";
 import ThemeProvider from "@duyet/components/ThemeProvider";
 import {
   createRootRoute,
@@ -13,11 +12,21 @@ import {
 
 function NotFoundComponent() {
   return (
-    <div className="flex min-h-[50vh] items-center justify-center">
+    <div className="flex min-h-[60vh] items-center justify-center px-6">
       <div className="text-center">
-        <h1 className="text-4xl font-bold">404</h1>
-        <p className="mt-2 text-muted-foreground">Page not found</p>
-        <a href="/" className="mt-4 inline-block text-sm underline">
+        <h1
+          className="font-serif text-6xl tracking-tight"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          404
+        </h1>
+        <p className="mt-3 text-sm text-[color:var(--muted-foreground)]">
+          Page not found
+        </p>
+        <a
+          href="/"
+          className="mt-6 inline-block text-sm text-[color:var(--foreground)] underline underline-offset-4 decoration-[color:var(--accent)] hover:decoration-2"
+        >
           Go home
         </a>
       </div>
@@ -35,7 +44,7 @@ export const Route = createRootRoute({
       {
         name: "description",
         content:
-          "Personal AI assistant for Duyet. Built with TanStack Start, LangGraph JS, and Cloudflare Durable Objects.",
+          "Personal AI assistant for Duyet. Auto-driven and auto-designed by the duyetbot agent.",
       },
     ],
     links: [
@@ -49,13 +58,69 @@ export const Route = createRootRoute({
       {
         rel: "preload",
         as: "style",
-        href: "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Libre+Baskerville:wght@400;700&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap",
       },
     ],
   }),
   notFoundComponent: NotFoundComponent,
   component: RootComponent,
 });
+
+function TopBar() {
+  return (
+    <header className="sticky top-0 z-30 h-14 w-full backdrop-blur-sm bg-[color:var(--background)]/80 border-b border-transparent transition-colors duration-150">
+      <div className="mx-auto flex h-full max-w-6xl items-center justify-between px-4 md:px-6">
+        <a
+          href="/"
+          className="group inline-flex items-baseline gap-2 text-[color:var(--foreground)]"
+        >
+          <span
+            className="font-serif text-xl tracking-tight"
+            style={{ fontFamily: "var(--font-serif)" }}
+          >
+            duyetbot
+          </span>
+          <span className="text-xs text-[color:var(--muted-foreground)]">
+            assistant
+          </span>
+        </a>
+        <nav className="flex items-center gap-5 text-sm">
+          <a
+            href="/"
+            className="relative text-[color:var(--foreground)] transition-colors hover:text-[color:var(--foreground)] after:absolute after:left-0 after:-bottom-1 after:h-px after:w-full after:scale-x-100 after:bg-[color:var(--accent)]"
+          >
+            Chat
+          </a>
+          <a
+            href="https://duyet.net"
+            className="text-[color:var(--muted-foreground)] transition-colors hover:text-[color:var(--foreground)]"
+          >
+            duyet.net
+          </a>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function CreditFooter() {
+  return (
+    <footer className="mx-auto w-full max-w-6xl px-4 md:px-6 py-6 text-center">
+      <p className="text-xs italic text-[color:var(--muted-foreground)]">
+        This site is auto-driven and auto-designed by the{" "}
+        <a
+          href="https://github.com/duyetbot"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="underline underline-offset-4 decoration-[color:var(--hairline)] transition-colors hover:text-[color:var(--foreground)] hover:decoration-[color:var(--accent)]"
+        >
+          duyetbot
+        </a>{" "}
+        agent.
+      </p>
+    </footer>
+  );
+}
 
 function RootComponent() {
   return (
@@ -64,19 +129,20 @@ function RootComponent() {
         <HeadContent />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Libre+Baskerville:wght@400;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap"
           media="print"
           // @ts-expect-error onLoad is valid on link elements
           onLoad="this.media='all'"
         />
       </head>
-      <body>
+      <body className="bg-[color:var(--background)] text-[color:var(--foreground)]">
         <ThemeProvider>
-          <div className="flex flex-col min-h-screen bg-white text-[#1a1a1a] dark:bg-[#0d0e0c] dark:text-[#f8f8f2]">
-            <main className="flex-1 flex flex-col relative z-10 bg-white dark:bg-[#0d0e0c]">
+          <div className="flex min-h-screen flex-col">
+            <TopBar />
+            <main className="flex-1 flex flex-col relative">
               <Outlet />
             </main>
-            <Footer className="bg-white dark:bg-[#1a1a1a] border-t border-zinc-100 dark:border-zinc-800" />
+            <CreditFooter />
           </div>
         </ThemeProvider>
         <Analytics />

--- a/apps/agent-assistant/src/routes/index.tsx
+++ b/apps/agent-assistant/src/routes/index.tsx
@@ -8,13 +8,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useMemo, useState, useEffect } from "react";
 import { Thread } from "@/components/assistant-ui/thread";
 import { createClient } from "@/lib/chatApi";
-import {
-  PanelLeftClose,
-  PanelLeftOpen,
-  Plus,
-  Trash2,
-  MessageSquare,
-} from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, Plus, Trash2 } from "lucide-react";
 
 export const Route = createFileRoute("/")({
   component: AssistantPage,
@@ -28,41 +22,46 @@ interface SavedThread {
   updatedAt: string;
 }
 
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffMs = Date.now() - then;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diffMs < minute) return "just now";
+  if (diffMs < hour) return `${Math.floor(diffMs / minute)}m ago`;
+  if (diffMs < day) return `${Math.floor(diffMs / hour)}h ago`;
+  if (diffMs < 7 * day) return `${Math.floor(diffMs / day)}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
 function AssistantPage() {
   const client = useMemo(() => createClient(), []);
 
-  // State for active thread ID
   const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
-
-  // State for thread history list
   const [threads, setThreads] = useState<SavedThread[]>([]);
-
-  // Sidebar visibility
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
-  // Initialize state from local storage on mount
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const storedThreads = localStorage.getItem("duyetbot_threads");
-      if (storedThreads) {
-        try {
-          const parsed = JSON.parse(storedThreads);
-          setThreads(parsed);
-        } catch (e) {
-          console.error("Failed to parse threads", e);
-        }
-      }
+    if (typeof window === "undefined") return;
 
-      const storedActive = localStorage.getItem("duyetbot_active_thread_id");
-      if (storedActive) {
-        setActiveThreadId(storedActive);
-      }
-
-      // Auto-hide sidebar on small screens
-      if (window.innerWidth < 768) {
-        setSidebarOpen(false);
+    const storedThreads = localStorage.getItem("duyetbot_threads");
+    if (storedThreads) {
+      try {
+        setThreads(JSON.parse(storedThreads));
+      } catch (e) {
+        console.error("Failed to parse threads", e);
       }
     }
+
+    const storedActive = localStorage.getItem("duyetbot_active_thread_id");
+    if (storedActive) setActiveThreadId(storedActive);
+
+    if (window.innerWidth < 768) setSidebarOpen(false);
   }, []);
 
   const stream = useMemo(
@@ -83,11 +82,10 @@ function AssistantPage() {
       const now = new Date();
       const newThread: SavedThread = {
         id: thread_id,
-        title: `Chat ${now.toLocaleDateString()} ${now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`,
+        title: `New conversation`,
         updatedAt: now.toISOString(),
       };
 
-      // Add to list and set active
       setTimeout(() => {
         setThreads((prev) => {
           const updated = [newThread, ...prev];
@@ -105,14 +103,14 @@ function AssistantPage() {
         messages: LangChainMessage[];
       }>(externalId);
 
-      // Update thread title if first message exists
       if (state.values.messages && state.values.messages.length > 0) {
         const firstMessage = state.values.messages[0];
-        let title = "Chat Thread";
+        let title = "Conversation";
         if (firstMessage && typeof firstMessage === "object") {
-          const content = (firstMessage as any).content || "";
+          const content =
+            (firstMessage as { content?: unknown }).content ?? "";
           if (content && typeof content === "string") {
-            title = content.slice(0, 30) + (content.length > 30 ? "..." : "");
+            title = content.slice(0, 40) + (content.length > 40 ? "…" : "");
           }
         }
 
@@ -140,23 +138,21 @@ function AssistantPage() {
   const handleSelectThread = (id: string) => {
     setActiveThreadId(id);
     localStorage.setItem("duyetbot_active_thread_id", id);
-    if (window.innerWidth < 768) {
-      setSidebarOpen(false); // Auto-hide sidebar on mobile after choosing
+    if (typeof window !== "undefined" && window.innerWidth < 768) {
+      setSidebarOpen(false);
     }
   };
 
   const handleNewChat = () => {
     setActiveThreadId(null);
     localStorage.removeItem("duyetbot_active_thread_id");
-    if (window.innerWidth < 768) {
-      setSidebarOpen(false); // Close sidebar on mobile
+    if (typeof window !== "undefined" && window.innerWidth < 768) {
+      setSidebarOpen(false);
     }
   };
 
   const handleDeleteThread = (id: string, e: React.MouseEvent) => {
     e.stopPropagation();
-
-    // Delete thread
     const updated = threads.filter((t) => t.id !== id);
     setThreads(updated);
     localStorage.setItem("duyetbot_threads", JSON.stringify(updated));
@@ -166,107 +162,129 @@ function AssistantPage() {
       localStorage.removeItem("duyetbot_active_thread_id");
     }
 
-    // Try deleting from backend (fire-and-forget or swallow error)
     client.threads.delete(id).catch((err) => {
       console.warn("Could not delete thread on backend", err);
     });
   };
 
   return (
-    <div className="flex flex-1 flex-row relative h-[calc(100vh-140px)] min-h-[600px] max-w-full overflow-hidden border rounded-2xl bg-card text-card-foreground shadow-sm dark:border-zinc-800">
-      {/* Sidebar */}
-      <div
-        className={`absolute md:relative z-20 h-full flex flex-col bg-zinc-50 border-r dark:bg-zinc-950 dark:border-zinc-800 transition-all duration-300 ${
-          sidebarOpen ? "w-64 translate-x-0" : "w-0 -translate-x-full md:w-0"
+    <div className="flex flex-1 flex-row relative h-[calc(100vh-3.5rem-4rem)] min-h-[560px] max-w-6xl mx-auto w-full overflow-hidden">
+      {/* Sidebar: borderless editorial column */}
+      <aside
+        className={`absolute md:relative z-20 h-full flex flex-col bg-[color:var(--background)] transition-[width,transform] duration-200 ease-out ${
+          sidebarOpen
+            ? "w-64 translate-x-0 border-r border-[color:var(--hairline)]"
+            : "w-0 -translate-x-full md:w-0 border-r-0"
         } overflow-hidden`}
       >
-        <div className="flex items-center justify-between p-3 border-b dark:border-zinc-800 shrink-0">
+        <div className="flex items-center justify-between px-4 py-3 shrink-0">
           <button
+            type="button"
             onClick={handleNewChat}
-            className="flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-lg border bg-background hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors w-full justify-start text-foreground cursor-pointer"
+            className="group inline-flex items-center gap-2 text-sm text-[color:var(--foreground)] transition-transform duration-150 ease-out hover:-translate-y-px"
           >
-            <Plus className="size-4" />
-            <span>New Chat</span>
+            <Plus className="size-4 text-[color:var(--muted-foreground)] transition-colors group-hover:text-[color:var(--accent)]" />
+            <span className="underline-offset-4 group-hover:underline group-hover:decoration-[color:var(--accent)]">
+              New conversation
+            </span>
           </button>
 
           <button
+            type="button"
             onClick={() => setSidebarOpen(false)}
-            className="md:hidden ml-2 p-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-lg text-muted-foreground cursor-pointer"
+            className="md:hidden ml-2 p-1.5 text-[color:var(--muted-foreground)] transition-colors hover:text-[color:var(--foreground)]"
             title="Collapse sidebar"
+            aria-label="Collapse sidebar"
           >
             <PanelLeftClose className="size-4" />
           </button>
         </div>
 
-        {/* Thread History list */}
-        <div className="flex-1 overflow-y-auto p-2 space-y-1 scrollbar-thin">
+        <div className="flex-1 overflow-y-auto px-2 pb-4 scrollbar-thin">
           {threads.length === 0 ? (
-            <div className="text-xs text-muted-foreground text-center py-8">
-              No chat history yet
-            </div>
+            <p className="px-3 py-6 text-xs italic text-[color:var(--muted-foreground)]">
+              No conversations yet.
+            </p>
           ) : (
-            threads.map((t) => {
-              const isActive = activeThreadId === t.id;
-              return (
-                <div
-                  key={t.id}
-                  onClick={() => handleSelectThread(t.id)}
-                  className={`group flex items-center justify-between px-3 py-2.5 rounded-lg text-sm cursor-pointer transition-colors relative ${
-                    isActive
-                      ? "bg-zinc-200/60 dark:bg-zinc-800 text-foreground font-medium"
-                      : "hover:bg-zinc-100 dark:hover:bg-zinc-900/50 text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  <div className="flex items-center gap-2 min-w-0 pr-6">
-                    <MessageSquare className="size-4 shrink-0 text-muted-foreground/75" />
-                    <span className="truncate text-xs">{t.title}</span>
-                  </div>
-
-                  <button
-                    onClick={(e) => handleDeleteThread(t.id, e)}
-                    className="absolute right-2 opacity-0 group-hover:opacity-100 hover:text-destructive transition-opacity p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-800 cursor-pointer"
-                    title="Delete chat"
+            <ul className="flex flex-col">
+              {threads.map((t) => {
+                const isActive = activeThreadId === t.id;
+                return (
+                  <li
+                    key={t.id}
+                    className="group/row relative transition-transform duration-150 ease-out hover:-translate-y-px"
                   >
-                    <Trash2 className="size-3.5" />
-                  </button>
-                </div>
-              );
-            })
+                    <button
+                      type="button"
+                      onClick={() => handleSelectThread(t.id)}
+                      className={`relative block w-full text-left pl-4 pr-9 py-2.5 text-sm transition-colors duration-150 ease-out ${
+                        isActive
+                          ? "text-[color:var(--foreground)]"
+                          : "text-[color:var(--muted-foreground)] hover:text-[color:var(--foreground)]"
+                      }`}
+                    >
+                      {isActive ? (
+                        <span
+                          aria-hidden
+                          className="absolute left-0 top-1.5 bottom-1.5 w-[2px] bg-[color:var(--accent)]"
+                        />
+                      ) : null}
+                      <span
+                        className={`block truncate ${
+                          isActive ? "font-medium" : "font-normal"
+                        }`}
+                      >
+                        {t.title}
+                      </span>
+                      <time
+                        dateTime={t.updatedAt}
+                        className="mt-0.5 block text-[11px] tabular-nums text-[color:var(--muted-foreground)] opacity-0 transition-opacity duration-150 group-hover/row:opacity-100"
+                      >
+                        {formatRelative(t.updatedAt)}
+                      </time>
+                    </button>
+
+                    <button
+                      type="button"
+                      onClick={(e) => handleDeleteThread(t.id, e)}
+                      className="absolute right-2 top-2.5 -translate-x-2 opacity-0 p-1 text-[color:var(--muted-foreground)] transition-[transform,opacity,color] duration-150 ease-out hover:text-[color:var(--accent)] group-hover/row:translate-x-0 group-hover/row:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100"
+                      title="Delete conversation"
+                      aria-label={`Delete ${t.title}`}
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
           )}
         </div>
-      </div>
+      </aside>
 
-      {/* Main Chat Canvas */}
-      <div className="flex-1 flex flex-col h-full bg-background relative overflow-hidden">
-        {/* Top Navbar overlay */}
-        <div className="absolute top-3 left-3 z-10 flex items-center gap-2">
-          {!sidebarOpen && (
-            <button
-              onClick={() => setSidebarOpen(true)}
-              className="p-2.5 rounded-lg border bg-background hover:bg-zinc-50 dark:hover:bg-zinc-900 transition-colors text-foreground shadow-sm cursor-pointer"
-              title="Expand sidebar"
-            >
-              <PanelLeftOpen className="size-4" />
-            </button>
-          )}
-        </div>
-
-        {/* Floating panel toggle button inside sidebar open mode (on Desktop) */}
-        {sidebarOpen && (
-          <div className="absolute top-3 left-3 z-10 hidden md:block">
-            <button
-              onClick={() => setSidebarOpen(false)}
-              className="p-2.5 rounded-lg border bg-background hover:bg-zinc-50 dark:hover:bg-zinc-900 transition-colors text-foreground shadow-sm cursor-pointer"
-              title="Collapse sidebar"
-            >
+      {/* Main canvas */}
+      <div className="flex-1 flex flex-col h-full relative overflow-hidden">
+        {/* Top-left sidebar toggle (no border, ghost) */}
+        <div className="absolute top-3 left-3 z-10">
+          <button
+            type="button"
+            onClick={() => setSidebarOpen((v) => !v)}
+            className="p-1.5 text-[color:var(--muted-foreground)] transition-colors hover:text-[color:var(--foreground)]"
+            title={sidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+            aria-label={sidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+          >
+            {sidebarOpen ? (
               <PanelLeftClose className="size-4" />
-            </button>
-          </div>
-        )}
+            ) : (
+              <PanelLeftOpen className="size-4" />
+            )}
+          </button>
+        </div>
 
-        {/* Chat Widget Wrapper */}
         <div className="flex-1 h-full flex flex-col overflow-hidden">
-          <AssistantRuntimeProvider key={activeThreadId || "new"} runtime={runtime}>
+          <AssistantRuntimeProvider
+            key={activeThreadId || "new"}
+            runtime={runtime}
+          >
             <Thread />
           </AssistantRuntimeProvider>
         </div>

--- a/apps/agent-assistant/src/styles.css
+++ b/apps/agent-assistant/src/styles.css
@@ -5,127 +5,237 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --font-sans: "Inter Variable", Inter, ui-sans-serif, system-ui, sans-serif;
+  --font-serif: "EB Garamond", Garamond, "Apple Garamond", ui-serif, serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+  --radius-xl: 8px;
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.141 0.005 285.823);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.141 0.005 285.823);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.001 286.375);
-  --muted-foreground: oklch(0.552 0.016 285.938);
-  --accent: oklch(0.967 0.001 286.375);
-  --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0.004 286.32);
-  --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.967 0.001 286.375);
-  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-  --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
+  --radius: 4px;
+
+  --background: #ffffff;
+  --foreground: #0a0a0a;
+
+  --muted: color-mix(in oklch, #0a0a0a 60%, transparent);
+  --muted-foreground: color-mix(in oklch, #0a0a0a 60%, transparent);
+  --subtle: color-mix(in oklch, #0a0a0a 35%, transparent);
+  --faint: color-mix(in oklch, #0a0a0a 8%, transparent);
+  --hairline: color-mix(in oklch, #0a0a0a 8%, transparent);
+
+  --border: color-mix(in oklch, #0a0a0a 8%, transparent);
+  --input: color-mix(in oklch, #0a0a0a 8%, transparent);
+
+  --accent: #cc785c;
+  --accent-foreground: #ffffff;
+  --ring: #cc785c;
+
+  --primary: #0a0a0a;
+  --primary-foreground: #ffffff;
+
+  --secondary: color-mix(in oklch, #0a0a0a 4%, transparent);
+  --secondary-foreground: #0a0a0a;
+
+  --card: #ffffff;
+  --card-foreground: #0a0a0a;
+  --popover: #ffffff;
+  --popover-foreground: #0a0a0a;
+
+  --destructive: #b3261e;
+
+  --sidebar: #ffffff;
+  --sidebar-foreground: #0a0a0a;
+  --sidebar-primary: #0a0a0a;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: color-mix(in oklch, #0a0a0a 4%, transparent);
+  --sidebar-accent-foreground: #0a0a0a;
+  --sidebar-border: color-mix(in oklch, #0a0a0a 8%, transparent);
+  --sidebar-ring: #cc785c;
 }
 
+:root.dark,
 .dark {
-  --background: oklch(0.141 0.005 285.823);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.21 0.006 285.885);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.21 0.006 285.885);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.274 0.006 286.033);
-  --muted-foreground: oklch(0.705 0.015 286.067);
-  --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.21 0.006 285.885);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.552 0.016 285.938);
+  --background: #0a0a0a;
+  --foreground: #fafafa;
+
+  --muted: color-mix(in oklch, #fafafa 55%, transparent);
+  --muted-foreground: color-mix(in oklch, #fafafa 55%, transparent);
+  --subtle: color-mix(in oklch, #fafafa 30%, transparent);
+  --faint: color-mix(in oklch, #fafafa 8%, transparent);
+  --hairline: color-mix(in oklch, #fafafa 8%, transparent);
+
+  --border: color-mix(in oklch, #fafafa 8%, transparent);
+  --input: color-mix(in oklch, #fafafa 8%, transparent);
+
+  --accent: #e8926e;
+  --accent-foreground: #0a0a0a;
+  --ring: #e8926e;
+
+  --primary: #fafafa;
+  --primary-foreground: #0a0a0a;
+
+  --secondary: color-mix(in oklch, #fafafa 6%, transparent);
+  --secondary-foreground: #fafafa;
+
+  --card: #0a0a0a;
+  --card-foreground: #fafafa;
+  --popover: #0a0a0a;
+  --popover-foreground: #fafafa;
+
+  --destructive: #e8584f;
+
+  --sidebar: #0a0a0a;
+  --sidebar-foreground: #fafafa;
+  --sidebar-primary: #fafafa;
+  --sidebar-primary-foreground: #0a0a0a;
+  --sidebar-accent: color-mix(in oklch, #fafafa 6%, transparent);
+  --sidebar-accent-foreground: #fafafa;
+  --sidebar-border: color-mix(in oklch, #fafafa 8%, transparent);
+  --sidebar-ring: #e8926e;
 }
 
 @layer base {
-  * {
-    border-color: var(--border);
-  }
-
   :root {
     color-scheme: light;
   }
-
   :root.dark {
     color-scheme: dark;
   }
 
+  html,
   body {
     background-color: var(--background);
     color: var(--foreground);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
+  /* Tabular numerals everywhere we render numbers */
+  .tabular-nums,
+  time,
+  [data-tabular] {
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+/* ---------- Editorial micro-interactions ---------- */
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+/* Shimmer overlay used by reasoning/tool-group titles when streaming */
+.shimmer {
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--foreground) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 1.6s ease-in-out infinite;
+}
+
+@keyframes copy-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in oklch, var(--accent) 30%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 6px color-mix(in oklch, var(--accent) 0%, transparent);
+  }
+}
+
+.copy-pulse {
+  animation: copy-pulse 200ms ease-out;
+}
+
+@keyframes fade-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-slide-up {
+  animation: fade-slide-up 180ms ease-out both;
+}
+
+/* Composer focus underline (single 1px accent line, no halo) */
+[data-slot="aui_composer-shell"] {
+  position: relative;
+}
+[data-slot="aui_composer-shell"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 1px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 160ms ease-out;
+}
+[data-slot="aui_composer-shell"]:focus-within::after {
+  transform: scaleX(1);
+}
+
+/* Field-sizing composer where supported */
+.aui-composer-input {
+  field-sizing: content;
+  max-height: 12rem;
+  overflow-y: auto;
+}
+
+/* Reduced motion safety */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
   }
 }


### PR DESCRIPTION
## Summary

Unit 6 of the editorial monochrome consolidation across home / blog / insights / agents. Pivots `apps/agent-assistant` to the stark white/black palette with a single warm accent and adds polished pure-CSS micro-interactions on top.

This site is auto-driven and auto-designed by the **duyetbot** agent.

### Layer A — editorial shell

- **Tokens** (`src/styles.css`): replace OKLCH cream with monochrome editorial tokens (`#ffffff` / `#0a0a0a`), warm accent `#cc785c` (light) / `#e8926e` (dark) used only for focus rings, active-thread left-rule, and copy-confirmed flash. EB Garamond serif + Inter sans + JetBrains Mono.
- **Top bar** (`__root.tsx`): slim h-14 sticky bar, brand left + nav right, `backdrop-blur-sm bg-background/80`. Shared `Footer` swapped for a minimal italic credit linking to https://github.com/duyetbot.
- **Sidebar** (`routes/index.tsx`): no background fill, no rounded boxes — typography-only column. Active thread = 2px accent left-rule (no fill). Hover-lift 1px on rows, delete button slides in from `-translate-x-2 opacity-0` on row hover, timestamp fades in on hover.
- **Welcome** (`thread.tsx`): serif `text-5xl md:text-6xl` "Hello." display + tagline. Suggestions are bare text with underline-on-hover (no boxes, no cards, no gradients).
- **Composer**: borderless, single 1px hairline divider above. No card chrome.

### Layer B — micro-interaction polish

- Composer focus: single 1px accent underline animates in along the bottom (no halo). `field-sizing: content` autogrow with `max-h-48` fallback. Placeholder fades on focus. Send button scales 0.98→1.0.
- Messages: assistant fade-up (existing `animate-in`), user slides in from the right (`slide-in-from-right-2`).
- Reasoning + Tool group: dropped from rounded-bordered card to a ghost left-rule (`border-l-2 border-[color:var(--hairline)]`). Chevron rotation kept at 200ms ease-out. The pre-existing `shimmer` class on the streaming title is now actually defined as a keyframe in styles.css (was referenced but never declared).
- Action bar: ghost-tonal hover via `--faint` faint surface, accent checkmark on copy. Ghost button variant intentionally inherits parent text color so the action bar's muted base color survives.
- Scroll-to-bottom: anchored bottom-right, scale + opacity transition driven by `disabled:` state (`disabled:scale-90 disabled:opacity-0`).
- Tabular numerals on all timestamps via `.tabular-nums` utility + `<time>` selector in base layer.
- `@media (prefers-reduced-motion: reduce)` safety net included.

### Anti-slop guardrails honored

- No drop shadows on chrome, no gradients (except the shimmer mask), no `rounded-2xl/3xl` (max `rounded-md`).
- Accent used very sparingly: focus rings, active-thread left-rule, copy-confirmed checkmark.
- Buttons: text-link → ghost → solid (one primary per surface).
- Pure CSS keyframes only — no Framer Motion.

## Files

- `apps/agent-assistant/src/styles.css` — tokens + keyframes + composer underline + field-sizing
- `apps/agent-assistant/src/routes/__root.tsx` — top bar + credit footer
- `apps/agent-assistant/src/routes/index.tsx` — editorial sidebar
- `apps/agent-assistant/components/assistant-ui/thread.tsx` — welcome / suggestions / composer / action bar / messages
- `apps/agent-assistant/components/assistant-ui/reasoning.tsx` — left-rule ghost variant
- `apps/agent-assistant/components/assistant-ui/tool-group.tsx` — left-rule ghost variant
- `apps/agent-assistant/components/ui/button.tsx` — monochrome variants, single-ring focus

## Test plan

- [x] `bun run check-types` — clean (root + agent-assistant)
- [x] `bunx biome lint apps/agent-assistant/src apps/agent-assistant/components` — clean (2 pre-existing warnings in routeTree.gen.ts + vendor)
- [x] `bun run test` — all 15 packages cached green
- [ ] **Visual e2e was skipped** — pre-existing `wrangler.toml` `main` field points at `dist/server/server.js` which doesn't exist in a fresh worktree, blocking both `vite dev` and `vite build`. Verified the failure reproduces on master baseline (config issue, not code regression). Cloudflare Pages CI build will exercise the full path on merge.
- [ ] Verify light + dark welcome screen after deploy
- [ ] Verify sidebar hover/lift + delete slide-in
- [ ] Verify composer focus underline
- [ ] Verify message exchange animations + reasoning chevron rotation