### PR TITLE
feat(ui): redesign home, insights, cv landing viz with accessible responsive SVG

### DIFF
--- a/apps/cv/components/education.tsx
+++ b/apps/cv/components/education.tsx
@@ -17,11 +17,11 @@ export function Education({
 }: EducationProps) {
   return (
     <div className={cn("mt-2", className)}>
-      <div className="flex items-baseline justify-between">
-        <h3 className="text-[15px] font-bold text-neutral-900 dark:text-neutral-100">
+      <div className="flex items-baseline justify-between gap-x-3">
+        <h3 className="min-w-0 text-[15px] font-bold text-neutral-900 dark:text-neutral-100">
           {university}
         </h3>
-        <span className="text-[13px] italic text-black dark:text-neutral-200">
+        <span className="shrink-0 whitespace-nowrap text-[13px] italic text-neutral-500 dark:text-neutral-400">
           <ResumeLink
             href={thesisUrl}
             external

--- a/apps/cv/components/experience.tsx
+++ b/apps/cv/components/experience.tsx
@@ -37,11 +37,11 @@ export function ExperienceItem({
           />
         </h3>
       </div>
-      <div className="flex items-baseline justify-between">
-        <span className="text-[14px] italic text-neutral-700 dark:text-neutral-300">
+      <div className="flex items-baseline justify-between gap-x-3">
+        <span className="min-w-0 text-[14px] italic text-neutral-700 dark:text-neutral-300">
           {title}
         </span>
-        <span className="text-[13px] italic text-black dark:text-neutral-200">
+        <span className="shrink-0 whitespace-nowrap text-[13px] italic tabular-nums text-neutral-500 dark:text-neutral-400">
           <PeriodText from={from} to={to} />
         </span>
       </div>

--- a/apps/home/src/components/GitHubContributions.tsx
+++ b/apps/home/src/components/GitHubContributions.tsx
@@ -4,6 +4,32 @@ const API = "https://github-contributions-api.deno.dev/duyet.json";
 const CACHE_KEY = "gh-contrib";
 const CACHE_TTL = 86_400_000; // 24h
 
+// SVG geometry in viewBox units; the whole grid scales fluidly to the
+// container width via a viewBox, so cells stay crisp from 320px up.
+const CELL = 11;
+const GAP = 2.5;
+const PITCH = CELL + GAP;
+const RADIUS = 2.5;
+
+// Sequential 5-step ramp derived from the theme accent so the heatmap
+// respects light/dark tokens instead of hardcoded GitHub greens. Empty
+// days use the muted surface; density mixes more accent toward the top.
+const RAMP = [
+  "var(--rd-surface-2)",
+  "color-mix(in srgb, var(--rd-accent) 26%, var(--rd-surface-2))",
+  "color-mix(in srgb, var(--rd-accent) 50%, var(--rd-surface-2))",
+  "color-mix(in srgb, var(--rd-accent) 74%, var(--rd-surface-2))",
+  "var(--rd-accent)",
+];
+
+const LEVEL_INDEX: Record<string, number> = {
+  NONE: 0,
+  FIRST_QUARTILE: 1,
+  SECOND_QUARTILE: 2,
+  THIRD_QUARTILE: 3,
+  FOURTH_QUARTILE: 4,
+};
+
 interface Day {
   date: string;
   contributionCount: number;
@@ -35,19 +61,8 @@ function setCache(data: Day[][]) {
   }
 }
 
-function levelToColor(level: string): string {
-  switch (level) {
-    case "FIRST_QUARTILE":
-      return "#0e4429";
-    case "SECOND_QUARTILE":
-      return "#006d32";
-    case "THIRD_QUARTILE":
-      return "#26a641";
-    case "FOURTH_QUARTILE":
-      return "#39d353";
-    default:
-      return "var(--rd-border)";
-  }
+function levelColor(level: string): string {
+  return RAMP[LEVEL_INDEX[level] ?? 0];
 }
 
 export function GitHubContributions() {
@@ -72,34 +87,51 @@ export function GitHubContributions() {
   if (!data) return <div className="mt-4" />;
 
   const total = data.flat().reduce((s, d) => s + d.contributionCount, 0);
+  const width = data.length * PITCH - GAP;
+  const height = 7 * PITCH - GAP;
+  const totalLabel = total.toLocaleString();
 
   return (
     <div className="mt-4 select-none">
       <div className="font-[var(--font-mono)] text-[11px] text-[var(--rd-text-3)] mb-1.5">
-        {total.toLocaleString()} contributions in the last year
+        {totalLabel} contributions in the last year
       </div>
-      <div
-        className="grid"
-        style={{
-          gridTemplateRows: "repeat(7, 1fr)",
-          gridTemplateColumns: `repeat(${data.length}, 1fr)`,
-          gap: "1.5px",
-          width: "fit-content",
-        }}
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        width="100%"
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label={`GitHub contribution heatmap: ${totalLabel} contributions in the last year`}
+        style={{ display: "block", height: "auto" }}
       >
         {data.flatMap((week, wi) =>
           week.map((day, di) => (
-            <div
+            <rect
               key={`${wi}-${di}`}
-              style={{
-                width: 4,
-                height: 4,
-                borderRadius: 1,
-                backgroundColor: levelToColor(day.contributionLevel),
-              }}
-            />
+              x={wi * PITCH}
+              y={di * PITCH}
+              width={CELL}
+              height={CELL}
+              rx={RADIUS}
+              ry={RADIUS}
+              fill={levelColor(day.contributionLevel)}
+            >
+              <title>{`${day.contributionCount} on ${day.date}`}</title>
+            </rect>
           )),
         )}
+      </svg>
+      <div className="mt-2 flex items-center gap-1.5 font-[var(--font-mono)] text-[10px] text-[var(--rd-text-3)]">
+        <span>Less</span>
+        {RAMP.map((c) => (
+          <span
+            key={c}
+            aria-hidden="true"
+            className="inline-block h-2.5 w-2.5 rounded-[2px]"
+            style={{ backgroundColor: c }}
+          />
+        ))}
+        <span>More</span>
       </div>
     </div>
   );

--- a/apps/home/src/components/GitHubContributions.tsx
+++ b/apps/home/src/components/GitHubContributions.tsx
@@ -84,10 +84,10 @@ export function GitHubContributions() {
       .catch(() => {});
   }, []);
 
-  if (!data) return <div className="mt-4" />;
+  if (!data || data.length === 0) return <div className="mt-4" />;
 
   const total = data.flat().reduce((s, d) => s + d.contributionCount, 0);
-  const width = data.length * PITCH - GAP;
+  const width = Math.max(0, data.length * PITCH - GAP);
   const height = 7 * PITCH - GAP;
   const totalLabel = total.toLocaleString();
 

--- a/apps/insights/components/charts/Sparkline.tsx
+++ b/apps/insights/components/charts/Sparkline.tsx
@@ -1,0 +1,82 @@
+import { useId } from "react";
+
+interface SparklineProps {
+  /** Time-series values, oldest to newest. */
+  data: number[];
+  /** Rendered height in pixels. */
+  h?: number;
+  /** Line/area color; accepts any CSS color incl. theme vars. */
+  stroke?: string;
+  /** Render the soft gradient fill beneath the line. */
+  fill?: boolean;
+  /** Accessible description of the trend for screen readers. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Tiny, dependency-free SVG sparkline.
+ *
+ * Pure inline SVG so it stays theme-aware via CSS variables and adds no
+ * runtime cost. Unlike the shared redesign sparkline, this variant exposes an
+ * accessible `label` (role="img" + aria-label) for the KPI tiles.
+ */
+export function Sparkline({
+  data,
+  h = 34,
+  stroke = "var(--rd-accent)",
+  fill = true,
+  label,
+  className,
+}: SparklineProps) {
+  // Stable id across SSR + client so the gradient ref never mismatches.
+  const reactId = useId();
+
+  // Fewer than two points cannot form a line; keep the layout height.
+  if (data.length < 2) {
+    return <div aria-hidden="true" className={className} style={{ height: h }} />;
+  }
+
+  const w = 120;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const rng = max - min || 1;
+  const step = w / (data.length - 1);
+  const pts = data.map(
+    (v, i) => [i * step, h - ((v - min) / rng) * (h - 4) - 2] as const,
+  );
+  const line = pts
+    .map((p, i) => `${i ? "L" : "M"}${p[0].toFixed(1)} ${p[1].toFixed(1)}`)
+    .join(" ");
+  const area = `${line} L${w} ${h} L0 ${h} Z`;
+  const gid = `spark-${reactId.replace(/:/g, "")}`;
+
+  return (
+    <svg
+      aria-hidden={label ? undefined : "true"}
+      aria-label={label}
+      className={className}
+      preserveAspectRatio="none"
+      role={label ? "img" : undefined}
+      style={{ width: "100%", height: h, display: "block" }}
+      viewBox={`0 0 ${w} ${h}`}
+    >
+      <defs>
+        <linearGradient id={gid} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={stroke} stopOpacity="0.16" />
+          <stop offset="1" stopColor={stroke} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {fill && <path d={area} fill={`url(#${gid})`} />}
+      <path
+        d={line}
+        fill="none"
+        stroke={stroke}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.8}
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}

--- a/apps/insights/components/charts/Sparkline.tsx
+++ b/apps/insights/components/charts/Sparkline.tsx
@@ -32,17 +32,19 @@ export function Sparkline({
   // Stable id across SSR + client so the gradient ref never mismatches.
   const reactId = useId();
 
-  // Fewer than two points cannot form a line; keep the layout height.
-  if (data.length < 2) {
+  // Ignore non-finite values (NaN/Infinity) so they never reach the SVG path
+  // and silently blank the chart. Fewer than two points cannot form a line.
+  const finite = data.filter(Number.isFinite);
+  if (finite.length < 2) {
     return <div aria-hidden="true" className={className} style={{ height: h }} />;
   }
 
   const w = 120;
-  const max = Math.max(...data);
-  const min = Math.min(...data);
+  const max = Math.max(...finite);
+  const min = Math.min(...finite);
   const rng = max - min || 1;
-  const step = w / (data.length - 1);
-  const pts = data.map(
+  const step = w / (finite.length - 1);
+  const pts = finite.map(
     (v, i) => [i * step, h - ((v - min) / rng) * (h - 4) - 2] as const,
   );
   const line = pts

--- a/apps/insights/components/dashboard/OverviewDashboard.tsx
+++ b/apps/insights/components/dashboard/OverviewDashboard.tsx
@@ -1,4 +1,12 @@
-import { ArrowUpRight, Clock, Server, Zap } from "lucide-react";
+import {
+  ArrowUpRight,
+  Clock,
+  Code2,
+  DollarSign,
+  Server,
+  Zap,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type { CCUsageMetricsData } from "@/app/ai/types";
 import { CompactCard } from "@/components/ui/CompactCard";
 
@@ -23,6 +31,53 @@ function formatTokens(tokens: number): string {
   return tokens.toString();
 }
 
+function formatCost(cost: number): string {
+  return new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    maximumFractionDigits: cost >= 100 ? 0 : 2,
+    style: "currency",
+  }).format(cost || 0);
+}
+
+interface KpiTileProps {
+  icon: LucideIcon;
+  label: string;
+  value: string | null;
+  unit?: string;
+  sub?: string;
+}
+
+/** Single KPI: icon + label, prominent value, and a small supporting hint. */
+function KpiTile({ icon: Icon, label, value, unit, sub }: KpiTileProps) {
+  return (
+    <CompactCard padding="sm" className="h-full">
+      <div className="flex h-full flex-col gap-2">
+        <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          <Icon aria-hidden="true" className="h-3.5 w-3.5" />
+          <span className="uppercase tracking-wide">{label}</span>
+        </div>
+        {value !== null ? (
+          <>
+            <div className="text-2xl font-semibold leading-none tracking-tight sm:text-3xl">
+              {value}
+              {unit ? (
+                <span className="ml-0.5 text-base font-medium text-muted-foreground">
+                  {unit}
+                </span>
+              ) : null}
+            </div>
+            {sub ? (
+              <div className="mt-auto text-xs text-muted-foreground">{sub}</div>
+            ) : null}
+          </>
+        ) : (
+          <div className="text-sm text-muted-foreground">Unavailable</div>
+        )}
+      </div>
+    </CompactCard>
+  );
+}
+
 interface OverviewDashboardProps {
   aiMetrics: CCUsageMetricsData | null;
   wakaTimeMetrics: WakaTimeMetricsData | null;
@@ -32,12 +87,6 @@ export function OverviewDashboard({
   aiMetrics,
   wakaTimeMetrics,
 }: OverviewDashboardProps) {
-  const aiTokens = aiMetrics ? formatTokens(aiMetrics.totalTokens) : null;
-
-  const codingHours = wakaTimeMetrics
-    ? wakaTimeMetrics.totalHours.toFixed(1)
-    : null;
-
   return (
     <div className="space-y-8">
       {/* Page Header */}
@@ -58,72 +107,74 @@ export function OverviewDashboard({
         <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Key Performance Indicators • Last 30 Days
         </h2>
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-          <CompactCard padding="sm" className="bg-[var(--insights-card-blue)]">
-            <div className="space-y-1">
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Clock className="h-3 w-3" />
-                <span>Coding Hours</span>
-              </div>
-              {codingHours !== null ? (
-                <>
-                  <div className="text-lg font-semibold">{codingHours}</div>
-                  <div className="text-xs text-muted-foreground">
-                    last 30 days
-                  </div>
-                </>
-              ) : (
-                <div className="text-sm text-muted-foreground">Unavailable</div>
-              )}
-            </div>
-          </CompactCard>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <KpiTile
+            icon={Clock}
+            label="Coding Hours"
+            value={
+              wakaTimeMetrics ? wakaTimeMetrics.totalHours.toFixed(1) : null
+            }
+            unit="h"
+            sub={
+              wakaTimeMetrics
+                ? `${wakaTimeMetrics.avgDailyHours.toFixed(1)}h avg / active day`
+                : undefined
+            }
+          />
 
-          <CompactCard padding="sm" className="bg-[var(--insights-card-emerald)]">
-            <div className="space-y-1">
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Zap className="h-3 w-3" />
-                <span>AI Tokens</span>
-              </div>
-              {aiTokens !== null ? (
-                <>
-                  <div className="text-lg font-semibold">{aiTokens}</div>
-                  <div className="text-xs text-muted-foreground">
-                    last 30 days
-                  </div>
-                </>
-              ) : (
-                <div className="text-sm text-muted-foreground">Unavailable</div>
-              )}
-            </div>
-          </CompactCard>
+          <KpiTile
+            icon={Code2}
+            label="Top Language"
+            value={wakaTimeMetrics ? wakaTimeMetrics.topLanguage : null}
+            sub={
+              wakaTimeMetrics
+                ? `${wakaTimeMetrics.daysActive} active days`
+                : undefined
+            }
+          />
 
-          <CompactCard padding="sm" className="bg-[var(--insights-card-coral)]">
-            <a
-              href="https://homelab.duyet.net"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="group block"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-white/70 dark:bg-white/10">
-                    <Server className="h-4 w-4 text-neutral-950 dark:text-[#f8f8f2]" />
-                  </div>
-                  <div className="space-y-1">
-                    <div className="text-sm font-semibold group-hover:underline group-hover:underline-offset-4">
-                      Homelab dashboard
-                    </div>
-                    <div className="text-xs text-muted-foreground">
-                      Infrastructure monitoring and homelab documentation
-                    </div>
-                  </div>
-                </div>
-                <ArrowUpRight className="h-4 w-4 shrink-0" />
-              </div>
-            </a>
-          </CompactCard>
+          <KpiTile
+            icon={Zap}
+            label="AI Tokens"
+            value={aiMetrics ? formatTokens(aiMetrics.totalTokens) : null}
+            sub={
+              aiMetrics ? `across ${aiMetrics.activeDays} active days` : undefined
+            }
+          />
+
+          <KpiTile
+            icon={DollarSign}
+            label="AI Spend"
+            value={aiMetrics ? formatCost(aiMetrics.totalCost) : null}
+            sub={aiMetrics ? `top model: ${aiMetrics.topModel}` : undefined}
+          />
         </div>
       </div>
+
+      {/* Related destinations */}
+      <CompactCard padding="sm">
+        <a
+          href="https://homelab.duyet.net"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group flex items-center justify-between gap-4"
+        >
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted">
+              <Server aria-hidden="true" className="h-4 w-4" />
+            </div>
+            <div className="space-y-0.5">
+              <div className="text-sm font-semibold group-hover:underline group-hover:underline-offset-4">
+                Homelab dashboard
+              </div>
+              <div className="text-xs text-muted-foreground">
+                Infrastructure monitoring and homelab documentation
+              </div>
+            </div>
+          </div>
+          <ArrowUpRight aria-hidden="true" className="h-4 w-4 shrink-0" />
+        </a>
+      </CompactCard>
     </div>
   );
 }

--- a/apps/insights/components/overview/KpiTile.tsx
+++ b/apps/insights/components/overview/KpiTile.tsx
@@ -33,7 +33,7 @@ function KpiTile({ t }: { t: KpiTileData }) {
       <Sparkline
         data={t.spark}
         h={34}
-        label={`${t.k} trend over the period, latest change ${t.trend}`}
+        label={`${t.k} trend over the period${t.trend === "—" ? "" : `, latest change ${t.trend}`}`}
         stroke={t.good ? "var(--rd-ok)" : "var(--rd-accent)"}
       />
       <div className="font-[var(--font-mono)] text-[var(--rd-text-3)] text-[11.5px]">

--- a/apps/insights/components/overview/KpiTile.tsx
+++ b/apps/insights/components/overview/KpiTile.tsx
@@ -1,4 +1,4 @@
-import { Sparkline } from "@duyet/components";
+import { Sparkline } from "@/components/charts/Sparkline";
 
 interface KpiTileData {
   k: string;
@@ -33,6 +33,7 @@ function KpiTile({ t }: { t: KpiTileData }) {
       <Sparkline
         data={t.spark}
         h={34}
+        label={`${t.k} trend over the period, latest change ${t.trend}`}
         stroke={t.good ? "var(--rd-ok)" : "var(--rd-accent)"}
       />
       <div className="font-[var(--font-mono)] text-[var(--rd-text-3)] text-[11.5px]">

--- a/apps/insights/components/overview/TokenAttributionSection.tsx
+++ b/apps/insights/components/overview/TokenAttributionSection.tsx
@@ -24,7 +24,7 @@ function TokenAttributionSection({ data }: { data: LoaderData }) {
     <>
       {/* Stacked bar chart: daily tokens by model */}
       <div className="rd-g2 mt-3">
-        <div className="rd-card p-[clamp(18px,2.2vw,26px)] p-[clamp(22px,2.6vw,30px)]">
+        <div className="rd-card p-[clamp(22px,2.6vw,30px)]">
           <div className="mb-5">
             <Eyebrow>AI · ccusage</Eyebrow>
             <h3
@@ -36,10 +36,13 @@ function TokenAttributionSection({ data }: { data: LoaderData }) {
               Daily token volume by model (thousands), last 30 days.
             </p>
           </div>
-          <InsightStackedBarChart data={byModel} />
+          <InsightStackedBarChart
+            ariaLabel="Daily token volume by model over the last 30 days"
+            data={byModel}
+          />
         </div>
 
-        <div className="rd-card p-[clamp(18px,2.2vw,26px)] p-[clamp(22px,2.6vw,30px)]">
+        <div className="rd-card p-[clamp(22px,2.6vw,30px)]">
           <div className="mb-5">
             <Eyebrow>Efficiency · ccusage</Eyebrow>
             <h3
@@ -52,10 +55,11 @@ function TokenAttributionSection({ data }: { data: LoaderData }) {
             </p>
           </div>
           <InsightAreaChart
+            accentKey="score"
+            ariaLabel="Cost efficiency trend, tokens produced per dollar"
             data={efficiency}
             keys={["score"]}
             labelMap={{ score: "Tokens/$" }}
-            accentKey="score"
           />
         </div>
       </div>
@@ -63,7 +67,7 @@ function TokenAttributionSection({ data }: { data: LoaderData }) {
       {/* Top sessions by tokens */}
       {projects.length > 0 && (
         <div
-          className="rd-card p-[clamp(18px,2.2vw,26px)] mt-3 p-[clamp(22px,2.6vw,30px)]"
+          className="rd-card p-[clamp(22px,2.6vw,30px)] mt-3"
         >
           <div className="mb-2">
             <Eyebrow>Projects · ccusage</Eyebrow>

--- a/apps/insights/components/overview/charts.tsx
+++ b/apps/insights/components/overview/charts.tsx
@@ -23,11 +23,13 @@ function InsightAreaChart({
   keys,
   labelMap,
   accentKey,
+  ariaLabel,
 }: {
   data: Array<Record<string, number | string>>;
   keys: string[];
   labelMap: Record<string, string>;
   accentKey?: string;
+  ariaLabel?: string;
 }) {
   const isHydrated = useHydrated();
   const { ref, width } = useElementWidth();
@@ -42,7 +44,12 @@ function InsightAreaChart({
   };
 
   return (
-    <div className="h-[200px] min-w-0" ref={ref}>
+    <div
+      aria-label={ariaLabel}
+      className="h-[200px] min-w-0"
+      ref={ref}
+      role={ariaLabel ? "img" : undefined}
+    >
       {(!isHydrated || width === 0) && (
         <div className="flex h-full items-center text-xs text-muted-foreground">
           Loading.
@@ -136,8 +143,10 @@ const STACK_COLORS = [
 
 function InsightStackedBarChart({
   data,
+  ariaLabel,
 }: {
   data: CCUsageActivityByModelData[];
+  ariaLabel?: string;
 }) {
   const isHydrated = useHydrated();
   const { ref, width } = useElementWidth();
@@ -151,7 +160,12 @@ function InsightStackedBarChart({
   );
 
   return (
-    <div className="h-[200px] min-w-0" ref={ref}>
+    <div
+      aria-label={ariaLabel}
+      className="h-[200px] min-w-0"
+      ref={ref}
+      role={ariaLabel ? "img" : undefined}
+    >
       {(!isHydrated || width === 0) && (
         <div className="flex h-full items-center text-xs text-muted-foreground">
           Loading.

--- a/apps/insights/src/routes/index.tsx
+++ b/apps/insights/src/routes/index.tsx
@@ -63,46 +63,62 @@ function IndexPage() {
       })
     : null;
 
-  /* ---- KPI data ---- */
+  /* ---- KPI data ----
+   * Trend is a real period-over-period delta: mean of the second half of the
+   * series vs the first half. Returns "—" when the series is too short. */
+  const trendPct = (series: number[]): string => {
+    const s = series.filter((n) => Number.isFinite(n));
+    if (s.length < 4) return "—";
+    const mid = Math.floor(s.length / 2);
+    const mean = (arr: number[]) =>
+      arr.reduce((a, b) => a + b, 0) / (arr.length || 1);
+    const first = mean(s.slice(0, mid));
+    const second = mean(s.slice(mid));
+    if (first === 0) return second > 0 ? "+100%" : "—";
+    const pct = Math.round(((second - first) / first) * 1000) / 10;
+    return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+  };
+
+  const wakaSpark = data.wakaTrend.map((t) => Number(t.hours) || 0);
+  const viewsSpark = traffic.map((t) => Number(t.pageViews) || 0);
+  const tokensSpark = aiActivity.map((a) => Number(a.tokens) || 0);
+  const costSpark = aiActivity.map((a) => Number(a.cost) || 0);
+
   const kpis: KpiTileData[] = [
     {
       k: "Coding hours",
       v: formatNumber(data.wakaMetrics.totalHours),
       unit: "h",
       sub: `${formatNumber(data.wakaMetrics.avgDailyHours)}h avg / active day`,
-      trend: "+3.1%",
-      spark: data.wakaTrend.map((t) => Number(t.hours) || 0),
+      trend: trendPct(wakaSpark),
+      spark: wakaSpark,
     },
     {
       k: "Page views",
       v: formatCompact(pageViews),
       unit: "",
       sub: "Cloudflare · 30d",
-      trend: "+12.4%",
-      spark: traffic.map((t) => Number(t.pageViews) || 0),
+      trend: trendPct(viewsSpark),
+      spark: viewsSpark,
     },
     {
       k: "AI tokens",
       v: formatCompact(data.aiMetrics.totalTokens),
       unit: "",
       sub: `across ${data.aiMetrics.activeDays} active days`,
-      trend: "+8.2%",
-      spark: aiActivity.map((a) => Number(a.tokens) || 0),
+      trend: trendPct(tokensSpark),
+      spark: tokensSpark,
     },
     {
       k: "AI spend",
       v: formatNumber(data.aiMetrics.totalCost),
       unit: "$",
       sub: `top: ${compactName(data.aiMetrics.topModel)}`,
-      trend: "-6.5%",
+      trend: trendPct(costSpark),
       good: true,
-      spark: aiActivity.map((a) => Number(a.cost) || 0),
+      spark: costSpark,
     },
   ];
-
-  /* ---- Editorial note derived from data ---- */
-  const editorialNote =
-    "The pattern this month: coding hours climbed into agent work while spend fell — caching prompt re-use across sessions does most of that. Reading skews to the old reference posts, not the new ones.";
 
   /* ---- Repo data for grid ---- */
   const totalStars = data.githubRepos.reduce(
@@ -141,18 +157,6 @@ function IndexPage() {
             <KpiTile t={t} />
           </Reveal>
         ))}
-      </div>
-
-      {/* ---- Editorial note ---- */}
-      <div
-        className="rd-card p-[clamp(18px,2.2vw,26px)] mt-3 p-[clamp(24px,3vw,34px)] bg-[var(--rd-bg-sub)]"
-      >
-        <Eyebrow>What it meant</Eyebrow>
-        <p
-          className="text-[clamp(1.1rem,1.8vw,1.45rem)] leading-[1.45] tracking-[-0.015em] mt-[14px] max-w-[58ch] text-pretty"
-        >
-          {editorialNote}
-        </p>
       </div>
 
       {/* ---- Coding + AI split ---- */}

--- a/apps/insights/src/routes/index.tsx
+++ b/apps/insights/src/routes/index.tsx
@@ -65,7 +65,8 @@ function IndexPage() {
 
   /* ---- KPI data ----
    * Trend is a real period-over-period delta: mean of the second half of the
-   * series vs the first half. Returns "—" when the series is too short. */
+   * series vs the first half. Returns "—" when the series is too short or the
+   * baseline is zero (an undefined ratio, not a synthetic +100%). */
   const trendPct = (series: number[]): string => {
     const s = series.filter((n) => Number.isFinite(n));
     if (s.length < 4) return "—";
@@ -74,9 +75,11 @@ function IndexPage() {
       arr.reduce((a, b) => a + b, 0) / (arr.length || 1);
     const first = mean(s.slice(0, mid));
     const second = mean(s.slice(mid));
-    if (first === 0) return second > 0 ? "+100%" : "—";
-    const pct = Math.round(((second - first) / first) * 1000) / 10;
-    return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+    if (first === 0) return "—";
+    // |first| in the denominator keeps the real sign for a negative baseline.
+    const pct = Math.round(((second - first) / Math.abs(first)) * 1000) / 10;
+    if (Math.abs(pct) < 0.05) return "0.0%";
+    return `${pct > 0 ? "+" : ""}${pct.toFixed(1)}%`;
   };
 
   const wakaSpark = data.wakaTrend.map((t) => Number(t.hours) || 0);


### PR DESCRIPTION
First slice of the redesign initiative (epic #1216). Three Opus subagents worked disjoint app dirs in parallel; each change is surgical and verified with `biome lint` + `check-types`.

## What changed

### Home landing — `apps/home`
- Rebuilt the GitHub contributions grid from a fixed 4px `<div>` grid into a **fluid, accessible inline-SVG heatmap**: scales to container width via `viewBox`, a theme-tokened 5-step color ramp (light/dark aware) replacing the hardcoded GitHub greens, `role="img"` + `aria-label`, per-cell `<title>`, and a Less→More legend. Fetch + localStorage caching unchanged.
- Other home viz (`SignalBar`, `HeroDiagram`, `NowDeco`) were already responsive SVG — left untouched.

### Insights admin dashboard — `apps/insights`
- New dependency-free, theme-aware **`Sparkline`** SVG component (`role="img"` + `aria-label`), used in the live KPI tiles; added optional `ariaLabel` to the overview area/stacked-bar charts.
- **Real KPI trend deltas**: replaced four hardcoded trend percentages (`+3.1%`, `+12.4%`, …) with a genuine period-over-period delta computed from each KPI's existing spark series.
- **Removed a fabricated "what it meant" editorial paragraph** that asserted unverifiable causal claims — the clearest "AI slop" on the public page.
- Fixed a duplicate Tailwind padding class in `TokenAttributionSection`.
- Rebuilt the previously **orphaned, broken-token** `OverviewDashboard.tsx` (its `--insights-card-*` vars are undefined repo-wide) into a responsive KPI grid using defined tokens and real signals only.

### CV landing — `apps/cv`
- Audit found the page already responsive; fixed two real issues in Experience/Education header rows: **inverted date hierarchy** (dates were rendered heavier than titles) and a **320px header-row collision** (long titles could collide with the right-aligned date/label). Print CSS still forces black, so the printed résumé is unaffected.

## Verification
- `pnpm --filter home check-types` ✅ · `pnpm --filter insights check-types` ✅ · `pnpm --filter cv check-types` ✅
- `biome lint` clean on all changed files (pre-existing `useImportType` warnings in untouched home files were not introduced here).

## Scope note
The `/batch` request was much broader (alerting adapters, Telegram formatting, health snapshots, monorepo TanStack/Wrangler deploy refactor, billing/usage/agent-chat/smart-suggestions, remaining landing pages). Those exceed a single branch and are tracked as issues rather than crammed in here: epic #1216 with #1217 (alerting), #1218 (deploy coupling), #1219 (insights billing/chat/suggestions), #1220 (remaining landing pages), #1221 (shared SVG primitives + perf).

Opened ready for review — not auto-merging a UI redesign into `master`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSxDWESiVedqkWWDyv5K8A)_

## Summary by Sourcery

Redesign key landing surfaces to use accessible, responsive SVG visualizations and real KPI signals while tightening layout and typography.

New Features:
- Replace the home GitHub contributions grid with a fluid inline-SVG heatmap that scales to container width and uses theme-aware color ramps with accessible labeling.
- Introduce a dependency-free SVG Sparkline component for insights KPI tiles with screen-reader-friendly descriptions.
- Rebuild the insights overview KPI section into a responsive grid showing coding activity, language, AI token usage, and AI spend using real metrics.

Bug Fixes:
- Correct the date/title visual hierarchy and prevent header collisions in CV experience and education sections at small viewports.
- Fix duplicate padding classes in the insights token attribution cards.

Enhancements:
- Compute KPI trend percentages from actual time-series data instead of hardcoded values on the insights dashboard.
- Add aria labels to insights overview charts to improve accessibility.
- Update the insights homelab link card layout for consistency with the redesigned KPI grid.
- Refine GitHub contributions styling to use theme tokens and add a clear Less→More legend.
- Adjust CV typography and spacing to improve readability and hierarchy for headers and date ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable SVG charts and sparkline visuals for smoother, more responsive data displays.
  * Updated KPI cards to show dynamic trends and clearer spend/cost formatting.

* **Bug Fixes**
  * Improved text wrapping and spacing in CV education and experience sections so long titles and dates display more cleanly.
  * Refined dashboard and contribution heatmap layouts for better readability.

* **Accessibility**
  * Added descriptive labels and tooltips to charts and contribution visuals for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->