### PR TITLE
feat(home): upgrade hero diagram to interactive 3d scene

### DIFF
--- a/apps/home/app/globals.css
+++ b/apps/home/app/globals.css
@@ -15,3 +15,20 @@
     overflow: hidden;
   }
 }
+
+@layer components {
+  /* 3D HeroDiagram — the R3F <Canvas> should fill .rd-hero-art */
+  .rd-hero-art canvas {
+    position: absolute;
+    inset: 0;
+    width: 100% !important;
+    height: 100% !important;
+  }
+  /* Make the existing .rd-hero-art absolute-SVG rule not collide with the 3D canvas. */
+  .rd-hero-art > svg.hd-svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -23,6 +23,8 @@
     "@duyet/libs": "*",
     "@duyet/urls": "*",
     "@phosphor-icons/react": "^2.1.10",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
     "class-variance-authority": "^0.7.1",
@@ -31,7 +33,8 @@
     "lucide-react": "^1.0.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@duyet/tailwind-config": "*",

--- a/apps/home/src/components/HeroDiagram3D.tsx
+++ b/apps/home/src/components/HeroDiagram3D.tsx
@@ -1,0 +1,557 @@
+import { Canvas, useThree } from "@react-three/fiber";
+import { Float, Html, Line, OrbitControls } from "@react-three/drei";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import * as THREE from "three";
+
+// ---------------------------------------------------------------------------
+// Data — same shape as the 2D HeroDiagram so the diagram stays consistent.
+// Nodes are now placed on a sphere using spherical coordinates (phi, theta, r)
+// instead of 2D polar (a, r). Edges are identical.
+// ---------------------------------------------------------------------------
+
+type NodeKind = "ai" | "data" | "infra";
+
+type NodeDef = {
+  id: string;
+  t: string;
+  kind: NodeKind;
+  slug?: string; // simpleicons slug (light variant)
+  dc?: string; // simpleicons dark hex
+  lc?: string; // simpleicons light hex (brand color override)
+  icon?: string; // custom icon URL (overrides slug)
+  url?: string; // clickable link target
+  phi: number; // azimuthal angle in degrees (around Y)
+  theta: number; // polar angle in degrees (from +Y)
+  r: number; // radius
+};
+
+// Front-facing positions: pulled toward the camera so the user sees them
+// centered on screen. (x,y) is the screen-space offset, z is depth in front of
+// the camera (camera is at +z, so negative z = in front of center).
+// phi/theta are still filled in by the fibonacci block below for the shell nodes.
+const FRONT_FACING: Record<string, [number, number, number]> = {
+  mcp: [0, 2.6, -3.0],
+  langgraph: [-2.0, 1.3, -2.5],
+  llamaindex: [2.0, 1.3, -2.5],
+  cloudflare: [-2.2, -0.2, -3.5],
+  anyrouter: [0, 0.4, -4.0],
+  workers: [2.2, -0.2, -3.5],
+  workflow: [-1.4, -1.7, -3.0],
+  airflow: [1.4, -1.7, -3.0],
+  clickhouse: [0, -2.8, -2.5],
+};
+
+const nodes: NodeDef[] = [
+  // Data Platform — center anchor
+  { id: "dataplatform", t: "Data Platform", kind: "data", phi: 0, theta: 90, r: 3.0 },
+  // AI / agents
+  { id: "claude", t: "Claude", kind: "ai", slug: "anthropic", url: "https://anthropic.com", phi: 0, theta: 0, r: 0 },
+  { id: "mcp", t: "Duyet MCP", kind: "ai", slug: "modelcontextprotocol", url: "https://modelcontextprotocol.io", phi: 0, theta: 0, r: 0 },
+  { id: "langgraph", t: "LangGraph", kind: "ai", slug: "langchain", url: "https://langchain.com", phi: 0, theta: 0, r: 0 },
+  { id: "llamaindex", t: "LlamaIndex", kind: "ai", url: "https://llamaindex.ai", phi: 0, theta: 0, r: 0 },
+  { id: "opencode", t: "OpenCode", kind: "ai", url: "https://opencode.ai", phi: 0, theta: 0, r: 0 },
+  { id: "anyrouter", t: "AnyRouter", kind: "ai", icon: "https://anyrouter.dev/brand/anyrouter-logo.svg", url: "https://anyrouter.dev", phi: 0, theta: 0, r: 0 },
+  { id: "openrouter", t: "OpenRouter", kind: "ai", slug: "openrouter", url: "https://openrouter.ai", phi: 0, theta: 0, r: 0 },
+  { id: "aisdk", t: "AI SDK", kind: "ai", slug: "vercel", url: "https://sdk.vercel.ai", phi: 0, theta: 0, r: 0 },
+  // Infra
+  { id: "k8s", t: "Kubernetes", kind: "infra", slug: "kubernetes", url: "https://kubernetes.io", phi: 0, theta: 0, r: 0 },
+  { id: "cloudflare", t: "Cloudflare", kind: "infra", slug: "cloudflare", url: "https://cloudflare.com", phi: 0, theta: 0, r: 0 },
+  { id: "workers", t: "Workers", kind: "infra", slug: "cloudflareworkers", url: "https://workers.cloudflare.com", phi: 0, theta: 0, r: 0 },
+  { id: "cfagents", t: "CF Agents", kind: "infra", slug: "cloudflare", url: "https://developers.cloudflare.com/agents", phi: 0, theta: 0, r: 0 },
+  { id: "workflow", t: "Workflow", kind: "infra", slug: "cloudflareworkers", url: "https://developers.cloudflare.com/workflows", phi: 0, theta: 0, r: 0 },
+  // Data tooling
+  { id: "airflow", t: "Airflow", kind: "data", slug: "apacheairflow", url: "https://airflow.apache.org", phi: 0, theta: 0, r: 0 },
+  { id: "duckdb", t: "DuckDB", kind: "data", slug: "duckdb", url: "https://duckdb.org", phi: 0, theta: 0, r: 0 },
+  { id: "spark", t: "Spark", kind: "data", slug: "apachespark", url: "https://spark.apache.org", phi: 0, theta: 0, r: 0 },
+  { id: "clickhouse", t: "ClickHouse", kind: "data", slug: "clickhouse", lc: "C28800", url: "https://clickhouse.com", phi: 0, theta: 0, r: 0 },
+  { id: "kafka", t: "Kafka", kind: "data", slug: "apachekafka", lc: "231F20", url: "https://kafka.apache.org", phi: 0, theta: 0, r: 0 },
+  { id: "qdrant", t: "Qdrant", kind: "data", slug: "qdrant", url: "https://qdrant.tech", phi: 0, theta: 0, r: 0 },
+  { id: "firecrawl", t: "Firecrawl", kind: "data", url: "https://firecrawl.dev", phi: 0, theta: 0, r: 0 },
+];
+
+const byId = Object.fromEntries(nodes.map((n) => [n.id, n] as const));
+
+const edges: [string, string][] = [
+  // Claude → its agent ecosystem
+  ["claude", "mcp"],
+  ["claude", "langgraph"],
+  ["claude", "llamaindex"],
+  ["claude", "anyrouter"],
+  ["claude", "opencode"],
+  ["claude", "aisdk"],
+  ["claude", "dataplatform"],
+  // Duyet MCP → the runtimes that consume it
+  ["mcp", "opencode"],
+  ["mcp", "langgraph"],
+  ["mcp", "aisdk"],
+  // model routing
+  ["anyrouter", "openrouter"],
+  ["openrouter", "aisdk"],
+  ["anyrouter", "aisdk"],
+  ["langgraph", "aisdk"],
+  ["langgraph", "llamaindex"],
+  // Data Platform → data tooling + internal data flow
+  ["dataplatform", "airflow"],
+  ["dataplatform", "duckdb"],
+  ["dataplatform", "spark"],
+  ["dataplatform", "clickhouse"],
+  ["dataplatform", "kafka"],
+  ["dataplatform", "k8s"],
+  ["airflow", "spark"],
+  ["kafka", "clickhouse"],
+  ["spark", "clickhouse"],
+  ["dataplatform", "qdrant"],
+  ["qdrant", "clickhouse"],
+  ["qdrant", "duckdb"],
+  ["dataplatform", "firecrawl"],
+  ["firecrawl", "langgraph"],
+  ["firecrawl", "qdrant"],
+  // Cloudflare → infra
+  ["cloudflare", "workers"],
+  ["cloudflare", "cfagents"],
+  ["cfagents", "workers"],
+  ["cloudflare", "k8s"],
+  ["workers", "aisdk"],
+];
+
+// ---------------------------------------------------------------------------
+// Geometry helpers
+// ---------------------------------------------------------------------------
+
+const TAU = Math.PI / 180;
+
+// Distribute non-anchor, non-front-facing nodes evenly across a sphere via
+// fibonacci spiral so the visual radius is consistent. Per-node radius gets a
+// tiny ±0.25 jitter for a touch of organic variance. dataplatform stays as
+// the inner anchor; FRONT_FACING entries are pinned in front of the camera.
+{
+  // Convert FRONT_FACING [x,y,z] into spherical (phi, theta, r) so posOf()
+  // can resolve them through the same code path as shell nodes.
+  for (const [id, p] of Object.entries(FRONT_FACING)) {
+    const r = Math.hypot(p[0], p[1], p[2]);
+    const theta = Math.acos(p[1] / r);
+    const phi = Math.atan2(p[2], p[0]);
+    const n = byId[id];
+    n.phi = ((phi / TAU) % 360 + 360) % 360;
+    n.theta = (theta / TAU) % 360;
+    n.r = r;
+  }
+
+  const shellNodes = nodes.filter(
+    (n) => n.id !== "dataplatform" && !(n.id in FRONT_FACING),
+  );
+  const SHELL_N = shellNodes.length;
+  const OUTER_R = 6.5;
+  const JITTER = 0.25;
+  const fibAngle = Math.PI * (3 - Math.sqrt(5));
+  for (let i = 0; i < SHELL_N; i++) {
+    const n = shellNodes[i];
+    const t = i + 0.5;
+    const y = 1 - (2 * t) / SHELL_N;
+    const phi = (i * fibAngle) % (Math.PI * 2);
+    const theta = Math.acos(y);
+    n.phi = (phi / TAU) % 360;
+    n.theta = (theta / TAU) % 360;
+    n.r = OUTER_R + (((i * 7) % 5) - 2) * JITTER;
+  }
+}
+
+function spherical(phi: number, theta: number, r: number): [number, number, number] {
+  const p = phi * TAU;
+  const t = theta * TAU;
+  return [
+    r * Math.sin(t) * Math.cos(p),
+    r * Math.cos(t),
+    r * Math.sin(t) * Math.sin(p),
+  ];
+}
+
+function posOf(id: string): [number, number, number] {
+  const n = byId[id];
+  return spherical(n.phi, n.theta, n.r);
+}
+
+// Color palette — matches the 2D diagram's CSS variables
+const palette = {
+  ai: {
+    line: "#b54a1f",
+    glow: "#f59568",
+    node: "#b54a1f",
+    label: "#b54a1f",
+  },
+  data: {
+    line: "#8c8b85",
+    glow: "#74736e",
+    node: "#0c0c0c",
+    label: "#0c0c0c",
+  },
+  infra: {
+    line: "#a8a7a1",
+    glow: "#74736e",
+    node: "#8c8b85",
+    label: "#8c8b85",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 3D Node — billboard HTML label (logo + text) anchored in 3D space
+// ---------------------------------------------------------------------------
+
+function Node({ data, reduceMotion }: { data: NodeDef; reduceMotion: boolean }) {
+  const [pos] = useState(() => posOf(data.id));
+  const labelColor = palette[data.kind].label;
+  const hasIcon = !!data.icon || !!data.slug;
+
+  return (
+    <Float
+      speed={reduceMotion ? 0 : 1.2}
+      rotationIntensity={0}
+      floatIntensity={reduceMotion ? 0 : 0.4}
+      floatingRange={[-0.05, 0.05]}
+    >
+      <Html
+        position={pos}
+        center
+        distanceFactor={8}
+        style={{ pointerEvents: "auto", userSelect: "none" }}
+      >
+        {data.url ? (
+          <a
+            href={data.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hd-pill"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "5px",
+              fontSize: "11px",
+              fontWeight: 500,
+              letterSpacing: "0.01em",
+              color: labelColor,
+              background: "var(--rd-surface, #ffffff)",
+              border: "1px solid var(--rd-border-2, #e8e8e6)",
+              borderRadius: "999px",
+              padding: "3px 9px 3px 7px",
+              whiteSpace: "nowrap",
+              fontFamily: "var(--font-sans, system-ui)",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+              textDecoration: "none",
+              transition: "transform 0.15s, box-shadow 0.15s",
+            }}
+          >
+            {hasIcon ? <NodeIcon data={data} /> : null}
+            {data.t}
+          </a>
+        ) : (
+          <span
+            className="hd-pill"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "5px",
+              fontSize: "11px",
+              fontWeight: 500,
+              letterSpacing: "0.01em",
+              color: labelColor,
+              background: "var(--rd-surface, #ffffff)",
+              border: "1px solid var(--rd-border-2, #e8e8e6)",
+              borderRadius: "999px",
+              padding: "3px 9px 3px 7px",
+              whiteSpace: "nowrap",
+              fontFamily: "var(--font-sans, system-ui)",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.04)",
+            }}
+          >
+            {hasIcon ? <NodeIcon data={data} /> : null}
+            {data.t}
+          </span>
+        )}
+      </Html>
+    </Float>
+  );
+}
+
+function NodeIcon({ data }: { data: NodeDef }) {
+  // Custom icon (e.g. AnyRouter) wins over simpleicons.
+  if (data.icon) {
+    return (
+      <img
+        src={data.icon}
+        alt=""
+        width={11}
+        height={11}
+        style={{ display: "block", flexShrink: 0 }}
+      />
+    );
+  }
+  if (!data.slug) return null;
+  // Use simpleicons auto-color for light + dark so it matches the theme.
+  const light = `https://cdn.simpleicons.org/${data.slug}${data.lc ? `/${data.lc}` : ""}`;
+  const dark = `https://cdn.simpleicons.org/${data.slug}/${data.dc || "f0f0f0"}`;
+  return (
+    <>
+      <img
+        src={light}
+        alt=""
+        width={11}
+        height={11}
+        className="hd-il"
+        style={{ display: "block", flexShrink: 0 }}
+      />
+      <img
+        src={dark}
+        alt=""
+        width={11}
+        height={11}
+        className="hd-id"
+        style={{ display: "none", flexShrink: 0 }}
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 3D Edge — curved line through a midpoint above the chord
+// ---------------------------------------------------------------------------
+
+function Edge({
+  a,
+  b,
+  kind,
+}: {
+  a: [number, number, number];
+  b: [number, number, number];
+  kind: NodeKind;
+}) {
+  const mid: [number, number, number] = useMemo(() => {
+    const m: [number, number, number] = [
+      (a[0] + b[0]) / 2,
+      (a[1] + b[1]) / 2,
+      (a[2] + b[2]) / 2,
+    ];
+    // Push the midpoint outward from the origin to arc the line.
+    const len = Math.hypot(m[0], m[1], m[2]) || 1;
+    const lift = 1.18;
+    return [
+      (m[0] / len) * len * lift,
+      (m[1] / len) * len * lift,
+      (m[2] / len) * len * lift,
+    ];
+  }, [a, b]);
+
+  const curve = useMemo(
+    () =>
+      new THREE.CatmullRomCurve3(
+        [
+          new THREE.Vector3(...a),
+          new THREE.Vector3(...mid),
+          new THREE.Vector3(...b),
+        ],
+        false,
+        "centripetal",
+      ),
+    [a, mid, b],
+  );
+
+  const points = useMemo(() => curve.getPoints(32), [curve]);
+
+  return (
+    <Line
+      points={points}
+      color={palette[kind].line}
+      lineWidth={1.4}
+      transparent
+      opacity={0.55}
+      dashed
+      dashSize={0.18}
+      gapSize={0.32}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Decorative rings — concentric circles in the equatorial plane
+// ---------------------------------------------------------------------------
+
+function Rings() {
+  const ringPoints = useMemo(() => {
+    const radii = [2.4, 4.4, 6.5];
+    const pts: [number, number, number][] = [];
+    const segments = 96;
+    for (const r of radii) {
+      const ring: [number, number, number][] = [];
+      for (let i = 0; i <= segments; i++) {
+        const a = (i / segments) * Math.PI * 2;
+        ring.push([Math.cos(a) * r, 0, Math.sin(a) * r]);
+      }
+      pts.push(...ring);
+    }
+    return pts;
+  }, []);
+
+  return (
+    <>
+      {[0, 1, 2].map((i) => (
+        <Line
+          key={i}
+          points={ringPoints.slice(i * 97, (i + 1) * 97)}
+          color="var(--rd-border-2, #e8e8e6)"
+          lineWidth={0.8}
+          transparent
+          opacity={0.35 - i * 0.08}
+          dashed
+          dashSize={0.1}
+          gapSize={0.4}
+        />
+      ))}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scene — the inner R3F graph
+// ---------------------------------------------------------------------------
+
+function Scene({ reduceMotion }: { reduceMotion: boolean }) {
+  const { gl } = useThree();
+  useEffect(() => {
+    gl.setClearColor(0x000000, 0);
+  }, [gl]);
+
+  return (
+    <>
+      {/* Lighting */}
+      <ambientLight intensity={0.65} />
+      <directionalLight position={[8, 10, 6]} intensity={0.9} color="#ffffff" />
+      <directionalLight position={[-6, -4, -8]} intensity={0.35} color="#b54a1f" />
+      <pointLight position={[0, 0, 0]} intensity={0.4} color="#f59568" distance={6} />
+
+      <Rings />
+
+      {/* Edges first (so nodes render on top) */}
+      {edges.map(([s, d], i) => {
+        const kind = byId[d]?.kind ?? byId[s]?.kind ?? "infra";
+        return <Edge key={`e${i}`} a={posOf(s)} b={posOf(d)} kind={kind as NodeKind} />;
+      })}
+
+      {/* Nodes */}
+      {nodes.map((n) => (
+        <Node key={n.id} data={n} reduceMotion={reduceMotion} />
+      ))}
+
+      <OrbitControls
+        enablePan={true}
+        enableZoom={true}
+        enableRotate={true}
+        enableDamping
+        dampingFactor={0.08}
+        rotateSpeed={0.6}
+        zoomSpeed={0.6}
+        panSpeed={0.4}
+        minDistance={4}
+        maxDistance={18}
+        autoRotate={false}
+        makeDefault
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public component — Canvas wrapper with reduced-motion detection
+// ---------------------------------------------------------------------------
+
+export function HeroDiagram3D() {
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia?.("(prefers-reduced-motion: reduce)");
+    if (mq) {
+      setReduceMotion(mq.matches);
+      const handler = (e: MediaQueryListEvent) => setReduceMotion(e.matches);
+      mq.addEventListener("change", handler);
+      return () => mq.removeEventListener("change", handler);
+    }
+    return undefined;
+  }, []);
+
+  return (
+    <div
+      className="rd-hero-art"
+      aria-hidden="true"
+      style={{ position: "relative", width: "100%", height: "100%", minHeight: 360 }}
+    >
+      <Canvas
+        camera={{ position: [0, 3, 12], fov: 45, near: 0.1, far: 100 }}
+        dpr={[1, 1.75]}
+        gl={{ antialias: true, alpha: true, powerPreference: "high-performance" }}
+        onCreated={() => setReady(true)}
+        style={{ width: "100%", height: "100%" }}
+      >
+        <Suspense fallback={null}>
+          <Scene reduceMotion={reduceMotion} />
+        </Suspense>
+      </Canvas>
+
+      {/* Hint badge — only while the scene is loading and motion is allowed */}
+      {!ready && !reduceMotion ? (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "grid",
+            placeItems: "center",
+            color: "var(--rd-text-3, #8c8b85)",
+            fontSize: 12,
+            fontFamily: "var(--font-sans, system-ui)",
+            pointerEvents: "none",
+          }}
+        >
+          loading 3d…
+        </div>
+      ) : null}
+
+      {/* Subtle control hint, fades out after first interaction */}
+      <ControlHint reduceMotion={reduceMotion} />
+    </div>
+  );
+}
+
+function ControlHint({ reduceMotion }: { reduceMotion: boolean }) {
+  const [visible, setVisible] = useState(true);
+  useEffect(() => {
+    if (reduceMotion) {
+      setVisible(false);
+      return;
+    }
+    const t = setTimeout(() => setVisible(false), 5500);
+    return () => clearTimeout(t);
+  }, [reduceMotion]);
+  if (reduceMotion) return null;
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: 12,
+        bottom: 10,
+        display: "flex",
+        gap: 10,
+        fontSize: 10.5,
+        color: "var(--rd-text-3, #8c8b85)",
+        fontFamily: "var(--font-sans, system-ui)",
+        opacity: visible ? 0.75 : 0,
+        transition: "opacity .6s ease",
+        pointerEvents: "none",
+        userSelect: "none",
+      }}
+    >
+      <span>drag to rotate</span>
+      <span style={{ opacity: 0.5 }}>·</span>
+      <span>scroll to zoom</span>
+      <span style={{ opacity: 0.5 }}>·</span>
+      <span>right-drag to pan</span>
+    </div>
+  );
+}

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -10,7 +10,7 @@ import { SecHead, Eyebrow, Reveal } from "@duyet/components";
 import { SignalBar } from "../components/SignalBar";
 import { WorkBento } from "../components/WorkBento";
 import { BlogTeaser } from "../components/BlogTeaser";
-import { HeroDiagram } from "../components/HeroDiagram";
+import { HeroDiagram3D as HeroDiagram } from "../components/HeroDiagram3D";
 import { NowDeco } from "../components/NowDeco";
 
 export const Route = createFileRoute("/")({

--- a/packages/components/SiteHeader.tsx
+++ b/packages/components/SiteHeader.tsx
@@ -521,7 +521,7 @@ export function SiteHeader({
   return (
     <header
       className={cn(
-        "sticky top-0 z-40 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+        "sticky top-0 z-[999] w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
         className,
       )}
     >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,12 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@react-three/drei':
+        specifier: ^10.7.7
+        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0))(@types/react@19.2.16)(@types/three@0.184.1)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)
+      '@react-three/fiber':
+        specifier: ^9.6.1
+        version: 9.6.1(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)
       '@tanstack/react-router':
         specifier: ^1.0.0
         version: 1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -711,6 +717,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.6.0
+      three:
+        specifier: ^0.184.0
+        version: 0.184.0
     devDependencies:
       '@duyet/tailwind-config':
         specifier: '*'
@@ -1885,6 +1894,9 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
   '@duckdb/node-api@1.5.2-r.2':
     resolution: {integrity: sha512-IqFeTarPL9sImt8R6Y/NbNjTR95c7fksk9uFCpFLV0hxbIzbNCCF//xy2BgBqVJtU7/gk2eIpTJTvtE6FS2eog==}
 
@@ -2889,6 +2901,9 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
+  '@mediapipe/tasks-vision@0.10.17':
+    resolution: {integrity: sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==}
+
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
@@ -2901,6 +2916,11 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@monogrid/gainmap-js@3.4.0':
+    resolution: {integrity: sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==}
+    peerDependencies:
+      three: '>= 0.159.0'
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -3737,6 +3757,42 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
+  '@react-three/drei@10.7.7':
+    resolution: {integrity: sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==}
+    peerDependencies:
+      '@react-three/fiber': ^9.0.0
+      react: ^19
+      react-dom: ^19
+      three: '>=0.159'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  '@react-three/fiber@9.6.1':
+    resolution: {integrity: sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   '@react-types/shared@3.35.0':
     resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
     peerDependencies:
@@ -4340,6 +4396,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -4448,6 +4507,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/draco3d@1.4.10':
+    resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -4478,10 +4540,18 @@ packages:
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/react@19.2.16':
     resolution: {integrity: sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==}
@@ -4491,6 +4561,12 @@ packages:
 
   '@types/sanitize-html@2.16.1':
     resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.184.1':
+    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -4504,6 +4580,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -4515,6 +4594,14 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@use-gesture/core@10.3.1':
+    resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}
+
+  '@use-gesture/react@10.3.1':
+    resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
+    peerDependencies:
+      react: '>= 16.8.0'
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -4787,6 +4874,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
@@ -4811,6 +4901,9 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -4841,6 +4934,12 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camera-controls@3.1.2:
+    resolution: {integrity: sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==}
+    engines: {node: '>=22.0.0', npm: '>=10.5.1'}
+    peerDependencies:
+      three: '>=0.126.1'
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
@@ -5060,6 +5159,11 @@ packages:
   cron-schedule@6.0.0:
     resolution: {integrity: sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==}
     engines: {node: '>=20'}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -5287,6 +5391,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-gpu@5.0.70:
+    resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -5345,6 +5452,9 @@ packages:
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
 
   duckdb-async@1.4.2:
     resolution: {integrity: sha512-qzF144DQ/zKCva6arzvT8xY7uuWGHtrX7dxHpxuQut3hkuJqoNBz2h7SBFobKpBnZ1/+nP/UwCL+BI7o0WVKdw==}
@@ -5572,6 +5682,12 @@ packages:
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
+  fflate@0.6.10:
+    resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -5684,6 +5800,9 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  glsl-noise@0.0.0:
+    resolution: {integrity: sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -5782,6 +5901,9 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  hls.js@1.6.16:
+    resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
+
   hono@4.12.23:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
@@ -5835,6 +5957,9 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
@@ -5935,6 +6060,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -5960,6 +6088,11 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -6076,6 +6209,9 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -6209,6 +6345,12 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  maath@0.10.8:
+    resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
+    peerDependencies:
+      '@types/three': '>=0.134.0'
+      three: '>=0.134.0'
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -6309,6 +6451,14 @@ packages:
 
   mermaid@11.15.0:
     resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+
+  meshline@3.3.1:
+    resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
+    peerDependencies:
+      three: '>=0.137'
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -6778,6 +6928,9 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@1.0.2:
+    resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
+
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
@@ -6798,6 +6951,9 @@ packages:
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
+
+  promise-worker-transferable@1.0.4:
+    resolution: {integrity: sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -6944,6 +7100,15 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
@@ -7263,6 +7428,15 @@ packages:
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
+  stats-gl@2.4.2:
+    resolution: {integrity: sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==}
+    peerDependencies:
+      '@types/three': '*'
+      three: '*'
+
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -7341,6 +7515,11 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   swr@2.3.4:
     resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
     peerDependencies:
@@ -7402,6 +7581,19 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  three-mesh-bvh@0.8.3:
+    resolution: {integrity: sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==}
+    peerDependencies:
+      three: '>= 0.159.0'
+
+  three-stdlib@2.36.1:
+    resolution: {integrity: sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==}
+    peerDependencies:
+      three: '>=0.128.0'
+
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
+
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
@@ -7444,6 +7636,19 @@ packages:
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  troika-three-text@0.52.4:
+    resolution: {integrity: sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-three-utils@0.52.4:
+    resolution: {integrity: sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==}
+    peerDependencies:
+      three: '>=0.125.0'
+
+  troika-worker-utils@0.52.0:
+    resolution: {integrity: sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
@@ -7494,6 +7699,9 @@ packages:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   turbo@2.9.16:
     resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
@@ -7637,6 +7845,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utility-types@3.11.0:
+    resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
+    engines: {node: '>= 4'}
+
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
@@ -7759,6 +7971,12 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
+
+  webgl-sdf-generator@1.1.1:
+    resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -7901,6 +8119,21 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
@@ -8516,6 +8749,8 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@duckdb/node-api@1.5.2-r.2':
     dependencies:
@@ -9232,6 +9467,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mediapipe/tasks-vision@0.10.17': {}
+
   '@mermaid-js/parser@1.1.1':
     dependencies:
       '@chevrotain/types': 11.1.2
@@ -9259,6 +9496,11 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@monogrid/gainmap-js@3.4.0(three@0.184.0)':
+    dependencies:
+      promise-worker-transferable: 1.0.4
+      three: 0.184.0
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -10138,6 +10380,59 @@ snapshots:
       react-aria: 3.49.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
+  '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0))(@types/react@19.2.16)(@types/three@0.184.1)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mediapipe/tasks-vision': 0.10.17
+      '@monogrid/gainmap-js': 3.4.0(three@0.184.0)
+      '@react-three/fiber': 9.6.1(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)
+      '@use-gesture/react': 10.3.1(react@19.2.6)
+      camera-controls: 3.1.2(three@0.184.0)
+      cross-env: 7.0.3
+      detect-gpu: 5.0.70
+      glsl-noise: 0.0.0
+      hls.js: 1.6.16
+      maath: 0.10.8(@types/three@0.184.1)(three@0.184.0)
+      meshline: 3.3.1(three@0.184.0)
+      react: 19.2.6
+      stats-gl: 2.4.2(@types/three@0.184.1)(three@0.184.0)
+      stats.js: 0.17.0
+      suspend-react: 0.1.3(react@19.2.6)
+      three: 0.184.0
+      three-mesh-bvh: 0.8.3(three@0.184.0)
+      three-stdlib: 2.36.1(three@0.184.0)
+      troika-three-text: 0.52.4(three@0.184.0)
+      tunnel-rat: 0.1.2(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+      utility-types: 3.11.0
+      zustand: 5.0.14(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+    optionalDependencies:
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/three'
+      - immer
+
+  '@react-three/fiber@9.6.1(@types/react@19.2.16)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.16)(react@19.2.6)
+      react: 19.2.6
+      react-use-measure: 2.1.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.6)
+      three: 0.184.0
+      use-sync-external-store: 1.6.0(react@19.2.6)
+      zustand: 5.0.14(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+    optionalDependencies:
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@react-types/shared@3.35.0(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -10677,6 +10972,8 @@ snapshots:
   '@turbo/windows-arm64@2.9.16':
     optional: true
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -10812,6 +11109,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/draco3d@1.4.10': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -10840,7 +11139,13 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/offscreencanvas@2019.7.3': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.16)':
+    dependencies:
+      '@types/react': 19.2.16
+
+  '@types/react-reconciler@0.28.9(@types/react@19.2.16)':
     dependencies:
       '@types/react': 19.2.16
 
@@ -10854,6 +11159,17 @@ snapshots:
     dependencies:
       htmlparser2: 10.1.0
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.184.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/trusted-types@2.0.7':
     optional: true
 
@@ -10862,6 +11178,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -10875,6 +11193,13 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@use-gesture/core@10.3.1': {}
+
+  '@use-gesture/react@10.3.1(react@19.2.6)':
+    dependencies:
+      '@use-gesture/core': 10.3.1
+      react: 19.2.6
 
   '@vercel/oidc@3.2.0': {}
 
@@ -11128,6 +11453,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.33: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   blake3-wasm@2.1.5: {}
 
   body-parser@2.2.2:
@@ -11166,6 +11495,11 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -11213,6 +11547,10 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
+
+  camera-controls@3.1.2(three@0.184.0):
+    dependencies:
+      three: 0.184.0
 
   caniuse-lite@1.0.30001793: {}
 
@@ -11399,6 +11737,10 @@ snapshots:
       typescript: 6.0.3
 
   cron-schedule@6.0.0: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-fetch@3.2.0(encoding@0.1.13):
     dependencies:
@@ -11640,6 +11982,10 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-gpu@5.0.70:
+    dependencies:
+      webgl-constants: 1.1.1
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
@@ -11699,6 +12045,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.4.2: {}
+
+  draco3d@1.5.7: {}
 
   duckdb-async@1.4.2(encoding@0.1.13):
     dependencies:
@@ -12029,6 +12377,10 @@ snapshots:
 
   fetchdts@0.1.7: {}
 
+  fflate@0.6.10: {}
+
+  fflate@0.8.3: {}
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -12157,6 +12509,8 @@ snapshots:
       ini: 6.0.0
 
   globrex@0.1.2: {}
+
+  glsl-noise@0.0.0: {}
 
   gopd@1.2.0: {}
 
@@ -12333,6 +12687,8 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  hls.js@1.6.16: {}
+
   hono@4.12.23: {}
 
   html-escaper@2.0.2: {}
@@ -12395,6 +12751,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  immediate@3.0.6: {}
 
   immer@10.2.0: {}
 
@@ -12463,6 +12821,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  is-promise@2.2.2: {}
+
   is-promise@4.0.0: {}
 
   isbot@5.1.40: {}
@@ -12489,6 +12849,13 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  its-fine@2.0.0(@types/react@19.2.16)(react@19.2.6):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.16)
+      react: 19.2.6
+    transitivePeerDependencies:
+      - '@types/react'
 
   jackspeak@3.4.3:
     dependencies:
@@ -12571,6 +12938,10 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -12684,6 +13055,11 @@ snapshots:
       react: 19.2.6
 
   lz-string@1.5.0: {}
+
+  maath@0.10.8(@types/three@0.184.1)(three@0.184.0):
+    dependencies:
+      '@types/three': 0.184.1
+      three: 0.184.0
 
   magic-string@0.30.21:
     dependencies:
@@ -12935,6 +13311,12 @@ snapshots:
       stylis: 4.4.0
       ts-dedent: 2.2.0
       uuid: 14.0.0
+
+  meshline@3.3.1(three@0.184.0):
+    dependencies:
+      three: 0.184.0
+
+  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -13543,6 +13925,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@1.0.2: {}
+
   prettier@3.8.3: {}
 
   pretty-format@27.5.1:
@@ -13557,6 +13941,11 @@ snapshots:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
+
+  promise-worker-transferable@1.0.4:
+    dependencies:
+      is-promise: 2.2.2
+      lie: 3.3.0
 
   prop-types@15.8.1:
     dependencies:
@@ -13776,6 +14165,12 @@ snapshots:
   react-transition-state@2.4.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  react-use-measure@2.1.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
 
   react@19.2.6: {}
@@ -14260,6 +14655,13 @@ snapshots:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
+  stats-gl@2.4.2(@types/three@0.184.1)(three@0.184.0):
+    dependencies:
+      '@types/three': 0.184.1
+      three: 0.184.0
+
+  stats.js@0.17.0: {}
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
@@ -14344,6 +14746,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  suspend-react@0.1.3(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
   swr@2.3.4(react@19.2.6):
     dependencies:
       dequal: 2.0.3
@@ -14419,6 +14825,22 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  three-mesh-bvh@0.8.3(three@0.184.0):
+    dependencies:
+      three: 0.184.0
+
+  three-stdlib@2.36.1(three@0.184.0):
+    dependencies:
+      '@types/draco3d': 1.4.10
+      '@types/offscreencanvas': 2019.7.3
+      '@types/webxr': 0.5.24
+      draco3d: 1.5.7
+      fflate: 0.6.10
+      potpack: 1.0.2
+      three: 0.184.0
+
+  three@0.184.0: {}
+
   throttleit@2.1.0: {}
 
   tiny-invariant@1.3.3: {}
@@ -14445,6 +14867,20 @@ snapshots:
   tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
+
+  troika-three-text@0.52.4(three@0.184.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.184.0
+      troika-three-utils: 0.52.4(three@0.184.0)
+      troika-worker-utils: 0.52.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-utils@0.52.4(three@0.184.0):
+    dependencies:
+      three: 0.184.0
+
+  troika-worker-utils@0.52.0: {}
 
   trough@2.2.0: {}
 
@@ -14493,6 +14929,14 @@ snapshots:
       esbuild: 0.28.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-rat@0.1.2(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   turbo@2.9.16:
     optionalDependencies:
@@ -14638,6 +15082,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  utility-types@3.11.0: {}
+
   uuid@14.0.0: {}
 
   vary@1.1.2: {}
@@ -14751,6 +15197,10 @@ snapshots:
       - msw
 
   web-namespaces@2.0.1: {}
+
+  webgl-constants@1.1.1: {}
+
+  webgl-sdf-generator@1.1.1: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -14890,6 +15340,14 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zustand@4.5.7(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.16
+      immer: 11.1.8
+      react: 19.2.6
 
   zustand@5.0.14(@types/react@19.2.16)(immer@11.1.8)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
     optionalDependencies:


### PR DESCRIPTION
## Summary
Replaces the static 2d hero diagram with an interactive 3d scene users can rotate, zoom, and pan with the mouse.

## Changes
- new `HeroDiagram3D` component using `@react-three/fiber` + `drei`
- 19 nodes distributed by fibonacci spiral on a sphere (radius 6.5, ±0.25 jitter)
- 9 featured nodes (cloudflare, clickhouse, airflow, anyrouter, langgraph, llamaindex, mcp, workers, workflow) pinned in front of the camera so their labels sit centered on screen
- clickable logo+label pills with canonical project urls
- orbit controls: drag rotate, scroll zoom, right-drag pan, no auto-rotate
- respects `prefers-reduced-motion` (disables float + damping)
- keep the original 2d `HeroDiagram.tsx` as fallback (import in `routes/index.tsx` swaps it)
- raise sticky nav `z-40` → `z-[999]` so it stays above the 3d canvas
- add `three`, `@react-three/fiber`, `@react-three/drei` to `apps/home`

## Verification
- `pnpm run check-types` ✅
- `pnpm run lint` ✅
- `pnpm run test` ✅ 32/32
- `pnpm run build` ✅
- visual check: dev server confirmed scene renders, links work, controls feel right