### PR TITLE
ci: remove failing skills install step from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,9 +42,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Install skills
-        run: npx skills add duyet/build-skill --yes
-
       - name: Lint
         run: |
           pnpm install --frozen-lockfile


### PR DESCRIPTION
## What

Removes the `Install skills` step (`npx skills add duyet/build-skill --yes`) from the **Run Biome linting** workflow (`.github/workflows/lint.yml`).

## Why

That step fails on every run — the `duyet/build-skill` clone isn't accessible in CI — which has been hard-failing the **Run Biome linting** check on every PR (e.g. #1193, #1194). It isn't needed to run Biome: the next `Lint` step does its own `pnpm install --frozen-lockfile && pnpm run lint`. Dropping the step unblocks the check repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
