### PR TITLE
fix(lib): restore Node 24-safe getPost loader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ For scoped reviews after the last run timestamp:
 - `git show --unified=3 <commit_sha>`
 - `pnpm why <package>` to verify dependency overrides resolve to the intended package version
 - `rg -n "pnpm-lock\\.yaml" scripts/cf-deploy.ts` to verify deploy-orchestrator full-rebuild detection matches the repo's real lockfile
+- `pnpm run cf:deploy -- --force` to rebuild all requested Cloudflare Pages apps when change detection is intentionally bypassed
 - `rg -n "<symbol>" <file-or-dir> --glob '!**/*.test.*' --glob '!**/__tests__/**'` for dead-reference evidence
 - `rg -n "pnpm/action-setup@" .github/workflows -g'*.yml'` to verify valid action pins after CI workflow updates
 - `rg -n "setup-bun" .github/workflows -g'*.yml'` to catch leftover Bun setup actions

--- a/apps/llm-timeline/scripts/sync-data.ts
+++ b/apps/llm-timeline/scripts/sync-data.ts
@@ -4,11 +4,11 @@
  * sync-data.ts — Pull LLM model data from registered sources and regenerate lib/data.ts
  *
  * Usage:
- *   bun scripts/sync-data.ts              # Fetch from all sources and write lib/data.ts
- *   bun scripts/sync-data.ts --dry-run    # Preview changes, don't write
- *   bun scripts/sync-data.ts --verbose    # Show column mapping and row details
- *   bun scripts/sync-data.ts --no-epoch   # Skip a source (auto-generated per source)
- *   bun scripts/sync-data.ts --help       # Show this help
+ *   pnpm run sync                         # Fetch from all sources and write lib/data.ts
+ *   pnpm run sync:dry                     # Preview changes and show verbose details
+ *   tsx scripts/sync-data.ts --verbose    # Show column mapping and row details
+ *   tsx scripts/sync-data.ts --no-epoch   # Skip a source (auto-generated per source)
+ *   tsx scripts/sync-data.ts --help       # Show this help
  */
 
 import { writeFileSync } from "node:fs";
