### PR TITLE
feat(home): add /fossil page summarizing Fossil Group chapter

### DIFF
--- a/apps/home/public/sitemap.xml
+++ b/apps/home/public/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://duyet.net/fossil</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://duyet.net/ls</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>

--- a/apps/home/src/routeTree.gen.ts
+++ b/apps/home/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ProjectsRouteImport } from './routes/projects'
 import { Route as LsRouteImport } from './routes/ls'
+import { Route as FossilRouteImport } from './routes/fossil'
 import { Route as AboutDuyetbotRouteImport } from './routes/about-duyetbot'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
@@ -24,6 +25,11 @@ const ProjectsRoute = ProjectsRouteImport.update({
 const LsRoute = LsRouteImport.update({
   id: '/ls',
   path: '/ls',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FossilRoute = FossilRouteImport.update({
+  id: '/fossil',
+  path: '/fossil',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AboutDuyetbotRoute = AboutDuyetbotRouteImport.update({
@@ -51,6 +57,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/about-duyetbot': typeof AboutDuyetbotRoute
+  '/fossil': typeof FossilRoute
   '/ls': typeof LsRoute
   '/projects': typeof ProjectsRoute
   '/p/$project': typeof PProjectRoute
@@ -59,6 +66,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/about-duyetbot': typeof AboutDuyetbotRoute
+  '/fossil': typeof FossilRoute
   '/ls': typeof LsRoute
   '/projects': typeof ProjectsRoute
   '/p/$project': typeof PProjectRoute
@@ -68,6 +76,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/about-duyetbot': typeof AboutDuyetbotRoute
+  '/fossil': typeof FossilRoute
   '/ls': typeof LsRoute
   '/projects': typeof ProjectsRoute
   '/p/$project': typeof PProjectRoute
@@ -78,16 +87,25 @@ export interface FileRouteTypes {
     | '/'
     | '/about'
     | '/about-duyetbot'
+    | '/fossil'
     | '/ls'
     | '/projects'
     | '/p/$project'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about' | '/about-duyetbot' | '/ls' | '/projects' | '/p/$project'
+  to:
+    | '/'
+    | '/about'
+    | '/about-duyetbot'
+    | '/fossil'
+    | '/ls'
+    | '/projects'
+    | '/p/$project'
   id:
     | '__root__'
     | '/'
     | '/about'
     | '/about-duyetbot'
+    | '/fossil'
     | '/ls'
     | '/projects'
     | '/p/$project'
@@ -97,6 +115,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
   AboutDuyetbotRoute: typeof AboutDuyetbotRoute
+  FossilRoute: typeof FossilRoute
   LsRoute: typeof LsRoute
   ProjectsRoute: typeof ProjectsRoute
   PProjectRoute: typeof PProjectRoute
@@ -116,6 +135,13 @@ declare module '@tanstack/react-router' {
       path: '/ls'
       fullPath: '/ls'
       preLoaderRoute: typeof LsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fossil': {
+      id: '/fossil'
+      path: '/fossil'
+      fullPath: '/fossil'
+      preLoaderRoute: typeof FossilRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about-duyetbot': {
@@ -153,6 +179,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
   AboutDuyetbotRoute: AboutDuyetbotRoute,
+  FossilRoute: FossilRoute,
   LsRoute: LsRoute,
   ProjectsRoute: ProjectsRoute,
   PProjectRoute: PProjectRoute,

--- a/apps/home/src/routes/fossil.tsx
+++ b/apps/home/src/routes/fossil.tsx
@@ -1,10 +1,22 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Eyebrow } from "@duyet/components";
+import { addUtmParams } from "../../app/lib/utm";
 
 const PERIOD = "Nov 2018 — Aug 2023";
 const TENURE = "4 yrs 10 mos";
 
-const posts = [
+interface Post {
+  title: string;
+  href: string;
+}
+
+interface Role {
+  title: string;
+  period: string;
+  body: string;
+}
+
+const posts: Post[] = [
   {
     title: "Fossil Data Platform Rewritten in Rust 🦀",
     href: "https://blog.duyet.net/2023/06/fossil-data-platform-written-rust",
@@ -19,7 +31,7 @@ const posts = [
   },
 ];
 
-const roles = [
+const roles: Role[] = [
   {
     title: "Senior Data Engineer",
     period: "Jan 2020 — Aug 2023",
@@ -87,9 +99,9 @@ function FossilPage() {
             {posts.map((p) => (
               <li key={p.href}>
                 <a
-                  href={p.href}
+                  href={addUtmParams(p.href, "fossil_page", "related_writing")}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="rd-ulink text-[14.5px] text-[var(--rd-text-2)]"
                 >
                   {p.title}

--- a/apps/home/src/routes/fossil.tsx
+++ b/apps/home/src/routes/fossil.tsx
@@ -1,0 +1,104 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Eyebrow } from "@duyet/components";
+
+const PERIOD = "Nov 2018 — Aug 2023";
+const TENURE = "4 yrs 10 mos";
+
+const posts = [
+  {
+    title: "Fossil Data Platform Rewritten in Rust 🦀",
+    href: "https://blog.duyet.net/2023/06/fossil-data-platform-written-rust",
+  },
+  {
+    title: "Spark on Kubernetes tại Fossil 🤔",
+    href: "https://blog.duyet.net/2022/03/spark-kubernetes-at-fossil",
+  },
+  {
+    title: "Why ClickHouse Should Be the Go-To Choice for Your Data Platform",
+    href: "https://blog.duyet.net/2023/01/clickhouse",
+  },
+];
+
+const roles = [
+  {
+    title: "Senior Data Engineer",
+    period: "Jan 2020 — Aug 2023",
+    body: "Led the data team — five engineers and three analysts. Cut Data Platform costs by 55% and started rebuilding the next generation in Rust.",
+  },
+  {
+    title: "Data Engineer",
+    period: "Nov 2018 — Jan 2020",
+    body: "Built core Data Platform components on Kubernetes, Airflow, and Spark, and proposed the Data Warehouse behind product insights.",
+  },
+];
+
+export const Route = createFileRoute("/fossil")({
+  component: FossilPage,
+  head: () => ({
+    meta: [
+      { title: "Fossil Group, Inc. — Duyet's chapter | duyet.net" },
+      {
+        name: "description",
+        content: `My ${TENURE} at Fossil Group, Inc. (${PERIOD}): from Data Engineer to leading the data team — cutting platform costs 55% and rebuilding it in Rust.`,
+      },
+    ],
+    links: [{ rel: "canonical", href: "https://duyet.net/fossil" }],
+  }),
+});
+
+function FossilPage() {
+  return (
+    <div className="page-enter bg-[var(--rd-bg)] text-[var(--rd-text)]">
+      <div className="mx-auto max-w-[640px] px-[var(--rd-pad)] pt-[clamp(40px,5vw,64px)] pb-[clamp(56px,8vw,96px)]">
+        <Eyebrow>
+          {PERIOD} · {TENURE}
+        </Eyebrow>
+        <h1 className="rd-display mt-[13px] text-[clamp(1.9rem,4vw,3rem)] leading-[1.04]">
+          <span className="text-[var(--rd-accent)]">Fossil Group</span>
+        </h1>
+        <p className="rd-lead mt-5 text-[clamp(1.02rem,1.4vw,1.15rem)] text-[var(--rd-text-2)]">
+          Nearly five years at Fossil Group, growing from Data Engineer to
+          leading the data team. I built and ran the Data Platform — Kubernetes,
+          Airflow, Spark, and ClickHouse — cut its running costs by more than
+          half, and started rebuilding the next generation in Rust. A good
+          place, a good team, and the chapter where I learned to scale data for
+          real.
+        </p>
+
+        <div className="mt-9 flex flex-col gap-5 border-t border-[var(--rd-border)] pt-7">
+          {roles.map((r) => (
+            <div key={r.title}>
+              <div className="flex flex-wrap items-baseline justify-between gap-x-3">
+                <h2 className="text-[1.1rem] tracking-[-0.02em]">{r.title}</h2>
+                <span className="font-[var(--font-mono)] text-[12px] text-[var(--rd-text-3)]">
+                  {r.period}
+                </span>
+              </div>
+              <p className="mt-1.5 text-[14.5px] leading-[1.55] text-[var(--rd-text-2)]">
+                {r.body}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-9 border-t border-[var(--rd-border)] pt-7">
+          <Eyebrow>Related writing</Eyebrow>
+          <ul className="mt-3 flex flex-col gap-2">
+            {posts.map((p) => (
+              <li key={p.href}>
+                <a
+                  href={p.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="rd-ulink text-[14.5px] text-[var(--rd-text-2)]"
+                >
+                  {p.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/home/src/routes/fossil.tsx
+++ b/apps/home/src/routes/fossil.tsx
@@ -16,6 +16,11 @@ interface Role {
   body: string;
 }
 
+interface Milestone {
+  label: string;
+  body: string;
+}
+
 const posts: Post[] = [
   {
     title: "Fossil Data Platform Rewritten in Rust 🦀",
@@ -35,12 +40,44 @@ const roles: Role[] = [
   {
     title: "Senior Data Engineer",
     period: "Jan 2020 — Aug 2023",
-    body: "Led the data team — five engineers and three analysts. Cut Data Platform costs by 55% and started rebuilding the next generation in Rust.",
+    body: "Data leader for a team of eight — five engineers and three analysts. Owned the platform end to end, drove the re-platforming for scale and cost, and cut Data Platform expenses by 55%.",
   },
   {
     title: "Data Engineer",
     period: "Nov 2018 — Jan 2020",
-    body: "Built core Data Platform components on Kubernetes, Airflow, and Spark, and proposed the Data Warehouse behind product insights.",
+    body: "Built and ran the core data platform on AWS, and proposed the data warehouse that became the foundation for product insights.",
+  },
+];
+
+// The technical story, oldest first.
+const journey: Milestone[] = [
+  {
+    label: "Collection on AWS",
+    body: "Node.js collectors streaming through Kinesis into S3, Lambda transforming data between zones, and serving queries from Athena and Redshift.",
+  },
+  {
+    label: "Streaming & storage upgrades",
+    body: "Moved ingestion from Kinesis Firehose to Kafka, and retuned data types for far better compression — real storage and cost savings.",
+  },
+  {
+    label: "Compute on Kubernetes",
+    body: "Migrated the batch workers onto EKS, processing at scale with Spark.",
+  },
+  {
+    label: "Rewritten in Rust",
+    body: "Re-built the platform end to end in Rust for another massive cost cut — faster, leaner, and cheaper to run.",
+  },
+  {
+    label: "Redshift → ClickHouse",
+    body: "Swapped the warehouse to ClickHouse on Kubernetes for fast serving, with Next.js dashboards on top.",
+  },
+  {
+    label: "A second platform on GCP",
+    body: "Stood up a parallel data platform on GCP to meet specific requirements.",
+  },
+  {
+    label: "Leading the team",
+    body: "Grew from engineer into leading the data team — hiring, mentoring, and setting the technical direction.",
   },
 ];
 
@@ -51,7 +88,7 @@ export const Route = createFileRoute("/fossil")({
       { title: "Fossil Group, Inc. — Duyet's chapter | duyet.net" },
       {
         name: "description",
-        content: `My ${TENURE} at Fossil Group, Inc. (${PERIOD}): from Data Engineer to leading the data team — cutting platform costs 55% and rebuilding it in Rust.`,
+        content: `My ${TENURE} at Fossil Group, Inc. (${PERIOD}): building the data platform from AWS collection to a Rust rewrite and ClickHouse, cutting costs 55%, and leading the team.`,
       },
     ],
     links: [{ rel: "canonical", href: "https://duyet.net/fossil" }],
@@ -70,11 +107,13 @@ function FossilPage() {
         </h1>
         <p className="rd-lead mt-5 text-[clamp(1.02rem,1.4vw,1.15rem)] text-[var(--rd-text-2)]">
           Nearly five years at Fossil Group, growing from Data Engineer to
-          leading the data team. I built and ran the Data Platform — Kubernetes,
-          Airflow, Spark, and ClickHouse — cut its running costs by more than
-          half, and started rebuilding the next generation in Rust. A good
-          place, a good team, and the chapter where I learned to scale data for
-          real.
+          leading the data team. I started on a Node.js data-collection platform
+          on AWS — Kinesis into S3, Lambda transforms, Athena and Redshift — and
+          spent the next few years making it faster, cheaper, and more reliable:
+          Kafka and Spark on Kubernetes, a full rewrite in Rust, and a move to
+          ClickHouse. Costs came down by more than half along the way. A good
+          place, a good team, and the chapter where I learned to scale data —
+          and to lead — for real.
         </p>
 
         <div className="mt-9 flex flex-col gap-5 border-t border-[var(--rd-border)] pt-7">
@@ -91,6 +130,27 @@ function FossilPage() {
               </p>
             </div>
           ))}
+        </div>
+
+        <div className="mt-9 border-t border-[var(--rd-border)] pt-7">
+          <Eyebrow>How the platform evolved</Eyebrow>
+          <ol className="mt-4 flex flex-col gap-4">
+            {journey.map((m, i) => (
+              <li key={m.label} className="flex gap-3">
+                <span className="font-[var(--font-mono)] text-[12px] text-[var(--rd-text-3)] pt-[3px] tabular-nums">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <div>
+                  <h3 className="text-[14.5px] font-medium tracking-[-0.01em]">
+                    {m.label}
+                  </h3>
+                  <p className="mt-1 text-[14px] leading-[1.55] text-[var(--rd-text-2)]">
+                    {m.body}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
         </div>
 
         <div className="mt-9 border-t border-[var(--rd-border)] pt-7">

--- a/packages/libs/getPost.ts
+++ b/packages/libs/getPost.ts
@@ -5,8 +5,13 @@ import { FileSystemError, ValidationError } from "./errors";
 import getSlug from "./getSlug";
 import { normalizeTag } from "./tags";
 
-const nodeFs = () => require("node:fs");
-const nodeJoin = () => require("node:path").join;
+// Access Node built-ins lazily and without a literal `require(...)` call.
+// Using `process.getBuiltinModule` keeps `node:fs`/`node:path` out of the
+// static import graph (so this module stays safe to include in browser
+// bundles), while avoiding the `require` token that makes Node's ESM/CJS
+// detector throw ERR_AMBIGUOUS_MODULE_SYNTAX under Node 24.
+const nodeFs = () => process.getBuiltinModule("node:fs");
+const nodeJoin = () => process.getBuiltinModule("node:path").join;
 const getPostsDirectory = () => nodeJoin()(process.cwd(), "_posts");
 
 const CACHED = new Map<string, string>();


### PR DESCRIPTION
## What

Adds a short, simple page at **duyet.net/fossil** summarizing my time at **Fossil Group, Inc.** (Nov 2018 – Aug 2023, 4 yrs 10 mos).

The page is intentionally minimal:
- A one-paragraph summary of what I did and how it was — built and ran the Data Platform (Kubernetes, Airflow, Spark, ClickHouse), cut its costs by 55%, started rebuilding the next gen in Rust.
- The two roles I held: **Data Engineer → Senior Data Engineer**, each with a one-line description.
- A small **Related writing** list linking the most relevant blog posts:
  - Fossil Data Platform Rewritten in Rust 🦀
  - Spark on Kubernetes tại Fossil 🤔
  - Why ClickHouse Should Be the Go-To Choice for Your Data Platform

## Notes

- **Not added to the site nav** (per request) — reachable directly at `/fossil` and added to `sitemap.xml`.
- Built with the existing redesign system (`--rd-*` tokens, `Eyebrow`, `rd-display`/`rd-lead`).
- `routeTree.gen.ts` regenerated by the TanStack Start plugin.

## Verification

- `pnpm exec biome lint` — clean
- `pnpm run check-types` — passes
- `pnpm run build` — `/fossil` prerenders successfully (6 pages crawled)

https://claude.ai/code/session_014SHpsucA1FY48thttT1XV3

---
_Generated by [Claude Code](https://claude.ai/code/session_014SHpsucA1FY48thttT1XV3)_

## Summary by Sourcery

Add a dedicated /fossil route describing the Fossil Group chapter of the author’s career and expose it as a standalone page.

New Features:
- Introduce a new Fossil Group career page at /fossil with summary text, role timeline, and related writing links.

Enhancements:
- Register the /fossil route in the generated TanStack router tree with proper metadata and canonical URL for SEO.

Documentation:
- Include the /fossil page in sitemap.xml so it is discoverable by search engines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Fossil page featuring a profile layout with roles organized by tenure period.
  * Included posts section with external links for additional resources.
  * Updated site sitemap for improved search engine discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/duyet/monorepo/pull/1173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->