### PR TITLE
fix(docs): align pnpm workflows after migration

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-bun commitlint --edit $1 
+pnpm exec commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 # Redirect to temp file to avoid pipe buffer overflow with 14+ concurrent test suites.
 # On failure, cat the output so you can see which test broke.
 TMPOUT=$(mktemp)
-if ! bun run test > "$TMPOUT" 2>&1; then
+if ! pnpm run test > "$TMPOUT" 2>&1; then
   cat "$TMPOUT"
   rm -f "$TMPOUT"
   exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Read [docs/ai/internal-knowledge.md](docs/ai/internal-knowledge.md) before changing this repository.
 
 Use semantic commit messages. Keep changes surgical and verify with the narrowest useful command for the touched app or package.
-For single-file verification, use `pnpm dlx biome lint <path>` before broader app checks.
+For single-file verification, use `pnpm exec biome lint <path>` before broader app checks.
 For dead-code cleanup, verify zero non-test references first with `rg -n "<symbol>" apps packages --glob '!**/*.test.*' --glob '!**/*.spec.*'`.
 For root quality checks, use `pnpm run lint`, `pnpm run check-types`, and `pnpm run test`.
 For deploy/config workflows, use root scripts (`pnpm run config`, `pnpm run deploy`, `pnpm run cf:deploy`, `pnpm run cf:deploy:prod`) when needed.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -8,7 +8,7 @@ Lightweight API built with Hono and deployed to Cloudflare Workers.
 - **Cloudflare Workers**: Serverless deployment with global edge network
 - **AI-Powered Descriptions**: Generate witty blog descriptions using OpenRouter API
 - **TypeScript**: Full type safety with strict mode
-- **Testing**: Built-in test support with Bun test runner
+- **Testing**: Built-in test support with Vitest
 
 ## Endpoints
 
@@ -49,19 +49,19 @@ curl "https://api.duyet.net/api/ai-description?source=featured&posts=post1,post2
 
 ```bash
 # Install dependencies
-bun install
+pnpm install
 
 # Run type checking
-bun run check-types
+pnpm run check-types
 
 # Run tests
-bun run test
+pnpm run test
 
 # Start local development server
-bun run dev
+pnpm run dev
 
 # Deploy to Cloudflare Workers
-bun run deploy
+pnpm run deploy
 ```
 
 ## Environment Variables
@@ -80,7 +80,7 @@ npx wrangler login
 npx wrangler secret put OPENROUTER_API_KEY
 
 # Deploy
-bun run deploy
+pnpm run deploy
 ```
 
 ## Project Structure
@@ -105,4 +105,3 @@ MIT
 ---
 
 **This repository is maintained by [@duyetbot](https://github.com/duyetbot).**
-

--- a/apps/blog/README.md
+++ b/apps/blog/README.md
@@ -18,22 +18,22 @@ Personal blog with MDX posts, KaTeX math rendering, and static pre-rendering.
 
 ```bash
 # Install dependencies
-bun install
+pnpm install
 
 # Start development server
-bun run dev
+pnpm run dev
 
 # Build for production
-bun run build
+pnpm run build
 
 # Run tests
-bun run test
+pnpm run test
 
 # Type checking
-bun run check-types
+pnpm run check-types
 
 # Linting
-bun run lint
+pnpm run lint
 ```
 
 ## Deployment
@@ -44,10 +44,10 @@ The blog is deployed to Cloudflare Pages via GitHub Actions.
 
 ```bash
 # Deploy to preview
-bun run cf:deploy
+pnpm run cf:deploy
 
 # Deploy to production
-bun run cf:deploy:prod
+pnpm run cf:deploy:prod
 ```
 
 ### Environment Variables
@@ -95,7 +95,7 @@ series: "series-name"
 - **Framework**: Vite + TanStack Router + TanStack Start
 - **Styling**: Tailwind CSS v4
 - **Content**: MDX posts with KaTeX math and syntax highlighting
-- **Package Manager**: Bun
+- **Package Manager**: pnpm
 - **Deployment**: Cloudflare Pages (static pre-rendering)
 
 ## Documentation

--- a/apps/cv/CLAUDE.md
+++ b/apps/cv/CLAUDE.md
@@ -13,14 +13,14 @@ Personal CV / resume hosting with TanStack Start and static pre-rendering. Displ
 ## Development Commands
 
 ```bash
