### PR TITLE
fix(kb-sync): use gh pr list to detect existing PR

### DIFF
--- a/.github/workflows/kb-submodule-sync.yml
+++ b/.github/workflows/kb-submodule-sync.yml
@@ -79,7 +79,7 @@ jobs:
 
           # Open the PR if it doesn't exist; otherwise the force-push already
           # updated the existing one (same branch).
-          if ! gh pr view --repo "$GITHUB_REPOSITORY" --head "$branch" >/dev/null 2>&1; then
+          if [ -z "$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null)" ]; then
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
               --base master \


### PR DESCRIPTION
## Root cause

The `Sync kb content submodule` workflow has failed every hourly run since PR #1184 opened. The existence guard used `gh pr view --repo … --head <branch>`, but **`--head` is not a valid `gh pr view` flag** (`unknown flag: --head`). The guard therefore always errored (non-zero), so the workflow always fell into the `gh pr create` branch — which then failed with `a pull request … already exists`.

## Fix

Replace the broken guard with `gh pr list --head <branch> --state open` (the pattern already proven in `sync-skills.yml`):

```diff
- if ! gh pr view --repo "$GITHUB_REPOSITORY" --head "$branch" >/dev/null 2>&1; then
+ if [ -z "$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null)" ]; then
```

## Verification

```
$ gh pr view  -R duyet/monorepo --head bot/kb-submodule-sync     # → unknown flag: --head
$ gh pr list -R duyet/monorepo --head bot/kb-submodule-sync ...  # → 1184  ✓
```

One-line surgical change; YAML validated. Next hourly run will update #1184 instead of erroring.

**Note (not fixed here):** line 90 `gh pr edit --repo … --head … --add-label chore` has the same `--head` issue (masked by `|| true`, so the `chore` label is silently never applied). Left untouched to keep this change surgical.

Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the efficiency of the automated submodule synchronization workflow by updating the pull request detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->