### PR TITLE
ci: drop commitlint scope-enum to unblock release-please

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,45 +1,6 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
-    "scope-enum": [
-      2,
-      "always",
-      [
-        // Dependency-related changes
-        "deps",
-        // Post
-        "post",
-        // App changes
-        "blog",
-        "cv",
-        "home",
-        "insights",
-        "photos",
-        "travel",
-        // Auth-related changes
-        "auth",
-        // CI-related changes
-        "ci",
-        // UI-related changes
-        "ui",
-        // Rust-related changes
-        "rust",
-        // Docs-related changes
-        "docs",
-        // Library-related changes
-        "lib",
-        // Agent-related changes
-        "agents",
-        // LLM Timeline app
-        "llm-timeline",
-        // Homelab app
-        "homelab",
-        // Knowledge Base app
-        "kb",
-        // Shared packages (components, libs, etc.)
-        "ui",
-      ],
-    ],
     "scope-empty": [1, "never"],
   },
 };


### PR DESCRIPTION
## Problem

Every `release-please` PR fails the `PR Title` / `conventional-title` check:

```
Validating PR title: chore(master): release 0.1.1
✖ scope must be one of [deps, post, blog, ...] [scope-enum]
```

release-please always titles its PR `chore(<branch>): release X.Y.Z`, and `<branch>` is `master` — which isn't in the `scope-enum` allowlist. So **every** release PR fails this check forever.

## Fix

Remove the `scope-enum` rule from `.commitlintrc.js`. Any scope now passes (including `master`/`main`), while the rest of `@commitlint/config-conventional` — `type-enum`, `subject-case`, `header-max-length` — still validates PR titles so release-please keeps reading clean squash-merge commits.

## Verified locally (`echo ... | pnpm exec commitlint`)

| Title | Before | After |
|---|---|---|
| `chore(master): release 0.1.1` | ❌ fail | ✅ pass |
| `chore(main): release 2.0.0` | ❌ fail | ✅ pass |
| `feat(blog): redesign tags index` | ✅ pass | ✅ pass |
| `wat(blog): nope` | ❌ fail (type) | ❌ fail (type — still enforced) |

## Notes

- The dead duplicate `commitlint.config.js` (cosmiconfig never reaches it — `.commitlintrc.js` wins) is left untouched; happy to remove it in a follow-up.
- `scope-empty` (warn-level) retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)