-bun run dev          # Start dev server on port 3002
-bun run build        # Build static site to 'dist/client/'
-bun run lint         # Run Biome linter
-bun run check-types  # TypeScript type check
+pnpm run dev          # Start dev server on port 3002
+pnpm run build        # Build static site to 'dist/client/'
+pnpm run lint         # Run Biome linter
+pnpm run check-types  # TypeScript type check
 
 # Deploy to Cloudflare Pages
-bun run cf:deploy        # Preview deployment
-bun run cf:deploy:prod   # Production deployment
+pnpm run cf:deploy        # Preview deployment
+pnpm run cf:deploy:prod   # Production deployment
 ```
 
 ## Architecture
@@ -30,7 +30,7 @@ bun run cf:deploy:prod   # Production deployment
 - **Framework**: TanStack Start (SSR + static pre-rendering), TanStack Router
 - **Styling**: Tailwind CSS + Radix UI Separator
 - **Icons**: `@icons-pack/react-simple-icons` for tech stack icons
-- **Package Manager**: Bun
+- **Package Manager**: pnpm
 
 ### Project Structure
 

--- a/apps/cv/README.md
+++ b/apps/cv/README.md
@@ -15,21 +15,21 @@ Personal CV / resume hosting with TanStack Start and static pre-rendering. Displ
 ## Development
 
 ```bash
-bun run dev          # Start dev server on port 3002
-bun run build        # Build static site to 'dist/client/'
-bun run lint         # Run Biome linter
-bun run check-types  # TypeScript type check
-bun run preview      # Preview production build locally
+pnpm run dev          # Start dev server on port 3002
+pnpm run build        # Build static site to 'dist/client/'
+pnpm run lint         # Run Biome linter
+pnpm run check-types  # TypeScript type check
+pnpm run preview      # Preview production build locally
 ```
 
 ## Deployment
 
 ```bash
 # Deploy to Cloudflare Pages (preview)
-bun run cf:deploy
+pnpm run cf:deploy
 
 # Deploy to Cloudflare Pages (production)
-bun run cf:deploy:prod
+pnpm run cf:deploy:prod
 ```
 
 See [CLAUDE.md](../../CLAUDE.md) for detailed documentation on architecture, development patterns, and common tasks.
@@ -37,4 +37,3 @@ See [CLAUDE.md](../../CLAUDE.md) for detailed documentation on architecture, dev
 ---
 
 **This repository is maintained by [@duyetbot](https://github.com/duyetbot).**
-

--- a/apps/data-sync/COMMANDS.md
+++ b/apps/data-sync/COMMANDS.md
@@ -14,7 +14,7 @@ The data-sync CLI provides three main commands:
 
 ```bash
 cd apps/data-sync
-bun install
+pnpm install
 ```
 
 ## Environment Variables
@@ -39,21 +39,21 @@ Sync data from external sources to ClickHouse.
 
 ```bash
 # Show help
-bun run start
+pnpm run start
 
 # Sync all enabled sources
-bun run sync all
-bun run sync:all
+pnpm run sync -- all
+pnpm run sync:all
 
 # Sync specific source
-bun run sync wakatime
-bun run sync:wakatime
+pnpm run sync -- wakatime
+pnpm run sync:wakatime
 
 # Sync multiple sources
-bun run sync wakatime cloudflare github
+pnpm run sync -- wakatime cloudflare github
 
 # Preview sync without writing data
-bun run sync all --dry-run
+pnpm run sync -- all --dry-run
 ```
 
 #### Available Sources
@@ -93,26 +93,26 @@ Manage database schema migrations using SQL files.
 
 ```bash
 # Apply pending migrations