@@ -44,7 +44,7 @@ if (showHelp) {
 sync-data.ts — Sync LLM model data to lib/data.ts
 
 Usage:
-  bun scripts/sync-data.ts [flags]
+  tsx scripts/sync-data.ts [flags]
 
 Flags:
   --dry-run         Print the generated output without writing the file

--- a/docs/ai/core-memory.md
+++ b/docs/ai/core-memory.md
@@ -10,6 +10,18 @@ This file stores durable outcomes from code-smell and dead-code automation runs.
 
 ## Durable Findings
 
+### 2026-06-05
+
+- Blog prebuild regression (warning -> fixed): `packages/libs/getPost.ts` had reverted from the earlier `process.getBuiltinModule(...)` Node 24-safe loader back to `createRequire(import.meta.url)`, reintroducing the same browser-bundle/ESM ambiguity path that `3caa801620d5e1d4216c8afb41ef49bb583d52df` had already fixed.
+  - Fixed `packages/libs/getPost.ts` by restoring the lazy `process.getBuiltinModule("node:fs" | "node:path")` access pattern.
+  - Evidence: `git show 3caa801620d5e1d4216c8afb41ef49bb583d52df -- packages/libs/getPost.ts`, `git show a581c86db4e0d0e0174b4cc07f34c9f8ac736382 -- packages/libs/getPost.ts`, and current `HEAD` file contents showed the regression.
+- Workflow/docs drift cleanup (info -> fixed): `scripts/cf-deploy.ts` supports `--force`, but its usage block and the repo automation docs did not mention it; `apps/llm-timeline/scripts/sync-data.ts` still advertised Bun commands after the repo moved to pnpm/tsx.
+  - Fixed the `cf-deploy` usage comments plus `CLAUDE.md`/`docs/ai/internal-knowledge.md`, and updated the `llm-timeline` sync script docstring/help text to match current pnpm/tsx usage.
+  - Evidence: `rg -n -- '--force|cf-deploy\\.ts \\[app-name\\]' scripts/cf-deploy.ts CLAUDE.md docs/ai/internal-knowledge.md` and `sed -n '1,120p' apps/llm-timeline/scripts/sync-data.ts`.
+- Dead-code review (confident): no new zero-reference dead-code candidates were justified in non-test files modified since the last run.
+  - Evidence: repo-wide non-test searches on the removal candidates from `091150f` showed live replacements for `SeriesNav` and zero remaining imports for removed `YearList`; no additional touched symbols collapsed to declaration-only references.
+- Performance audit: no measured runtime or CI-duration regression signal was available in this scan window, so no grounded performance fix was proposed.
+
 ### 2026-06-03
 
 - Pnpm migration follow-up (warning -> fixed): Husky hooks still invoked Bun after the repo switched to pnpm, which would break local commits on machines without Bun.

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -23,6 +23,7 @@ This repository is the pnpm/Turborepo monorepo for duyet.net public apps, shared
 - `pnpm run deploy` builds deployable apps, then runs workspace config.
 - `pnpm run cf:deploy` deploys changed Cloudflare Pages apps.
 - `pnpm run cf:deploy:prod` runs production Cloudflare deploy tasks through Turbo.
+- `pnpm run cf:deploy -- --force` bypasses git-based change detection and rebuilds all requested Cloudflare Pages apps.
 - `pnpm run wasm:build` builds all Rust crates to WASM via `wasm-pack`.
 - `pnpm run wasm:build:release` builds WASM with optimizations.
 - `pnpm run wasm:test` runs `cargo test` across the Rust workspace.

--- a/packages/libs/getPost.ts
+++ b/packages/libs/getPost.ts
@@ -5,13 +5,12 @@ import { FileSystemError, ValidationError } from "./errors";
 import getSlug from "./getSlug";
 import { normalizeTag } from "./tags";
 
-import { createRequire } from "node:module";
-const customRequire = createRequire(import.meta.url);
-
-const nodeFs = () => customRequire("node:fs");
-const nodeJoin = () => customRequire("node:path").join;
+// Access Node built-ins lazily without a literal require() token.
+// This keeps the module browser-bundle safe and avoids Node 24's
+// ESM/CJS ambiguity detection that previously broke blog prebuilds.
+const nodeFs = () => process.getBuiltinModule("node:fs");
+const nodeJoin = () => process.getBuiltinModule("node:path").join;
 const getPostsDirectory = () => nodeJoin()(process.cwd(), "_posts");
-
 
 const CACHED = new Map<string, string>();
 const MAX_CACHE_SIZE = 500;

--- a/scripts/cf-deploy.ts
+++ b/scripts/cf-deploy.ts
@@ -3,11 +3,12 @@
 /**
  * Comprehensive Cloudflare Pages Deployment Orchestrator
  *
- * Usage: tsx cf-deploy.ts [app-name] [--prod] [--dry-run]
+ * Usage: tsx cf-deploy.ts [app-name] [--prod] [--dry-run] [--force]
  *
  * Options:
  *   --prod     Deploy to production (main branch, custom domains)
  *   --dry-run  Show what would be deployed without making changes
+ *   --force    Skip change detection and rebuild all requested deploy targets
  *
  * Deploys all apps (or specific app) to Cloudflare Pages with proper orchestration:
  * 1. Build phase: Build all apps in parallel


### PR DESCRIPTION
## Summary
- restore the Node 24-safe builtin loading path in `packages/libs/getPost.ts`
- document the supported `cf:deploy -- --force` workflow in repo instructions
- refresh durable maintenance memory and llm-timeline sync usage text

## Verification
- `pnpm exec biome lint packages/libs/getPost.ts scripts/cf-deploy.ts apps/llm-timeline/scripts/sync-data.ts CLAUDE.md docs/ai/internal-knowledge.md docs/ai/core-memory.md`
- `pnpm exec vitest run packages/libs/getPost.test.ts` *(blocked in this worktree: `vitest` not installed)*

## Summary by Sourcery

Restore a Node 24-safe blog post loader and align deployment and sync script documentation with current workflows.

Bug Fixes:
- Fix blog post loading by reverting getPost to a Node 24-compatible lazy builtin module access pattern to avoid ESM/CJS ambiguity in prebuilds.

Enhancements:
- Clarify Cloudflare deploy orchestration script usage by documenting the --force option and its behavior.
- Update the LLM timeline data sync script help text to reflect current tsx-based invocation.

Documentation:
- Record the regression and fixes in the durable core-memory log, including details on getPost, cf-deploy, and sync-data workflows.
- Document the cf:deploy -- --force workflow in internal knowledge and AI assistant guidance docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Node/Bundler compatibility issue affecting core library functionality.

* **Documentation**
  * Updated CLI help for deployment commands to document the `--force` flag for rebuilding apps.
  * Updated contributor documentation and internal knowledge records.

* **Chores**
  * Updated script execution examples to use tsx.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->