### PR TITLE
refactor(agents): drop deprecated ReasoningGroup wrapper

### DIFF
--- a/apps/agent-assistant/components/assistant-ui/reasoning.tsx
+++ b/apps/agent-assistant/components/assistant-ui/reasoning.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import {
-  type ReasoningGroupComponent,
   type ReasoningMessagePartComponent,
-  useAuiState,
   useScrollLock,
 } from "@assistant-ui/react";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -219,30 +217,6 @@ function ReasoningText({ className, ...props }: React.ComponentProps<"div">) {
 
 const ReasoningImpl: ReasoningMessagePartComponent = () => <MarkdownText />;
 
-const ReasoningGroupImpl: ReasoningGroupComponent = ({
-  children,
-  startIndex,
-  endIndex,
-}) => {
-  const isReasoningStreaming = useAuiState((s) => {
-    if (s.message.status?.type !== "running") return false;
-    const lastIndex = s.message.parts.length - 1;
-    if (lastIndex < 0) return false;
-    const lastType = s.message.parts[lastIndex]?.type;
-    if (lastType !== "reasoning") return false;
-    return lastIndex >= startIndex && lastIndex <= endIndex;
-  });
-
-  return (
-    <ReasoningRoot defaultOpen={isReasoningStreaming}>
-      <ReasoningTrigger active={isReasoningStreaming} />
-      <ReasoningContent aria-busy={isReasoningStreaming}>
-        <ReasoningText>{children}</ReasoningText>
-      </ReasoningContent>
-    </ReasoningRoot>
-  );
-};
-
 const Reasoning = memo(
   ReasoningImpl
 ) as unknown as ReasoningMessagePartComponent & {
@@ -260,21 +234,10 @@ Reasoning.Content = ReasoningContent;
 Reasoning.Text = ReasoningText;
 Reasoning.Fade = ReasoningFade;
 
-/**
- * @deprecated This wrapper targets the legacy `components.ReasoningGroup`
- * prop on `<MessagePrimitive.Parts>`. Use `<MessagePrimitive.GroupedParts>`
- * with a `groupBy` returning `"group-reasoning"` and compose `ReasoningRoot`
- * / `ReasoningTrigger` / `ReasoningContent` / `ReasoningText` directly.
- * See `thread.tsx` for an example.
- */
-const ReasoningGroup = memo(ReasoningGroupImpl);
-ReasoningGroup.displayName = "ReasoningGroup";
-
 export {
   Reasoning,
   ReasoningContent,
   ReasoningFade,
-  ReasoningGroup,
   ReasoningRoot,
   ReasoningText,
   ReasoningTrigger,


### PR DESCRIPTION
## Summary

- The codebase has no literal `TODO`/`FIXME` comments in source. The closest equivalents are `@deprecated` wrappers with explicit migration instructions. `ReasoningGroup` in `apps/agent-assistant/components/assistant-ui/reasoning.tsx` was the most clearly actionable one — its docstring already pointed at the replacement, and the replacement is already live in `thread.tsx`.
- Verified the wrapper has zero non-test references (`ReasoningGroup`, `ReasoningGroupImpl`, `ReasoningGroupComponent` were all only used within the file declaring them).
- Removed the wrapper, the `ReasoningGroupImpl` factory it wrapped, and the imports (`useAuiState`, `ReasoningGroupComponent`) that became unused after deletion.

The new composition pattern (`<MessagePrimitive.GroupedParts groupBy={...}>` with directly-composed `ReasoningRoot` / `ReasoningTrigger` / `ReasoningContent` / `ReasoningText`) already lives in `apps/agent-assistant/components/assistant-ui/thread.tsx:347-393`, which the deprecation comment specifically referenced as the example.

## Test plan

- [x] `bunx biome lint apps/agent-assistant/components/assistant-ui/reasoning.tsx` — clean.
- [x] `rg -n "ReasoningGroup|ReasoningGroupImpl|ReasoningGroupComponent" apps packages --glob '!**/node_modules/**' …` — no remaining references after the deletion (including in test files).
- [ ] `bun run check-types` — could not run locally; root `bun install` is blocked by the repo's `minimumReleaseAge` policy on a few unrelated `@tanstack/*` packages in this sandbox. CI on the PR will verify.
- [ ] Manual verification that the agent-assistant reasoning UI still renders in `thread.tsx` — pure deletion of unreferenced exports, so structurally cannot affect runtime behavior, but worth a smoke test before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_017kLM3amASxBcTR3hK6AqsV)_

## Summary by Sourcery

Enhancements:
- Simplify the reasoning UI module by deleting the obsolete ReasoningGroup implementation and export now superseded by the newer grouping composition pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the reasoning component implementation by removing legacy code and streamlining the rendering logic for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/monorepo/pull/1165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->