-bun run migrate up
-bun run migrate:up
+pnpm run migrate -- up
+pnpm run migrate:up
 
 # Rollback last migration
-bun run migrate down
-bun run migrate:down
+pnpm run migrate -- down
+pnpm run migrate:down
 
 # Rollback multiple migrations
-bun run migrate down --count 2
+pnpm run migrate -- down --count 2
 
 # Show migration status
-bun run migrate status
-bun run migrate:status
+pnpm run migrate -- status
+pnpm run migrate:status
 
 # Verify migration checksums
-bun run migrate verify
-bun run migrate:verify
+pnpm run migrate -- verify
+pnpm run migrate:verify
 
 # Show help
-bun run migrate help
+pnpm run migrate -- help
 ```
 
 #### Migration Files
@@ -161,11 +161,11 @@ Apply retention policies to delete old data from tables.
 
 ```bash
 # Run cleanup
-bun run cleanup
+pnpm run cleanup
 
 # Preview cleanup without deleting data
-bun run cleanup --dry-run
-bun run cleanup:dry-run
+pnpm run cleanup -- --dry-run
+pnpm run cleanup:dry-run
 ```
 
 #### Retention Policies
@@ -220,10 +220,10 @@ All commands:
 
 ```bash
 # Run type checking
-bun run check-types
+pnpm run check-types
 
 # Run tests
-bun run test
+pnpm run test
 ```
 
 ## Architecture
@@ -266,7 +266,7 @@ If you get ClickHouse connection errors:
 
 If migration checksums don't match:
 
-1. Run `bun run migrate verify` to see which migrations failed
+1. Run `pnpm run migrate -- verify` to see which migrations failed
 2. DO NOT modify applied migrations (this breaks checksum validation)
 3. Create a new migration to fix issues instead
 

--- a/apps/data-sync/README.md
+++ b/apps/data-sync/README.md
@@ -15,16 +15,16 @@ This service syncs data from multiple external sources into ClickHouse for analy
 
 ```bash
 # Show help
-bun run start
+pnpm run start
 
 # Initialize database
-bun run migrate:up
+pnpm run migrate:up
 
 # Sync all data sources
-bun run sync:all
+pnpm run sync:all
 
 # Run cleanup
-bun run cleanup
+pnpm run cleanup
 ```
 
 ## Usage
@@ -35,71 +35,71 @@ For detailed command documentation, see [COMMANDS.md](./COMMANDS.md).
 
 ```bash
 # Show help and available commands
-bun run start
-bun run start --help
+pnpm run start
+pnpm run start -- --help
 
 # Run specific commands
-bun run start sync all
-bun run start migrate status
-bun run start cleanup --dry-run
+pnpm run start -- sync all
+pnpm run start -- migrate status
+pnpm run start -- cleanup --dry-run
 ```
 
 ### Sync Commands
 
 ```bash
 # Sync all sources
-bun run sync all
-bun run sync:all
+pnpm run sync -- all
+pnpm run sync:all
 
 # Sync specific source
-bun run sync wakatime
-bun run sync:wakatime
-bun run sync:cloudflare
-bun run sync:github
-bun run sync:unsplash
+pnpm run sync -- wakatime
+pnpm run sync:wakatime
+pnpm run sync:cloudflare
+pnpm run sync:github
+pnpm run sync:unsplash
 
 # Sync multiple sources
-bun run sync wakatime cloudflare
+pnpm run sync -- wakatime cloudflare
 
 # Dry run (preview without writing)
-bun run sync all --dry-run
+pnpm run sync -- all --dry-run
 ```
 
 ### Migration Commands
 
 ```bash
 # Show migration help
-bun run migrate help
+pnpm run migrate -- help
 
 # Apply pending migrations
-bun run migrate up
-bun run migrate:up
+pnpm run migrate -- up
+pnpm run migrate:up
 
 # Rollback last migration
-bun run migrate down
-bun run migrate:down
+pnpm run migrate -- down
+pnpm run migrate:down
 
 # Rollback multiple migrations
