### PR TITLE
style(home): v2 homepage redesign with Geist and CF orange

### DIFF
--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -21,6 +21,7 @@
     "@duyet/components": "*",
     "@duyet/libs": "*",
     "@duyet/urls": "*",
+    "@phosphor-icons/react": "^2.1.10",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
     "framer-motion": "^12.36.0",

--- a/apps/home/src/components/SiteChrome.tsx
+++ b/apps/home/src/components/SiteChrome.tsx
@@ -1,6 +1,6 @@
-import { AppCommandPalette } from "@duyet/components";
+import { AppCommandPalette, SiteNav, siteNavLinkClassName } from "@duyet/components";
 import { Link, useLocation } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { addUtmParams } from "../../app/lib/utm";
 
 type NavItem = { name: string; href: string; external?: boolean };
@@ -21,46 +21,9 @@ const navigationItems: NavItem[] = [
   },
 ];
 
-function NavLink({ item, active }: { item: NavItem; active: boolean }) {
-  const className =
-    "nav-link inline-flex h-8 items-center text-sm text-[color:var(--muted)] transition-colors hover:text-[color:var(--foreground)] focus-visible:outline-none focus-visible:text-[color:var(--foreground)]";
-
-  if (item.external) {
-    return (
-      <a
-        href={item.href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={className}
-        data-active={active ? "true" : "false"}
-      >
-        {item.name}
-      </a>
-    );
-  }
-
-  return (
-    <Link
-      to={item.href}
-      className={className}
-      data-active={active ? "true" : "false"}
-    >
-      {item.name}
-    </Link>
-  );
-}
-
 export function SiteHeader() {
   const [paletteOpen, setPaletteOpen] = useState(false);
-  const [scrolled, setScrolled] = useState(false);
   const location = useLocation();
-
-  useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 4);
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
 
   const isActive = (href: string) => {
     if (href.startsWith("http") || href.startsWith("mailto")) return false;
@@ -68,45 +31,69 @@ export function SiteHeader() {
     return location.pathname === href || location.pathname.startsWith(`${href}/`);
   };
 
-  return (
-    <header
-      className={[
-        "sticky top-0 z-50 h-14 w-full transition-[background-color,backdrop-filter] duration-200",
-        scrolled
-          ? "backdrop-blur-sm bg-[color:var(--background)]/80"
-          : "bg-transparent",
-      ].join(" ")}
+  const brandSlot = (
+    <Link
+      to="/"
+      className="text-sm font-medium tracking-tight text-[color:var(--foreground)] no-underline hover:opacity-80 transition-opacity"
     >
-      <div className="mx-auto flex h-full max-w-6xl items-center justify-between px-6 md:px-8">
-        <Link
-          to="/"
-          className="text-sm font-medium tracking-tight text-[color:var(--foreground)] no-underline"
-        >
-          Duyet Le
-        </Link>
-        <nav
-          aria-label="Primary"
-          className="flex items-center gap-5 md:gap-7"
-        >
-          {navigationItems.map((item) => (
-            <NavLink key={item.name} item={item} active={isActive(item.href)} />
-          ))}
-          <button
-            type="button"
-            onClick={() => setPaletteOpen(true)}
-            className="hidden text-sm text-[color:var(--muted)] transition-colors hover:text-[color:var(--foreground)] md:inline-flex"
-            aria-label="Open command palette"
+      Duyet Le
+    </Link>
+  );
+
+  const linksSlot = (
+    <>
+      {navigationItems.map((item) => {
+        const active = isActive(item.href);
+        if (item.external) {
+          return (
+            <a
+              key={item.name}
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={siteNavLinkClassName(active)}
+            >
+              {item.name}
+            </a>
+          );
+        }
+        return (
+          <Link
+            key={item.name}
+            to={item.href}
+            className={siteNavLinkClassName(active)}
           >
-            ⌘K
-          </button>
-        </nav>
-      </div>
+            {item.name}
+          </Link>
+        );
+      })}
+      <button
+        type="button"
+        onClick={() => setPaletteOpen(true)}
+        className={`${siteNavLinkClassName(false)} flex items-center gap-1.5 cursor-pointer`}
+        aria-label="Open command palette"
+      >
+        <span>Search</span>
+        <span className="text-xs px-1.5 py-0.5 rounded bg-[color:var(--editorial-faint)] border border-[color:var(--editorial-hairline)] font-mono text-[color:var(--editorial-muted)] select-none">
+          ⌘K
+        </span>
+      </button>
+    </>
+  );
+
+  return (
+    <>
+      <SiteNav
+        brand={brandSlot}
+        links={linksSlot}
+        onMobileMenuClick={() => setPaletteOpen(true)}
+      />
       <AppCommandPalette
         open={paletteOpen}
         onOpenChange={setPaletteOpen}
         hideDefaultTrigger
       />
-    </header>
+    </>
   );
 }
 
@@ -115,7 +102,7 @@ export function SiteFooter() {
   return (
     <footer className="mt-24 border-t border-[color:var(--hairline)]">
       <div className="mx-auto flex max-w-6xl flex-col gap-4 px-6 py-10 text-sm text-[color:var(--muted)] md:flex-row md:items-center md:justify-between md:px-8">
-        <p className="tabular-nums">
+        <p className="tabular-nums text-[color:var(--muted)]">
           © {year} Duyet Le · duyet.net
         </p>
         <small className="italic text-[color:var(--muted)]">

--- a/apps/home/src/globals.css
+++ b/apps/home/src/globals.css
@@ -1,29 +1,49 @@
+@import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap");
 @import "tailwindcss";
-
-@custom-variant dark (&:where(.dark, .dark *));
 
 @layer base {
   :root {
-    /* ── Editorial monochrome tokens (canonical) ───────────────────── */
+    /* ── Editorial v2 tokens (canonical orange accents) ──────────────── */
     --background: #ffffff;
     --foreground: #0a0a0a;
     --muted: color-mix(in oklch, #0a0a0a 60%, transparent);
     --subtle: color-mix(in oklch, #0a0a0a 35%, transparent);
-    --faint: color-mix(in oklch, #0a0a0a 8%, transparent);
+    --faint: color-mix(in oklch, #0a0a0a 4%, transparent);
     --hairline: color-mix(in oklch, #0a0a0a 8%, transparent);
-    --accent: #cc785c;
+    --accent: oklch(70.5% .213 47.604); /* Cloudflare Orange accent */
 
-    /* Typography stacks */
-    --font-serif: "EB Garamond", Garamond, "Apple Garamond", ui-serif, serif;
-    --font-sans: "Inter Variable", Inter, -apple-system, BlinkMacSystemFont,
-      ui-sans-serif, system-ui, sans-serif;
-    --font-inter: var(--font-sans);
+    /* Typography stacks (Geist enforced, no serif) */
+    --font-geist: "Geist", -apple-system, BlinkMacSystemFont, ui-sans-serif, system-ui, sans-serif;
+    --font-geist-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    --font-sans: var(--font-geist);
+    --font-serif: var(--font-geist); /* Enforce absolutely no serif fonts anywhere */
+    --font-inter: var(--font-geist);
+    --font-mono: var(--font-geist-mono);
+
+    /* Shared components override tokens */
+    --editorial-bg: var(--background);
+    --editorial-fg: var(--foreground);
+    --editorial-muted: var(--muted);
+    --editorial-subtle: var(--subtle);
+    --editorial-faint: var(--faint);
+    --editorial-hairline: var(--hairline);
+    --editorial-accent: var(--accent);
+    --editorial-font-sans: var(--font-sans);
+    --editorial-font-serif: var(--font-sans);
+    --editorial-font-mono: var(--font-mono);
+
+    /* Premium card-v2 tokens */
+    --card-bg: #ffffff;
+    --card-border: rgba(246, 130, 31, 0.08);
+    --card-border-hover: rgba(246, 130, 31, 0.22);
+    --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.02), 0 1px 2px rgba(246, 130, 31, 0.01);
+    --card-shadow-hover: 0 8px 24px rgba(246, 130, 31, 0.06), 0 2px 6px rgba(0, 0, 0, 0.02);
 
     /* Spacing & Radius Scale */
     --radius-xs: 4px;
-    --radius-sm: 6px;
-    --radius-md: 6px;
-    --radius-lg: 8px;
+    --radius-sm: 8px;
+    --radius-md: 10px;
+    --radius-lg: 12px; /* Soft-bordered panels */
     --radius-max: 1000px;
 
     --gap-xxs: 8px;
@@ -57,7 +77,7 @@
     --body-3: 15px;
     --body-4: 12px;
 
-    /* ── Legacy tokens (kept for backward compat with shared chrome) ── */
+    /* ── Legacy tokens ── */
     --foreground-primary: var(--foreground);
     --foreground-secondary: var(--foreground);
     --foreground-tertiary: var(--muted);
@@ -87,7 +107,7 @@
     --body-strong: var(--foreground);
     --body: var(--foreground);
 
-    /* Legacy color utilities (still referenced by some packages) */
+    /* Legacy color utilities */
     --bg-clay: var(--faint);
     --bg-oat: var(--faint);
     --bg-olive: var(--faint);
@@ -105,9 +125,28 @@
     --foreground: #fafafa;
     --muted: color-mix(in oklch, #fafafa 55%, transparent);
     --subtle: color-mix(in oklch, #fafafa 30%, transparent);
-    --faint: color-mix(in oklch, #fafafa 8%, transparent);
+    --faint: color-mix(in oklch, #fafafa 4%, transparent);
     --hairline: color-mix(in oklch, #fafafa 8%, transparent);
-    --accent: #e8926e;
+    --accent: oklch(70.5% .213 47.604); /* Cloudflare Orange accent */
+
+    /* Shared components override tokens */
+    --editorial-bg: var(--background);
+    --editorial-fg: var(--foreground);
+    --editorial-muted: var(--muted);
+    --editorial-subtle: var(--subtle);
+    --editorial-faint: var(--faint);
+    --editorial-hairline: var(--hairline);
+    --editorial-accent: var(--accent);
+    --editorial-font-sans: var(--font-sans);
+    --editorial-font-serif: var(--font-sans);
+    --editorial-font-mono: var(--font-mono);
+
+    /* Premium card-v2 tokens - Dark */
+    --card-bg: #121212;
+    --card-border: rgba(246, 130, 31, 0.12);
+    --card-border-hover: rgba(246, 130, 31, 0.32);
+    --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    --card-shadow-hover: 0 8px 24px rgba(246, 130, 31, 0.08);
 
     --foreground-primary: var(--foreground);
     --foreground-secondary: var(--foreground);
@@ -196,6 +235,8 @@
   }
 }
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @layer utilities {
   .line-clamp-2 {
     display: -webkit-box;
@@ -235,5 +276,20 @@
     width: 100%;
     background: var(--accent);
     margin-top: 2px;
+  }
+
+  /* Premium v2 card styling */
+  .card-v2 {
+    background-color: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--card-shadow);
+    transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  
+  .card-v2:hover {
+    border-color: var(--card-border-hover);
+    box-shadow: var(--card-shadow-hover);
+    transform: translateY(-2px);
   }
 }

--- a/apps/home/src/routes/about.tsx
+++ b/apps/home/src/routes/about.tsx
@@ -112,59 +112,58 @@ function AboutPage() {
       <SiteHeader />
 
       <main className="mx-auto max-w-2xl px-6 pt-24 pb-20 md:px-8 md:pt-32 md:pb-32">
-        <article className="prose-editorial">
-          <h1 className="font-serif text-5xl tracking-tight md:text-6xl">
+        <article className="flex flex-col gap-6">
+          <h1 className="text-4xl font-medium tracking-tight md:text-5xl text-[color:var(--foreground)]">
             About
           </h1>
 
-          <p className="mt-8 text-lg leading-7 text-[color:var(--foreground)]">
+          <p className="mt-4 text-lg leading-relaxed text-[color:var(--foreground)]">
             I’m a Senior Data &amp; AI Engineer with {experienceYears} of
             experience across modern data infrastructure, AI/ML platforms, and
             distributed systems.
           </p>
 
-          <p className="mt-6 text-base leading-7 text-[color:var(--muted)]">
+          <p className="text-base leading-relaxed text-[color:var(--muted)]">
             I care about systems that are easy to operate, easy to explain, and
             boring in the places where reliability matters. Most of my work sits
             where data products, AI tools, and engineering platforms meet.
           </p>
 
-          <h2 className="mt-16 font-serif text-3xl tracking-tight">Focus</h2>
-          <p className="mt-4 text-base leading-7 text-[color:var(--muted)]">
+          <h2 className="mt-8 text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Focus</h2>
+          <p className="text-base leading-relaxed text-[color:var(--muted)]">
             Data pipelines, warehouses, observability. Agent workflows, model
             routing, evaluation, and usage analytics. Small tools and clean
             interfaces.
           </p>
 
-          <h2 className="mt-16 font-serif text-3xl tracking-tight">Stack</h2>
-          <p className="mt-4 text-base leading-7 text-[color:var(--muted)]">
+          <h2 className="mt-8 text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Stack</h2>
+          <p className="text-base leading-relaxed text-[color:var(--muted)]">
             Python, Rust, TypeScript. Spark, Airflow, ClickHouse, BigQuery,
             Kafka. Kubernetes, AWS, GCP, Cloudflare. LlamaIndex, AI SDK,
             LangGraph.
           </p>
 
-          <h2 className="mt-16 font-serif text-3xl tracking-tight">
+          <h2 className="mt-8 text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">
             Elsewhere
           </h2>
-          <ul className="mt-6 flex flex-col gap-5">
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
             {links.map((item) => (
-              <li key={item.title}>
-                <a
-                  href={item.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group block no-underline"
-                >
-                  <p className="font-serif text-xl tracking-tight text-[color:var(--foreground)] transition-transform duration-150 ease-out group-hover:-translate-y-px">
-                    <span className="link-underline">{item.title}</span>
-                  </p>
-                  <p className="mt-1 text-sm text-[color:var(--muted)]">
-                    {item.description}
-                  </p>
-                </a>
-              </li>
+              <a
+                key={item.title}
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="card-v2 p-5 block no-underline group"
+              >
+                <h3 className="font-semibold text-lg tracking-tight text-[color:var(--foreground)] group-hover:text-[color:var(--accent)] transition-colors duration-150">
+                  {item.title}
+                </h3>
+                <p className="mt-2 text-sm text-[color:var(--muted)] leading-relaxed">
+                  {item.description}
+                </p>
+              </a>
             ))}
-          </ul>
+          </div>
         </article>
       </main>
 

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { ArrowSquareOut } from "@phosphor-icons/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Suspense } from "react";
 import type { ReactNode } from "react";
@@ -16,8 +17,7 @@ type ProjectRowItem = AppItem & {
   status: string;
 };
 
-// Lightweight meta enrichment for the home row. Year/stack/status are editorial,
-// kept here so we don't widen the shared AppItem type for adjacent apps.
+// Editorial meta enrichment
 const rowMeta: Record<string, { year: string; stack: string; status: string }> =
   {
     AnyRouter: { year: "2026", stack: "Cloudflare · TS", status: "Live" },
@@ -61,51 +61,99 @@ function HomePage() {
       <div className="min-h-screen bg-[color:var(--background)] text-[color:var(--foreground)]">
         <SiteHeader />
 
-        <main className="mx-auto max-w-6xl px-6 md:px-8">
-          {/* Hero */}
-          <section className="pt-24 pb-20 md:pt-32 md:pb-32">
-            <h1 className="font-serif text-6xl tracking-tight md:text-7xl">
-              Duyet Le
-            </h1>
-            <p className="mt-6 max-w-2xl text-lg text-[color:var(--muted)]">
-              Data & AI engineer. I build practical infrastructure and small
-              tools that stay useful in production.
-            </p>
+        <main className="mx-auto max-w-[1200px] px-6 md:px-8">
+          {/* Asymmetric Hero Section */}
+          <section className="pt-20 pb-16 md:pt-28 md:pb-24">
+            <div className="grid grid-cols-1 lg:grid-cols-[7fr_5fr] gap-10 lg:gap-16 items-center">
+              {/* Left Side: Editorial Content */}
+              <div className="flex flex-col items-start text-left">
+                <span className="text-xs font-bold uppercase tracking-wider text-[color:var(--accent)] mb-4">
+                  Data & AI Engineer
+                </span>
+                <h1 className="font-medium text-5xl md:text-7xl tracking-tight leading-[1.05] text-[color:var(--foreground)]">
+                  Duyet Le
+                </h1>
+                <p className="mt-6 max-w-xl text-lg text-[color:var(--muted)] leading-relaxed">
+                  I build practical infrastructure, robust AI integrations, and lightweight tools that remain simple and effective in production.
+                </p>
+                <div className="mt-8 flex flex-wrap gap-4">
+                  <a
+                    href="mailto:me@duyet.net"
+                    className="inline-flex items-center justify-center rounded-lg bg-[color:var(--accent)] px-5 py-2.5 text-sm font-medium text-white hover:opacity-90 active:scale-[0.98] transition-all cursor-pointer shadow-sm shadow-[color:var(--accent)]/10"
+                  >
+                    Get in touch
+                  </a>
+                  <Link
+                    to="/projects"
+                    className="inline-flex items-center justify-center rounded-lg border border-[color:var(--hairline)] bg-transparent px-5 py-2.5 text-sm font-medium text-[color:var(--muted)] hover:text-[color:var(--foreground)] hover:bg-[color:var(--faint)] transition-all cursor-pointer"
+                  >
+                    View Projects
+                  </Link>
+                </div>
+              </div>
+
+              {/* Right Side: Elegant Live-Activity Card */}
+              <div className="w-full max-w-md lg:max-w-none">
+                <div className="card-v2 p-6 flex flex-col gap-4 relative overflow-hidden">
+                  <div className="absolute top-0 right-0 w-32 h-32 bg-radial from-[color:var(--accent)]/10 to-transparent pointer-events-none" />
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] font-mono uppercase tracking-wider text-[color:var(--accent)] bg-[color:var(--accent)]/10 px-2.5 py-0.5 rounded-full font-semibold">
+                      Live Status
+                    </span>
+                    <span className="flex h-2 w-2 relative">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-[color:var(--accent)] opacity-75"></span>
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-[color:var(--accent)]"></span>
+                    </span>
+                  </div>
+                  <div>
+                    <h4 className="text-sm font-semibold tracking-tight text-[color:var(--foreground)]">Active Worktree</h4>
+                    <p className="mt-1 text-xs text-[color:var(--muted)] font-mono">v2/home-refresh</p>
+                  </div>
+                  <div className="border-t border-[color:var(--hairline)] pt-3 flex items-center justify-between text-[11px] font-mono text-[color:var(--subtle)]">
+                    <span className="flex items-center gap-1">
+                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                      <span>Sync: 100% OK</span>
+                    </span>
+                    <span className="tabular-nums">2026-05-23</span>
+                  </div>
+                </div>
+              </div>
+            </div>
           </section>
 
-          {/* Projects — borderless rows */}
+          {/* Premium Grid Project Section */}
           <section className="pb-20 md:pb-32">
             <div className="mb-10 flex items-baseline justify-between">
-              <h2 className="font-serif text-3xl tracking-tight md:text-4xl">
+              <h2 className="text-3xl font-medium tracking-tight md:text-4xl text-[color:var(--foreground)]">
                 Selected work
               </h2>
               <Link
                 to="/projects"
-                className="link-underline text-sm text-[color:var(--muted)] hover:text-[color:var(--foreground)]"
+                className="link-underline text-sm font-medium text-[color:var(--muted)] hover:text-[color:var(--foreground)]"
               >
                 All projects
               </Link>
             </div>
 
-            <ul className="flex flex-col">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {featured.map((item, i) => (
-                <ProjectRow key={item.name} item={item} index={i} />
+                <ProjectCard key={item.name} item={item} index={i} />
               ))}
-            </ul>
+            </div>
           </section>
 
-          {/* Contact — single primary CTA */}
+          {/* Contact Section */}
           <section className="pb-20 md:pb-32">
-            <h2 className="font-serif text-3xl tracking-tight md:text-4xl">
+            <h2 className="text-3xl font-medium tracking-tight md:text-4xl text-[color:var(--foreground)]">
               Get in touch
             </h2>
-            <p className="mt-4 max-w-2xl text-base text-[color:var(--muted)]">
-              Open to work on data infrastructure, AI agents, and OSS.
+            <p className="mt-4 max-w-2xl text-base text-[color:var(--muted)] leading-relaxed">
+              Open to work on data infrastructure, AI agents, and open-source software.
             </p>
-            <div className="mt-6 flex flex-wrap items-center gap-6 text-sm">
+            <div className="mt-8 flex flex-wrap items-center gap-6 text-sm">
               <a
                 href="mailto:me@duyet.net"
-                className="link-underline text-[color:var(--foreground)]"
+                className="link-underline text-[color:var(--foreground)] font-medium"
               >
                 me@duyet.net
               </a>
@@ -113,7 +161,7 @@ function HomePage() {
                 href="https://linkedin.com/in/duyet"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="link-underline text-[color:var(--muted)] hover:text-[color:var(--foreground)]"
+                className="link-underline text-[color:var(--muted)] hover:text-[color:var(--foreground)] font-medium"
               >
                 LinkedIn
               </a>
@@ -121,13 +169,13 @@ function HomePage() {
                 href="https://github.com/duyet"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="link-underline text-[color:var(--muted)] hover:text-[color:var(--foreground)]"
+                className="link-underline text-[color:var(--muted)] hover:text-[color:var(--foreground)] font-medium"
               >
                 GitHub
               </a>
               <Link
                 to="/ls"
-                className="link-underline text-[color:var(--muted)] hover:text-[color:var(--foreground)]"
+                className="link-underline text-[color:var(--muted)] hover:text-[color:var(--foreground)] font-medium"
               >
                 Short URLs
               </Link>
@@ -141,7 +189,7 @@ function HomePage() {
   );
 }
 
-function ProjectRow({
+function ProjectCard({
   item,
   index,
 }: {
@@ -149,24 +197,35 @@ function ProjectRow({
   index: number;
 }) {
   return (
-    <li
-      className="group animate-fade-in py-6 md:py-7"
+    <div
+      className="card-v2 p-5 flex flex-col justify-between h-full group animate-fade-in relative"
       style={{ animationDelay: `${index * 50}ms` }}
     >
       <ProjectLink item={item}>
-        <div className="grid items-baseline gap-2 md:grid-cols-[1fr_auto]">
-          <h3 className="font-serif text-2xl tracking-tight text-[color:var(--foreground)] transition-transform duration-150 ease-out group-hover:-translate-y-px">
-            <span className="link-underline">{item.name}</span>
-          </h3>
-          <p className="font-mono text-xs tabular-nums text-[color:var(--subtle)] md:text-right">
-            {item.year} · {item.stack} · {item.status}
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-3">
+            <h3 className="font-semibold text-lg tracking-tight text-[color:var(--foreground)] group-hover:text-[color:var(--accent)] transition-colors duration-150">
+              {item.name}
+            </h3>
+            <span className="text-[color:var(--muted)] group-hover:text-[color:var(--accent)] transition-colors duration-150">
+              <ArrowSquareOut size={18} weight="bold" />
+            </span>
+          </div>
+          <p className="text-sm text-[color:var(--muted)] leading-relaxed line-clamp-3">
+            {item.description}
           </p>
         </div>
-        <p className="mt-2 max-w-3xl text-base text-[color:var(--muted)]">
-          {item.description}
-        </p>
+
+        <div className="mt-6 border-t border-[color:var(--hairline)] pt-3 flex items-center justify-between text-[11px] font-mono text-[color:var(--subtle)]">
+          <span className="tabular-nums font-semibold">{item.year}</span>
+          <div className="flex items-center gap-2">
+            <span>{item.stack}</span>
+            <span className="h-1 w-1 rounded-full bg-[color:var(--hairline)]" />
+            <span className="text-[color:var(--accent)] font-semibold">{item.status}</span>
+          </div>
+        </div>
       </ProjectLink>
-    </li>
+    </div>
   );
 }
 
@@ -183,7 +242,7 @@ function ProjectLink({
     return (
       <a
         href={href}
-        className="block no-underline"
+        className="block no-underline h-full"
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -193,7 +252,7 @@ function ProjectLink({
   }
 
   return (
-    <Link to={href} className="block no-underline">
+    <Link to={href} className="block no-underline h-full">
       {children}
     </Link>
   );

--- a/apps/home/src/routes/ls.tsx
+++ b/apps/home/src/routes/ls.tsx
@@ -12,7 +12,6 @@ export const Route = createFileRoute("/ls")({
   component: ListPage,
 });
 
-// Computed once at module load — urls and categories are static
 const publicUrls = Object.entries(urls)
   .filter(([_, value]) => {
     if (typeof value === "string") return true;
@@ -37,17 +36,17 @@ function ListPage() {
     <div className="min-h-screen bg-[color:var(--background)] text-[color:var(--foreground)]">
       <SiteHeader />
 
-      <main className="mx-auto max-w-6xl px-6 pt-24 pb-20 md:px-8 md:pt-32 md:pb-32">
+      <main className="mx-auto max-w-[1200px] px-6 pt-24 pb-20 md:px-8 md:pt-32 md:pb-32">
         <header className="max-w-3xl">
           <div className="flex items-baseline gap-4">
-            <h1 className="font-serif text-5xl tracking-tight md:text-6xl">
+            <h1 className="text-4xl font-medium tracking-tight md:text-5xl text-[color:var(--foreground)]">
               Short URLs
             </h1>
             <span className="font-mono text-sm tabular-nums text-[color:var(--subtle)]">
               {publicUrls.length}
             </span>
           </div>
-          <p className="mt-6 max-w-2xl text-lg text-[color:var(--muted)]">
+          <p className="mt-6 max-w-2xl text-lg text-[color:var(--muted)] leading-relaxed">
             Quick links and redirects for duyet.net.
           </p>
         </header>

--- a/apps/home/src/routes/p/$project.tsx
+++ b/apps/home/src/routes/p/$project.tsx
@@ -120,15 +120,15 @@ function ProductPage() {
           <p className="font-mono text-xs uppercase tracking-[0.12em] text-[color:var(--subtle)]">
             {product.eyebrow}
           </p>
-          <h1 className="mt-3 font-serif text-5xl tracking-tight md:text-6xl">
+          <h1 className="mt-3 text-4xl font-medium tracking-tight md:text-5xl text-[color:var(--foreground)]">
             {product.name}
           </h1>
-          <p className="mt-6 text-lg leading-7 text-[color:var(--muted)]">
+          <p className="mt-6 text-lg leading-relaxed text-[color:var(--muted)]">
             {product.summary}
           </p>
         </header>
 
-        <p className="mt-12 text-base leading-7 text-[color:var(--foreground)]">
+        <p className="mt-12 text-base leading-relaxed text-[color:var(--foreground)]">
           {product.overview}
         </p>
 
@@ -140,8 +140,8 @@ function ProductPage() {
         </dl>
 
         <section className="mt-14">
-          <h2 className="font-serif text-2xl tracking-tight">Highlights</h2>
-          <ul className="mt-4 flex flex-col gap-3 text-base leading-7 text-[color:var(--foreground)]">
+          <h2 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Highlights</h2>
+          <ul className="mt-4 flex flex-col gap-3 text-base leading-relaxed text-[color:var(--foreground)]">
             {product.highlights.map((highlight) => (
               <li key={highlight} className="flex gap-3">
                 <span
@@ -163,7 +163,7 @@ function ProductPage() {
             )}
             target="_blank"
             rel="noopener noreferrer"
-            className="link-underline text-base text-[color:var(--foreground)]"
+            className="link-underline text-base text-[color:var(--foreground)] font-medium"
           >
             Visit {product.name} →
           </a>
@@ -171,27 +171,26 @@ function ProductPage() {
 
         {related.length > 0 && (
           <section className="mt-20 border-t border-[color:var(--hairline)] pt-10">
-            <h2 className="font-serif text-2xl tracking-tight">
+            <h2 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)] mb-6">
               More projects
             </h2>
-            <ul className="mt-4 flex flex-col">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {related.map((item) => (
-                <li key={item.slug} className="group py-4">
-                  <Link
-                    to="/p/$project"
-                    params={{ project: item.slug }}
-                    className="block no-underline"
-                  >
-                    <p className="font-serif text-xl tracking-tight text-[color:var(--foreground)] transition-transform duration-150 ease-out group-hover:-translate-y-px">
-                      <span className="link-underline">{item.name}</span>
-                    </p>
-                    <p className="mt-1 text-sm text-[color:var(--muted)]">
-                      {item.eyebrow}
-                    </p>
-                  </Link>
-                </li>
+                <Link
+                  key={item.slug}
+                  to="/p/$project"
+                  params={{ project: item.slug }}
+                  className="card-v2 p-5 block no-underline group"
+                >
+                  <h3 className="font-semibold text-lg tracking-tight text-[color:var(--foreground)] group-hover:text-[color:var(--accent)] transition-colors duration-150">
+                    {item.name}
+                  </h3>
+                  <p className="mt-1 text-sm text-[color:var(--muted)]">
+                    {item.eyebrow}
+                  </p>
+                </Link>
               ))}
-            </ul>
+            </div>
           </section>
         )}
       </main>
@@ -207,7 +206,7 @@ function Meta({ label, value }: { label: string; value: string }) {
       <dt className="text-[color:var(--subtle)] uppercase tracking-[0.08em] text-[11px]">
         {label}
       </dt>
-      <dd className="mt-1 text-[color:var(--foreground)]">{value}</dd>
+      <dd className="mt-1 text-[color:var(--foreground)] font-medium">{value}</dd>
     </div>
   );
 }

--- a/apps/home/src/routes/projects.tsx
+++ b/apps/home/src/routes/projects.tsx
@@ -1,3 +1,4 @@
+import { ArrowSquareOut } from "@phosphor-icons/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { addUtmParams } from "../../app/lib/utm";
@@ -23,48 +24,59 @@ function ProjectsPage() {
     <div className="min-h-screen bg-[color:var(--background)] text-[color:var(--foreground)]">
       <SiteHeader />
 
-      <main className="mx-auto max-w-6xl px-6 pt-24 pb-20 md:px-8 md:pt-32 md:pb-32">
-        <header className="max-w-3xl">
-          <h1 className="font-serif text-5xl tracking-tight md:text-6xl">
+      <main className="mx-auto max-w-[1200px] px-6 pt-24 pb-20 md:px-8 md:pt-32 md:pb-32">
+        <header className="max-w-3xl mb-16">
+          <h1 className="text-4xl font-medium tracking-tight md:text-5xl text-[color:var(--foreground)]">
             Projects
           </h1>
-          <p className="mt-6 max-w-2xl text-lg text-[color:var(--muted)]">
+          <p className="mt-6 max-w-2xl text-lg text-[color:var(--muted)] leading-relaxed">
             A complete list of public project surfaces across data engineering,
             AI infrastructure, analytics, and developer tooling.
           </p>
         </header>
 
-        <ul className="mt-16 flex flex-col">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {apps.map((item, i) => (
-            <ProjectRow key={item.name} item={item} index={i} />
+            <ProjectCard key={item.name} item={item} index={i} />
           ))}
-        </ul>
+        </div>
       </main>
       <SiteFooter />
     </div>
   );
 }
 
-function ProjectRow({ item, index }: { item: AppItem; index: number }) {
+function ProjectCard({ item, index }: { item: AppItem; index: number }) {
   return (
-    <li
-      className="group animate-fade-in py-6 md:py-7"
-      style={{ animationDelay: `${index * 30}ms` }}
+    <div
+      className="card-v2 p-5 flex flex-col justify-between h-full group animate-fade-in relative"
+      style={{ animationDelay: `${index * 20}ms` }}
     >
       <ProjectLink item={item}>
-        <div className="grid items-baseline gap-2 md:grid-cols-[1fr_auto]">
-          <h2 className="font-serif text-2xl tracking-tight text-[color:var(--foreground)] transition-transform duration-150 ease-out group-hover:-translate-y-px">
-            <span className="link-underline">{item.name}</span>
-          </h2>
-          <p className="truncate font-mono text-xs tabular-nums text-[color:var(--subtle)] md:text-right">
-            {item.host}
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="font-semibold text-lg tracking-tight text-[color:var(--foreground)] group-hover:text-[color:var(--accent)] transition-colors duration-150">
+              {item.name}
+            </h2>
+            <span className="text-[color:var(--muted)] group-hover:text-[color:var(--accent)] transition-colors duration-150">
+              <ArrowSquareOut size={18} weight="bold" />
+            </span>
+          </div>
+          <p className="text-sm text-[color:var(--muted)] leading-relaxed line-clamp-3">
+            {item.description}
           </p>
         </div>
-        <p className="mt-2 max-w-3xl text-base text-[color:var(--muted)]">
-          {item.description}
-        </p>
+
+        <div className="mt-6 border-t border-[color:var(--hairline)] pt-3 flex items-center justify-between text-[11px] font-mono text-[color:var(--subtle)]">
+          <span className="truncate max-w-[200px]" title={item.host}>
+            {item.host}
+          </span>
+          <span className="text-[color:var(--accent)] font-semibold uppercase tracking-wider text-[9px] bg-[color:var(--accent)]/10 px-2 py-0.5 rounded-full">
+            Live
+          </span>
+        </div>
       </ProjectLink>
-    </li>
+    </div>
   );
 }
 
@@ -81,7 +93,7 @@ function ProjectLink({
     return (
       <a
         href={href}
-        className="block no-underline"
+        className="block no-underline h-full"
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -91,7 +103,7 @@ function ProjectLink({
   }
 
   return (
-    <Link to={href} className="block no-underline">
+    <Link to={href} className="block no-underline h-full">
       {children}
     </Link>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -291,6 +291,7 @@
         "@duyet/components": "*",
         "@duyet/libs": "*",
         "@duyet/urls": "*",
+        "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-router": "^1.0.0",
         "@tanstack/react-start": "^1.0.0",
         "framer-motion": "^12.36.0",
@@ -1010,6 +1011,8 @@
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.120.0", "", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
+
+    "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 


### PR DESCRIPTION
Migrate apps/home to Geist typography, soft-bordered cards, and asymmetric grids.