### PR TITLE
fix: preserve kb raw article links metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ For scoped reviews after the last run timestamp:
 - `rg -n "setup-bun@v" .github/workflows -g'*.yml'` to catch unpinned Bun setup actions
 - `rg -n "dtolnay/rust-toolchain@|jetli/wasm-pack-action@|version: latest" .github/workflows -g'*.yml'` to verify Rust/WASM action refs and wasm-pack version pins after deploy-workflow changes
 - `rg -n "if \\(field ===" packages/libs --glob '*.ts'` to catch duplicate field branches in parser-style switch/if chains before cleanup
+- `cd apps/kb && bun run build` regenerates `public/{robots,sitemap,llms,llms-full}.txt` plus `public/k/*.md`; keep article `links` frontmatter intact for raw markdown consumers
 - Keep durable findings in `docs/ai/core-memory.md` and list reference docs in `docs/INDEX.md`
 - Do not create dated `docs/reviews/code-smell-dead-code-<DATE>.md` files
 - `gh run list --branch master --event push --limit 10 --json databaseId,headSha,status,conclusion,name,updatedAt` to confirm post-merge `master` CI is green

--- a/apps/agent-api/src/agent.ts
+++ b/apps/agent-api/src/agent.ts
@@ -50,7 +50,7 @@ export interface SubmitApiMessageResult {
   interactionRequired: boolean;
   messages: UIMessage[];
   pendingInteractions: PendingInteraction[];
-  status: "aborted" | "completed" | "skipped";
+  status: "aborted" | "completed" | "error" | "skipped";
 }
 
 export class SessionOwnerMismatchError extends Error {

--- a/apps/kb/lib/content.ts
+++ b/apps/kb/lib/content.ts
@@ -6,7 +6,7 @@
  * (prebuild scripts), it falls back to a filesystem walk.
  */
 
-import { basename, extname, join, dirname } from "node:path";
+import { basename } from "node:path";
 import matter from "gray-matter";
 
 // ── Types ─────────────────────────────────────────────────────────────────────

--- a/apps/kb/public/k/welcome.md
+++ b/apps/kb/public/k/welcome.md
@@ -2,9 +2,12 @@
 title: "Welcome to the Knowledge Base"
 category: "meta"
 tags: ["getting-started", "overview"]
+links: []
 summary: "An introduction to the duyet.net knowledge base — what it covers, how it is organized, and how to navigate it."
 updated: "2026-05-26"
----# Welcome to the Knowledge Base
+---
+
+# Welcome to the Knowledge Base
 
 This knowledge base documents the [duyet/monorepo](https://github.com/duyet/monorepo) — a Bun + Turborepo monorepo hosting all personal web apps and shared packages.
 

--- a/apps/kb/scripts/generate-static-files.ts
+++ b/apps/kb/scripts/generate-static-files.ts
@@ -35,6 +35,7 @@ interface Article {
   title: string;
   category: string;
   tags: string[];
+  links: string[];
   summary: string;
   updated: string;
   raw: string;
@@ -76,6 +77,7 @@ for (const filePath of walkMd(CONTENT_DIR)) {
     title: typeof data.title === "string" ? data.title : slug,
     category: typeof data.category === "string" ? data.category : "uncategorized",
     tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
+    links: Array.isArray(data.links) ? data.links.map(String) : [],
     summary: typeof data.summary === "string" ? data.summary : "",
     updated: typeof data.updated === "string" ? data.updated : "",
     raw: content.trim(),
@@ -204,6 +206,7 @@ for (const article of articles) {
     `title: ${JSON.stringify(article.title)}`,
     `category: ${JSON.stringify(article.category)}`,
     article.tags.length ? `tags: [${article.tags.map((t) => JSON.stringify(t)).join(", ")}]` : "",
+    `links: [${article.links.map((link) => JSON.stringify(link)).join(", ")}]`,
     article.summary ? `summary: ${JSON.stringify(article.summary)}` : "",
     article.updated ? `updated: ${JSON.stringify(article.updated)}` : "",
     "---",

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -144,3 +144,15 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
   - Evidence: `bunx bun pm view @langchain/langgraph-sdk versions --json | tail -n 20` plus CI reinstall logs after re-trigger.
 - Dead-code review (needs-review): no dead code candidates were added by this follow-up; these files are now referenced by app UI runtime paths.
   - Evidence: `rg -n "from \"@radix-ui/(react-avatar|react-slot|react-collapsible|react-dialog|react-tooltip)\"|tool-fallback.tsx" apps/agent-assistant`.
+
+### 2026-05-29
+
+- Commit window scan since the last automation timestamp found no new non-merge commits after `2026-05-28T06:13:19Z`, so the review widened to the repo-approved `7 days ago` fallback.
+- Code smell review (warning -> fixed): `apps/kb/scripts/generate-static-files.ts` rebuilt `public/k/*.md` without carrying article `links` frontmatter even though KB source files and graph consumers rely on it.
+  - Evidence: source markdown under `apps/kb/content/**/*.md` includes `links: [...]`, while `generate-static-files.ts` only serialized `title`, `category`, `tags`, `summary`, and `updated` before this fix.
+- Fixes applied:
+  - added `links` parsing + serialization in `apps/kb/scripts/generate-static-files.ts` so generated raw markdown stays graph-complete.
+  - removed stale unused imports from `apps/kb/lib/content.ts` left by the isomorphic loader refactor.
+- Dead-code review (confident): no zero-reference code removal was justified in the recent-change window.
+  - Evidence: the touched KB generator and loader files are directly referenced by `apps/kb/package.json` and KB routes; no additional non-test zero-reference symbols were confirmed.
+- Performance audit: no measurements or traces changed in this window, so no grounded performance regression claim was made.

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -153,6 +153,8 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 - Fixes applied:
   - added `links` parsing + serialization in `apps/kb/scripts/generate-static-files.ts` so generated raw markdown stays graph-complete.
   - removed stale unused imports from `apps/kb/lib/content.ts` left by the isomorphic loader refactor.
+- CI follow-up (warning -> fixed): PR validation exposed a pre-existing `apps/agent-api` type drift where `saveMessages()` can return `"error"` but `SubmitApiMessageResult["status"]` did not allow it.
+  - Evidence: GitHub Actions run `26602389118`, job `78389062594`, `src/agent.ts(273,7): error TS2322 ... Type '"error"' is not assignable`.
 - Dead-code review (confident): no zero-reference code removal was justified in the recent-change window.
   - Evidence: the touched KB generator and loader files are directly referenced by `apps/kb/package.json` and KB routes; no additional non-test zero-reference symbols were confirmed.
 - Performance audit: no measurements or traces changed in this window, so no grounded performance regression claim was made.

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -44,6 +44,7 @@ This repository is the Bun/Turborepo monorepo for duyet.net public apps, shared 
 - `apps/ai-percentage`: AI-written-code dashboard for `https://ai-percentage.duyet.net`; data comes from `apps/data-sync`.
 - `apps/data-sync`: operational CLI for ClickHouse analytics/activity syncs and migrations.
 - `apps/agent-assistant`: Vite-powered TanStack Start application with assistant-ui + LangGraph serving as a local agent interface. Deployed directly serverless on Cloudflare Workers/Pages (`duyet-agent-assistant`) for `https://agent-assistant.duyet.net` utilizing a native Cloudflare Durable Object (`ThreadStateDO`) backed by SQLite for checkpoint persistence.
+- `apps/kb`: static TanStack Start knowledge base for `https://kb.duyet.net`, bundling `content/**/*.md` at build time and generating `llms.txt`, `llms-full.txt`, `sitemap.xml`, `robots.txt`, and raw `public/k/*.md` article endpoints.
 
 ## Shared Packages
 
@@ -73,6 +74,7 @@ This repository is the Bun/Turborepo monorepo for duyet.net public apps, shared 
 - `apps/api`: `bun run dev` uses Wrangler; `bun run deploy` builds then deploys the Worker.
 - `apps/cv`: `bun run preview` validates production output locally.
 - `apps/data-sync`: use `bun run sync <name>`, `bun run sync:all`, `bun run migrate:*`, and `bun run cleanup:dry-run`.
+- `apps/kb`: `bun run build` runs the content prebuild and must preserve article `links` frontmatter in `public/k/*.md` for knowledge-graph and LLM consumers.
 - `apps/llm-timeline`: use `bun run sync`, `bun run sync:dry`, `bun run rss`, `bun run llms-txt`, and `bun run sitemap` for content generation.
 - `apps/ai-percentage`: refresh data through `apps/data-sync` with `bun run sync ai-code-percentage`.
 


### PR DESCRIPTION
## Summary
- preserve `links` frontmatter when `apps/kb` regenerates raw `public/k/*.md` articles
- fix the malformed closing frontmatter fence in `apps/kb/public/k/welcome.md`
- record the KB build workflow and this maintenance finding in repo docs

## Verification
- `bunx biome lint apps/kb/lib/content.ts apps/kb/scripts/generate-static-files.ts CLAUDE.md docs/ai/internal-knowledge.md docs/ai/core-memory.md`
- `git diff --check`

## Notes
- Local Bun build/typecheck verification is blocked in this sandbox by `error: bun is unable to write files to tempdir: PermissionDenied`; GitHub CI is the authoritative follow-up signal for this PR.

## Summary by Sourcery

Preserve knowledge base article frontmatter metadata in generated raw markdown and document the KB build behavior and recent maintenance findings.

Bug Fixes:
- Ensure KB static file generation preserves article `links` frontmatter in `public/k/*.md` outputs.
- Fix malformed frontmatter fencing in `apps/kb/public/k/welcome.md` so the markdown header is parsed correctly.

Enhancements:
- Extend the KB static article schema to include `links` metadata when parsing and serializing content.
- Clean up unused imports in the KB content loader to reflect recent refactors.

Documentation:
- Document the `apps/kb` application behavior, including its static build outputs and requirement to preserve `links` frontmatter, in internal knowledge docs and CLAUDE review guidance.
- Record the KB build issue and its resolution in the core-memory automation log for future code-smell reviews.