-bun run migrate down --count 2
+pnpm run migrate -- down --count 2
 
 # Check migration status
-bun run migrate status
-bun run migrate:status
+pnpm run migrate -- status
+pnpm run migrate:status
 
 # Verify migration checksums
-bun run migrate verify
-bun run migrate:verify
+pnpm run migrate -- verify
+pnpm run migrate:verify
 ```
 
 ### Cleanup Commands
 
 ```bash
 # Run data retention cleanup
-bun run cleanup
+pnpm run cleanup
 
 # Preview cleanup (dry run)
-bun run cleanup --dry-run
-bun run cleanup:dry-run
+pnpm run cleanup -- --dry-run
+pnpm run cleanup:dry-run
 ```
 
 ## Configuration
@@ -123,10 +123,10 @@ Data retention policies are defined in `src/config/retention.config.ts`:
 
 ```bash
 # Type checking
-bun run check-types
+pnpm run check-types
 
 # Run tests
-bun run test
+pnpm run test
 ```
 
 ## Environment Variables
@@ -158,4 +158,3 @@ migrations/          # Database migrations
 ---
 
 **This repository is maintained by [@duyetbot](https://github.com/duyetbot).**
-

--- a/apps/data-sync/src/commands/migrate.ts
+++ b/apps/data-sync/src/commands/migrate.ts
@@ -10,7 +10,7 @@ function printHelp() {
 Database Migration Tool
 
 Usage:
-  bun run migrate <command> [options]
+  pnpm run migrate -- <command> [options]
 
 Commands:
   up              Apply pending migrations
@@ -22,11 +22,11 @@ Options:
   --count N       Number of migrations to rollback (use with down)
 
 Examples:
-  bun run migrate up
-  bun run migrate down
-  bun run migrate down --count 2
-  bun run migrate status
-  bun run migrate verify
+  pnpm run migrate -- up
+  pnpm run migrate -- down
+  pnpm run migrate -- down --count 2
+  pnpm run migrate -- status
+  pnpm run migrate -- verify
 `);
 }
 

