### PR TITLE
fix(ci): align deploy orchestrator lockfile detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ For scoped reviews after the last run timestamp:
 - See `docs/ai/internal-knowledge.md` for linked-worktree permission fallback details
 - `git show --unified=3 <commit_sha>`
 - `bun pm why <package>` to verify dependency overrides resolve to the intended package version
+- `rg -n "bun\\.lock|bun\\.lockb" scripts/cf-deploy.ts` to verify deploy-orchestrator full-rebuild detection matches the repo's real lockfile
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence
 - `rg -n "setup-bun@" .github/workflows -g'*.yml'` to verify valid action pins after CI workflow updates
 - `rg -n "setup-bun@v" .github/workflows -g'*.yml'` to catch unpinned Bun setup actions

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -10,6 +10,16 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 
 ## Durable Findings
 
+### 2026-06-01
+
+- Deploy orchestrator fix (warning -> fixed): `scripts/cf-deploy.ts` now treats `bun.lock` as the repo's core dependency lockfile when deciding whether to rebuild all apps; the previous `bun.lockb` checks missed lockfile-only dependency updates in this Bun text-lockfile repo.
+  - Evidence: `rg -n "bun\\.lock|bun\\.lockb" scripts/cf-deploy.ts`, plus `git show 2587eaad7780d87d75c6e45d2b77377735486aa6 -- package.json` confirmed recent dependency-only changes in the same scan window.
+- Deploy orchestrator hardening (warning -> fixed): the "no deployable apps discovered" path in `scripts/cf-deploy.ts` referenced undefined `rawOutput`, which would raise `ReferenceError` and hide the real discovery failure.
+  - Evidence: `rg -n "rawOutput|No deployable apps discovered" scripts/cf-deploy.ts`.
+- Dead-code review (confident): no zero-reference removals were justified in the scanned non-test files after targeted repo-wide checks on the newly extracted blog/home components and recent deploy surfaces.
+  - Evidence: targeted import/reference scans across `apps/blog`, `apps/home`, `apps/burns`, and `scripts/cf-deploy.ts` found live consumers or pure file moves rather than orphaned code.
+- Performance audit: no grounded runtime regression claim from this window; no measurements or traces changed in the reviewed commits.
+
 ### 2026-05-12
 
 - Removed redundant boolean cast in `apps/blog/scripts/generate-posts-data.ts` (`!Boolean(p.isMDX)` -> `!p.isMDX`).

--- a/scripts/cf-deploy.ts
+++ b/scripts/cf-deploy.ts
@@ -179,8 +179,7 @@ function discoverApps(): Record<string, AppConfig> {
   if (Object.keys(config).length === 0) {
     console.error(
       `[ERROR] No deployable apps discovered in ${appsDir}. ` +
-        `Ensure apps have both wrangler.toml and a "cf:deploy:prod" script in package.json. ` +
-        `Raw ls output: ${rawOutput}`
+        `Ensure apps have both wrangler.toml and a "cf:deploy:prod" script in package.json.`
     );
     process.exit(1);
   }
@@ -355,7 +354,7 @@ function getChangedApps(baseBranch = "origin/master"): string[] {
       "packages/",
       "turbo.json",
       "package.json",
-      "bun.lockb",
+      "bun.lock",
       ".env.production",
       "scripts/",
     ],
@@ -394,7 +393,7 @@ function getChangedApps(baseBranch = "origin/master"): string[] {
     [
       "turbo.json",
       "package.json",
-      "bun.lockb",
+      "bun.lock",
       ".env.production",
       "scripts/cf-deploy.ts",
     ].includes(file)
@@ -405,7 +404,7 @@ function getChangedApps(baseBranch = "origin/master"): string[] {
     sharedPackageChanges.length > 0 ||
     configChanges.some(
       (file) =>
-        file === "turbo.json" || file === "package.json" || file === "bun.lockb"
+        file === "turbo.json" || file === "package.json" || file === "bun.lock"
     );
 
   if (buildAllApps) {
@@ -417,7 +416,7 @@ function getChangedApps(baseBranch = "origin/master"): string[] {
     }
     if (
       configChanges.some((f) =>
-        ["turbo.json", "package.json", "bun.lockb"].includes(f)
+        ["turbo.json", "package.json", "bun.lock"].includes(f)
       )
     ) {
       reasons.push("core config changed");


### PR DESCRIPTION
## Summary
- fix deploy-orchestrator full-rebuild detection to use `bun.lock` instead of `bun.lockb`
- remove the undefined `rawOutput` reference from the empty app-discovery error path
- record the finding in `docs/ai/core-memory.md` and add the verification command to `CLAUDE.md`

## Verification
- `bunx biome lint scripts/cf-deploy.ts CLAUDE.md docs/ai/core-memory.md`
- `TMPDIR=/private/tmp bun scripts/cf-deploy.ts --dry-run`
- `TMPDIR=/private/tmp bun run --filter blog check-types`
- `TMPDIR=/private/tmp bun run --filter burns check-types`

## Summary by Sourcery

Align deploy orchestrator change-detection with the repo’s actual Bun lockfile and harden its error handling, while recording the finding and verification steps in internal AI documentation.

Bug Fixes:
- Use bun.lock instead of bun.lockb in deploy orchestrator change detection so dependency-only lockfile updates trigger full rebuilds as intended.
- Remove the undefined rawOutput reference from the no-apps-discovered error path in the deploy script to avoid masking real discovery failures.

Documentation:
- Document the deploy orchestrator lockfile fix and related findings in docs/ai/core-memory.md.
- Add a ripgrep command to CLAUDE.md for verifying that deploy-orchestrator full-rebuild detection matches the repository’s real lockfile.