### PR TITLE
feat(home): apps directory and project domains

### DIFF
--- a/apps/home/src/data/projects.ts
+++ b/apps/home/src/data/projects.ts
@@ -8,6 +8,13 @@ export interface AppItem {
   description: string;
   screenshot?: string;
   tone?: string;
+  /**
+   * Canonical production domain (without scheme). Optional — render in the
+   * project row meta strip and link to `https://{domain}` when present.
+   * Distinct from `host`, which is derived from the navigation `href` and may
+   * point at a repo (e.g. github.com) or an internal route.
+   */
+  domain?: string;
 }
 
 const hostOf = (url: string) => new URL(url).host;
@@ -36,6 +43,7 @@ export const apps: AppItem[] = [
       "One API for every AI model. Route traffic across providers with fallback, observability, and BYOK from a single OpenAI-compatible endpoint built on Cloudflare's edge.",
     screenshot: "/screenshots/anyrouter-art.svg",
     tone: "bg-[#536f91]",
+    domain: "anyrouter.dev",
   },
   {
     name: "ClickHouse Monitoring",
@@ -46,6 +54,7 @@ export const apps: AppItem[] = [
       "ClickHouse monitoring with AI agent support for finding insights, monitoring clusters, and triaging activity",
     screenshot: "/screenshots/ch-monitor.png",
     tone: "bg-[#8b633f]",
+    domain: "chmonitor.dev",
   },
   {
     name: "ShareHTML",
@@ -55,6 +64,7 @@ export const apps: AppItem[] = [
     description:
       "Share HTML, Markdown, and code files. Built for Human and AI Agent. Self-hosted on Cloudflare Workers.",
     tone: "bg-[#5f6257]",
+    domain: "html.duyet.net",
   },
   {
     name: "AI Agents",
@@ -64,6 +74,7 @@ export const apps: AppItem[] = [
     description: "AI chat interface with Cloudflare Workers AI and streaming",
     screenshot: "/screenshots/ai-agents.png",
     tone: "bg-[#536f91]",
+    domain: "agents.duyet.net",
   },
   {
     name: "Agent State",
@@ -73,6 +84,7 @@ export const apps: AppItem[] = [
     description: "AI agent state management and debugging tools",
     screenshot: "/screenshots/agentstate-art.svg",
     tone: "bg-[#536f91]",
+    domain: "agentstate.app",
   },
   {
     name: "MCP Tools",
@@ -82,6 +94,7 @@ export const apps: AppItem[] = [
     description: "Model Context Protocol tools and integrations",
     screenshot: "/screenshots/mcp-tools-art.png",
     tone: "bg-[#5f6257]",
+    domain: "mcp.duyet.net",
   },
   {
     name: "Claude Codex Plugins",
@@ -100,6 +113,7 @@ export const apps: AppItem[] = [
     description: "URL shortener with analytics and custom domains",
     screenshot: "/screenshots/stamp.png",
     tone: "bg-[#7f524e]",
+    domain: "stamp.duyet.net",
   },
   {
     name: "PageView",
@@ -109,6 +123,7 @@ export const apps: AppItem[] = [
     description: "Simple, privacy-friendly analytics for websites",
     screenshot: "/screenshots/pageview-art.svg",
     tone: "bg-[#7a705d]",
+    domain: "pageview.duyet.net",
   },
   {
     name: "LLM Timeline",
@@ -118,6 +133,7 @@ export const apps: AppItem[] = [
     description: "Interactive timeline of LLM models from 2017-2025",
     screenshot: "/screenshots/llm-timeline.png",
     tone: "bg-[#4f6f62]",
+    domain: "llm-timeline.duyet.net",
   },
   {
     name: "Rust Tieng Viet",

--- a/apps/home/src/data/sibling-apps.ts
+++ b/apps/home/src/data/sibling-apps.ts
@@ -1,0 +1,96 @@
+import { duyetUrls } from "@duyet/urls";
+
+/**
+ * A sibling app deployed from this monorepo to a public production domain.
+ *
+ * Source of truth for live URLs:
+ * - Convention is `{appName}.duyet.net` (see `scripts/cf-deploy.ts`),
+ *   except `home` → `duyet.net` and `agent-ui` → `agents.duyet.net`.
+ * - Where `@duyet/urls` already exposes the URL, prefer that value so
+ *   environment overrides flow through.
+ *
+ * Excluded:
+ * - `home` (this app — already on the page)
+ * - Backend-only workers without a UI surface
+ *   (`api`, `agent-api`, `data-sync`)
+ */
+export interface SiblingApp {
+  /** Display name shown in the directory row. */
+  name: string;
+  /** One-line description (sans serif, muted). */
+  description: string;
+  /** Live production domain, no scheme — e.g. `blog.duyet.net`. */
+  domain: string;
+}
+
+export const siblingApps: SiblingApp[] = [
+  {
+    name: "Blog",
+    description:
+      "Long-form notes on data engineering, distributed systems, AI agents, and open source.",
+    domain: hostOf(duyetUrls.apps.blog) ?? "blog.duyet.net",
+  },
+  {
+    name: "Resume",
+    description:
+      "CV and project history covering data platforms, AI products, and team leadership.",
+    domain: hostOf(duyetUrls.apps.cv) ?? "cv.duyet.net",
+  },
+  {
+    name: "Insights",
+    description:
+      "Live dashboards for coding activity, site traffic, and token spend across the network.",
+    domain: hostOf(duyetUrls.apps.insights) ?? "insights.duyet.net",
+  },
+  {
+    name: "Photos",
+    description:
+      "Photo journal with build-time EXIF metadata extraction and Unsplash mirroring.",
+    domain: hostOf(duyetUrls.apps.photos) ?? "photos.duyet.net",
+  },
+  {
+    name: "Homelab",
+    description:
+      "Monitoring dashboard for a three-node mini-PC cluster running self-hosted workloads.",
+    domain: hostOf(duyetUrls.apps.homelab) ?? "homelab.duyet.net",
+  },
+  {
+    name: "LLM Timeline",
+    description:
+      "Interactive timeline of large language model releases from 2017 onward.",
+    domain: "llm-timeline.duyet.net",
+  },
+  {
+    name: "AI Percentage",
+    description:
+      "Tracks how much code in each repository is co-authored by AI assistants.",
+    domain: "ai-percentage.duyet.net",
+  },
+  {
+    name: "Agent Assistant",
+    description:
+      "Claude-backed chat assistant with streaming, thread persistence, and tool use.",
+    domain: "agent-assistant.duyet.net",
+  },
+  {
+    name: "AI Agents",
+    description:
+      "Chat surface over Cloudflare Workers AI with streaming, artifacts, and tools.",
+    domain: "agents.duyet.net",
+  },
+  {
+    name: "Burns",
+    description:
+      "Visualization of language burndown across projects using historical commit data.",
+    domain: "burns.duyet.net",
+  },
+];
+
+function hostOf(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).host;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -7,6 +7,7 @@ import { KeyboardFeatures } from "../components/KeyboardFeatures";
 import { SiteFooter, SiteHeader } from "../components/SiteChrome";
 import { WorkStackSection } from "../components/WorkStackSection";
 import { type AppItem, apps } from "../data/projects";
+import { type SiblingApp, siblingApps } from "../data/sibling-apps";
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -146,6 +147,27 @@ function HomePage() {
             </div>
           </section>
 
+          {/* Sites Section — sibling apps in the monorepo */}
+          <section
+            id="sites"
+            className="mx-auto max-w-[1180px] px-5 py-8 sm:px-8 lg:px-10 lg:py-10"
+          >
+            <div className="mb-6">
+              <h2 className="text-2xl font-semibold sm:text-3xl">Sites</h2>
+              <p className="mt-3 max-w-xl text-sm leading-6 text-[var(--muted-foreground)] sm:text-base">
+                Live apps in this monorepo. Each one ships from{" "}
+                <span className="text-[var(--foreground)]">duyet/monorepo</span>{" "}
+                to its own production domain on Cloudflare.
+              </p>
+            </div>
+
+            <div className="border-y border-[var(--hairline)]">
+              {siblingApps.map((item) => (
+                <SiteRow key={item.domain} item={item} />
+              ))}
+            </div>
+          </section>
+
           {/* Apps Section */}
           <section
             id="apps"
@@ -261,9 +283,40 @@ function AppRow({
         {item.description}
       </p>
       <p className="truncate font-mono text-xs tabular-nums text-[var(--muted-soft)] sm:text-right">
-        {item.host}
+        <span>{item.host}</span>
+        {item.domain && item.domain !== item.host ? (
+          <>
+            <span aria-hidden="true"> · </span>
+            <span className="text-[var(--muted-foreground)] transition-colors duration-200 ease-out group-hover:text-[var(--accent)]">
+              {item.domain}
+            </span>
+          </>
+        ) : null}
       </p>
     </AppLink>
+  );
+}
+
+function SiteRow({ item }: { item: SiblingApp }) {
+  return (
+    <a
+      href={`https://${item.domain}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group grid gap-2 border-t border-[var(--hairline)] py-4 text-[var(--foreground)] transition-colors duration-200 ease-out first:border-t-0 hover:text-[var(--muted-foreground)] sm:grid-cols-[180px_1fr_220px] sm:gap-8"
+    >
+      <div className="min-w-0">
+        <h3 className="text-base font-semibold leading-snug transition-transform duration-200 ease-out group-hover:translate-x-0.5">
+          {item.name}
+        </h3>
+      </div>
+      <p className="text-sm leading-6 text-[var(--muted-foreground)] sm:max-w-2xl">
+        {item.description}
+      </p>
+      <p className="truncate font-mono text-xs tabular-nums text-[var(--muted-soft)] transition-colors duration-200 ease-out group-hover:text-[var(--accent)] sm:text-right">
+        {item.domain}
+      </p>
+    </a>
   );
 }
 

--- a/apps/home/src/routes/projects.tsx
+++ b/apps/home/src/routes/projects.tsx
@@ -63,7 +63,15 @@ function ProjectIndexItem({
           {item.description}
         </p>
         <p className="mt-3 truncate font-mono text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--muted-soft)]">
-          {item.host}
+          <span>{item.host}</span>
+          {item.domain && item.domain !== item.host ? (
+            <>
+              <span aria-hidden="true"> · </span>
+              <span className="text-[var(--muted-foreground)] transition-colors duration-200 ease-out group-hover:text-[var(--accent)]">
+                {item.domain}
+              </span>
+            </>
+          ) : null}
         </p>
       </article>
     </ProjectLink>


### PR DESCRIPTION
## Summary

- Add a new **Sites** section to the home index page listing every sibling
  app in this monorepo with a one-line description and the live production
  domain in mono. Each row links to the app's `https://<domain>` in a new
  tab. URLs come from `@duyet/urls` where available and fall back to the
  `{appName}.duyet.net` convention from `scripts/cf-deploy.ts`. Backend-only
  workers (`api`, `agent-api`, `data-sync`) are excluded, and `home` itself
  is excluded because the listing renders on it.
- Extend `AppItem` with an optional `domain?: string` for the canonical
  production domain — distinct from `host`, which is derived from the
  navigation `href` and can point at a repo or internal route. Populate the
  domain for AnyRouter (`anyrouter.dev`), ClickHouse Monitoring
  (`chmonitor.dev`), ShareHTML (`html.duyet.net`), and the duyet.net
  subdomain projects with a confirmed production URL.
- Render the domain in the mono meta strip on both the home Apps section
  and the `/projects` grid. Suppressed when it equals `host` to avoid
  duplication. The domain text picks up the accent color on row hover.

Visual language stays inside the editorial monochrome system shipped in
PR #1151: borderless rows separated by `--hairline`, `font-mono tabular-nums`
for the domain strip, accent only on hover, no shadows, no rounded boxes.

This site is auto-driven and auto-designed by the duyetbot agent.

## Test plan

- [x] `bun run test` (32 home tests pass; root cache fully warm)
- [x] `bun run check-types` (home passes; pre-existing `api` env failure
      unrelated to this diff)
- [x] `bunx biome lint apps/home/src/data/sibling-apps.ts \
      apps/home/src/routes/index.tsx apps/home/src/routes/projects.tsx \
      apps/home/src/data/projects.ts` — clean
- [x] `bun run build` from `apps/home` prerenders `/`, `/projects`, `/about`,
      `/ls`; verified the new Sites section and all 10 sibling rows are in
      the static `dist/client/index.html`
- [ ] Visual e2e (light + dark screenshot) — skipped, no browser tool
      available in this worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Sites" section to the homepage displaying sibling applications with descriptions and direct links to their live domains.
  * Enhanced project metadata to show canonical production domains alongside hosting information, providing easier access to official project sites when available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/monorepo/pull/1156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->