--- a/apps/data-sync/src/index.ts
+++ b/apps/data-sync/src/index.ts
@@ -5,7 +5,7 @@ function printHelp() {
 Data Sync CLI
 
 Usage:
-  bun run <command> [options]
+  pnpm run start -- <command> [options]
 
 Commands:
   sync [sources...]    Sync data from external sources
@@ -13,21 +13,21 @@ Commands:
   cleanup              Run retention cleanup
 
 Sync Command:
-  bun run sync all                    Sync all enabled sources
-  bun run sync wakatime               Sync specific source
-  bun run sync wakatime cloudflare    Sync multiple sources
-  bun run sync all --dry-run          Preview without writing
+  pnpm run sync -- all                    Sync all enabled sources
+  pnpm run sync -- wakatime               Sync specific source
+  pnpm run sync -- wakatime cloudflare    Sync multiple sources
+  pnpm run sync -- all --dry-run          Preview without writing
 
 Migration Commands:
-  bun run migrate up                  Apply pending migrations
-  bun run migrate down                Rollback last migration
-  bun run migrate down --count 2      Rollback N migrations
-  bun run migrate status              Show migration status
-  bun run migrate verify              Verify checksums
+  pnpm run migrate -- up                  Apply pending migrations
+  pnpm run migrate -- down                Rollback last migration
+  pnpm run migrate -- down --count 2      Rollback N migrations
+  pnpm run migrate -- status              Show migration status
+  pnpm run migrate -- verify              Verify checksums
 
 Cleanup Command:
-  bun run cleanup                     Run retention cleanup
-  bun run cleanup --dry-run           Preview cleanup
+  pnpm run cleanup                     Run retention cleanup
+  pnpm run cleanup -- --dry-run       Preview cleanup
 
 Available Sources:
   - wakatime      WakaTime coding activity stats
@@ -36,9 +36,9 @@ Available Sources:
   - unsplash      Unsplash photo statistics
 
 Examples:
-  bun run sync all
-  bun run migrate up
-  bun run cleanup --dry-run
+  pnpm run sync -- all
+  pnpm run migrate -- up
+  pnpm run cleanup -- --dry-run
 
 For more information, visit: https://github.com/duyet/monorepo
 `);

--- a/apps/homelab/README.md
+++ b/apps/homelab/README.md
@@ -25,16 +25,16 @@ A beautiful monitoring dashboard for a 3-node minipc cluster, styled with Claude
 
 ```bash
 # Install dependencies
-bun install
+pnpm install
 
 # Run development server (port 3002)
-bun run dev
+pnpm run dev
 
 # Build for production
-bun run build
+pnpm run build
 
 # Start production server
-bun run start
+pnpm run start
 ```
 
 ## Color Palette
@@ -59,4 +59,3 @@ Currently displays mock data for demonstration purposes. To integrate with real 
 ---
 
 **This repository is maintained by [@duyetbot](https://github.com/duyetbot).**
-

--- a/apps/kb/content/data-pipeline/data-sync-overview.md
+++ b/apps/kb/content/data-pipeline/data-sync-overview.md
@@ -3,7 +3,7 @@ title: "Data Sync Overview"
 category: "data-pipeline"
 tags: ["data-sync", "ccusage", "wakatime", "pipeline"]
 links: ["insights-app", "llm-timeline-app", "blog-app"]
-summary: "data-sync ingests external data; CCUsage feeds insights, LLM models sync via bun run sync, blog posts are local markdown files."
+summary: "data-sync ingests external data; CCUsage feeds insights, LLM models sync via pnpm run sync, blog posts are local markdown files."
 updated: "2026-05-26"
 ---
 
@@ -14,7 +14,7 @@ The monorepo has a `packages/data-sync` package (13 tests) responsible for pulli
 ## LLM Timeline data sync
 
 ```bash
-bun run sync
+pnpm run sync
 ```
 
 Pulls from two sources:

--- a/apps/kb/content/data-pipeline/llm-timeline-data.md
+++ b/apps/kb/content/data-pipeline/llm-timeline-data.md
@@ -26,7 +26,7 @@ This data lives in `apps/llm-timeline/lib/data.ts`. It is **out of scope for duy
 ## Sync
 
 ```bash
-bun run sync
+pnpm run sync
 ```
 
 The last sync: 2026-03-25. Result: 3937 unique models (4 duplicates removed from the union of both sources).
@@ -37,7 +37,7 @@ The `packages/libs` dedup crate handles cross-source deduplication. The WASM ben
 
 ## Build-time usage
 
-During `bun build`, the LLM Timeline app reads the data from `lib/data.ts` (compiled-in) rather than fetching at runtime. There's no runtime API call for model data — it's baked into the pre-rendered pages.
+During `pnpm run build`, the LLM Timeline app reads the data from `lib/data.ts` (compiled-in) rather than fetching at runtime. There's no runtime API call for model data — it's baked into the pre-rendered pages.
 
 ## Badge classification
 

--- a/apps/kb/content/infrastructure/blog-wasm-prerender-ci.md
+++ b/apps/kb/content/infrastructure/blog-wasm-prerender-ci.md
@@ -9,7 +9,7 @@ updated: "2026-05-15"
 
 # Blog WASM Prerender CI Dependency
 
-The blog's markdown rendering pipeline uses a Rust-backed WASM crate (`packages/wasm/`). WASM artifacts are gitignored, so CI must build them before running `bun build` for the blog — or the prerender step silently skips most post routes.
+The blog's markdown rendering pipeline uses a Rust-backed WASM crate (`packages/wasm/`). WASM artifacts are gitignored, so CI must build them before running `pnpm run build` for the blog — or the prerender step silently skips most post routes.
 
 ## The failure mode
 
@@ -25,11 +25,11 @@ In the incident that surfaced this (before the fix), only 106 out of 720 pages w
 
 ## The fix in CI
 
-The deploy job for `matrix.app == 'blog'` now runs three extra steps before `bun build`:
+The deploy job for `matrix.app == 'blog'` now runs three extra steps before `pnpm run build`:
 
 1. `dtolnay/rust-toolchain@stable` — install Rust
 2. `jetli/wasm-pack-action` — install wasm-pack
-3. `bun run wasm:build:release` — compile all cdylib crates to `pkg/`
+3. `pnpm run wasm:build:release` — compile all cdylib crates to `pkg/`
 
 If a future app starts importing `@duyet/libs/markdownToHtml` at build time, extend the `matrix.app == 'blog'` guard to include it.
 

--- a/apps/kb/content/infrastructure/deploy-workflow.md
+++ b/apps/kb/content/infrastructure/deploy-workflow.md
@@ -9,14 +9,14 @@ updated: "2026-05-26"
 
 # Deploy Workflow
 
-Every app in the monorepo deploys to Cloudflare Pages. The deploy script is `scripts/cf-deploy-prod.sh`, invoked per-app as `bun run cf:deploy:prod`.
+Every app in the monorepo deploys to Cloudflare Pages. The deploy script is `scripts/cf-deploy-prod.sh`, invoked per-app as `pnpm run cf:deploy:prod`.
 
 ## Manual deploy pattern
 
 After committing and pushing:
 
 ```bash
-cd apps/<app> && bun run cf:deploy:prod
+cd apps/<app> && pnpm run cf:deploy:prod
 ```
 
 Always run deploys with `run_in_background: true` (in agent sessions) so the next task isn't blocked on Cloudflare's ~30–60 s upload time. Do NOT run two background deploys in parallel — `cf-deploy-prod.sh` renames `.env.local` to `.env.local.deploy-bak` during the run; parallel invocations collide on that rename and lose `CLOUDFLARE_API_TOKEN`.
@@ -27,8 +27,8 @@ The GitHub Actions workflow deploys on push to `master` using a matrix over all 
 
 1. `dtolnay/rust-toolchain@stable`
 2. `jetli/wasm-pack-action`
-3. `bun run wasm:build:release`
-4. `bun build` + deploy
+3. `pnpm run wasm:build:release`
+4. `pnpm run build` + deploy
 
 All other apps skip the Rust/WASM steps.
 

--- a/apps/kb/content/workflows/commit-push-deploy.md
+++ b/apps/kb/content/workflows/commit-push-deploy.md
@@ -14,7 +14,7 @@ Every completed task ends with three steps: commit, push, deploy.
 ```bash
 git commit -m "feat(blog): add copy dropdown"
 git push origin master
-cd apps/blog && bun run cf:deploy:prod  # run in background
+cd apps/blog && pnpm run cf:deploy:prod  # run in background
 ```
 
 ## Commit format
@@ -31,19 +31,19 @@ Semantic commits with a scope matching the changed app or package:
 
 ## commitlint constraints
 
-The `commit-msg` hook runs `bun commitlint` with two enforced rules:
+The `commit-msg` hook runs `pnpm exec commitlint` with two enforced rules:
 
 - **body-max-line-length: 100** — body lines must be ≤100 characters
 - **subject-case: lowercase** — description must be lowercase
 
 ## Pre-commit hook
 
-`bun run test` runs across all 14 packages before every commit. Cached runs take ~100 ms; uncached runs can cause a pipe buffer overflow that returns exit code 1 even when tests pass.
+`pnpm run test` runs the workspace test suite before every commit.
 
-**Always warm the cache before committing:**
+**If you want an early failure signal, run the suite manually before committing:**
 
 ```bash
-bun run test  # warm cache
+pnpm run test
 git commit ...
 ```
 
@@ -72,13 +72,13 @@ gh run list --branch master --event push --limit 5 \
 Run these before marking a multi-file task complete:
 
 ```bash
-bun run lint         # Biome lint
-bun run check-types  # TypeScript
-bun run test         # all packages
+pnpm run lint         # Biome lint
+pnpm run check-types  # TypeScript
+pnpm run test         # all packages
 ```
 
 For single-file changes:
 
 ```bash
-bunx biome lint <path>
+pnpm exec biome lint <path>
 ```

--- a/apps/kb/content/workflows/dead-code-cleanup.md
+++ b/apps/kb/content/workflows/dead-code-cleanup.md
@@ -48,7 +48,7 @@ git show --unified=3 <commit_sha>
 ## Verify dependency overrides
 
 ```bash
-bun pm why <package>
+pnpm why <package>
 ```
 
 ## Common scoped searches
@@ -58,7 +58,7 @@ bun pm why <package>
 rg -n "if (field ===" packages/libs --glob '*.ts'
 
 # Verify action pins in CI workflows
-rg -n "setup-bun@" .github/workflows -g'*.yml'
+rg -n "pnpm/action-setup@" .github/workflows -g'*.yml'
 rg -n "dtolnay/rust-toolchain@|jetli/wasm-pack-action@" .github/workflows -g'*.yml'
 ```
 

--- a/apps/kb/content/workflows/test-coverage.md
+++ b/apps/kb/content/workflows/test-coverage.md
@@ -1,15 +1,15 @@
 ---
 title: "Test Coverage by App"
 category: "workflows"
-tags: ["tests", "coverage", "bun", "quality"]
+tags: ["tests", "coverage", "pnpm", "quality"]
 links: ["commit-push-deploy", "dead-code-cleanup"]
-summary: "Test counts per package; agents leads at 142, libs at 117; total ~14 packages run in ~100ms cached via bun run test."
+summary: "Test counts per package; run the workspace suite from the repo root with pnpm."
 updated: "2026-05-26"
 ---
 
 # Test Coverage by App
 
-Tests run via `bun run test` at the monorepo root, covering all 14 packages. Cached runs take ~100 ms.
+Tests run via `pnpm run test` at the monorepo root.
 
 ## Current test counts
 
@@ -33,9 +33,9 @@ Tests run via `bun run test` at the monorepo root, covering all 14 packages. Cac
 
 ## Pre-commit behavior
 
-The pre-commit hook runs `bun run test`. An uncached run can cause a pipe buffer overflow that returns exit code 1 despite all tests passing.
+The pre-commit hook runs `pnpm run test`.
 
-**Mitigation:** run `bun run test` manually before committing to warm the Bun cache. Then commit. The hook's cached run will complete cleanly.
+If you want to validate before committing, run `pnpm run test` manually first.
 
 ## Adding tests
 

--- a/apps/llm-timeline/README.md
+++ b/apps/llm-timeline/README.md
@@ -24,10 +24,10 @@ Interactive timeline of Large Language Model releases from 2017 to present.
 
 ```bash
 cd apps/llm-timeline
-bun run dev      # Start dev server on port 3005
-bun run build    # Build for production
-bun run lint     # Run linter
-bun run check-types  # TypeScript type check
+pnpm run dev      # Start dev server on port 3005
+pnpm run build    # Build for production
+pnpm run lint     # Run linter
+pnpm run check-types  # TypeScript type check
 ```
 
 ## Adding Models
@@ -49,7 +49,7 @@ Edit `lib/data.ts` and add models to the `models` array following the type struc
 ## Deployment
 
 ```bash
-bun run cf:deploy:prod  # Deploy to Cloudflare Pages production
+pnpm run cf:deploy:prod  # Deploy to Cloudflare Pages production
 ```
 
 GitHub Actions automatically deploy on push to `master`.

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -10,6 +10,18 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 
 ## Durable Findings
 
+### 2026-06-03
+
+- Pnpm migration follow-up (warning -> fixed): Husky hooks still invoked Bun after the repo switched to pnpm, which would break local commits on machines without Bun.
+  - Fixed `.husky/commit-msg` to use `pnpm exec commitlint --edit "$1"` and `.husky/pre-commit` to use `pnpm run test`.
+  - Evidence: `.husky/commit-msg` contained `bun commitlint --edit $1`; `.husky/pre-commit` contained `bun run test`.
+- Workflow/doc drift cleanup (warning -> fixed): user-facing command/help surfaces still told contributors to use Bun in current pnpm-only paths.
+  - Fixed current instructions in `CLAUDE.md`, `apps/data-sync/src/{index.ts,commands/migrate.ts}`, `packages/{libs/native-cli.ts,wasm/index.ts,wasm/package.json}`, app READMEs/CLAUDE entrypoints, and KB workflow articles under `apps/kb/content/**`.
+  - Evidence: repo-wide scoped search over touched docs/code returned stale `bun run`, `bun install`, `bun build`, `bun pm why`, and `bunx biome` references before the patch; post-patch search on the edited surfaces left only the intentional `setup-bun` cleanup command in `CLAUDE.md`.
+- Dead-code review (confident): no new zero-reference code removal was justified in the scanned recent-change window.
+  - Evidence: migration-era `apps/photos/bun-test-setup.ts` is already gone on disk, and targeted non-test searches did not surface additional orphaned symbols in the touched code files.
+- Performance audit: no measured runtime or CI regression signal was available in this window, so no grounded performance fix was proposed.
+
 ### 2026-06-01
 
 - Deploy orchestrator fix (warning -> fixed): `scripts/cf-deploy.ts` now treats `bun.lock` as the repo's core dependency lockfile when deciding whether to rebuild all apps; the previous `bun.lockb` checks missed lockfile-only dependency updates in this Bun text-lockfile repo.

--- a/packages/libs/native-cli.ts
+++ b/packages/libs/native-cli.ts
@@ -15,7 +15,7 @@ interface CliResult<T> {
 function ensureBinary(): void {
   if (!existsSync(BINARY_PATH)) {
     throw new Error(
-      `duyet-cli binary not found at ${BINARY_PATH}. Run 'bun run rust:build' first.`
+      `duyet-cli binary not found at ${BINARY_PATH}. Run 'pnpm run rust:build' first.`
     )
   }
 }

--- a/packages/urls/src/duyet.urls.test.ts
+++ b/packages/urls/src/duyet.urls.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 // duyetUrls evaluates env at module load time, so we test the shape
 // and hardcoded fallbacks directly from the cached module.
 import { duyetUrls } from "./duyet.urls";
+import { createNavigation } from "./utils";
 
 describe("duyetUrls", () => {
   test("has apps sub-object", () => {
@@ -51,8 +52,7 @@ describe("duyetUrls", () => {
 });
 
 describe("duyetUrls navigation via createNavigation", () => {
-  test("produces valid navigation from duyetUrls", async () => {
-    const { createNavigation } = await import("./utils");
+  test("produces valid navigation from duyetUrls", () => {
     const profile = {
       personal: {
         name: "Duyet",

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -1,6 +1,6 @@
 // @duyet/wasm - Rust/WASM modules compiled via wasm-pack
 //
-// Build first: `bun run wasm:build` at repo root
+// Build first: `pnpm run wasm:build` at repo root
 //
 // Each crate under crates/ produces bindings in ./pkg/<crate-name>/
 // Import directly from the generated module:

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -5,7 +5,7 @@
   "main": "./index.ts",
   "scripts": {
     "build": "echo 'WASM modules built via cargo/wasm-pack at repo root'",
-    "test": "echo 'WASM tests run via cargo test — see bun run wasm:test'"
+    "test": "echo 'WASM tests run via cargo test — see pnpm run wasm:test'"
   },
   "devDependencies": {
     "@duyet/tsconfig": "*",


### PR DESCRIPTION
## Summary
- fix Husky hooks that still called Bun after the pnpm migration
- align current CLI help, repo entrypoints, and KB workflow docs with pnpm commands
- record the follow-up in `docs/ai/core-memory.md`

## Verification
- `git diff --check`
- `pnpm run test`
- scoped search confirmed the edited workflow surfaces no longer point at Bun commands