### PR TITLE
feat(home): link blog posts from project cards

### DIFF
--- a/apps/home/__tests__/project-blog-links.test.ts
+++ b/apps/home/__tests__/project-blog-links.test.ts
@@ -1,0 +1,99 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../blog/public/posts-data.json", () => ({
+  default: [
+    {
+      slug: "/2024/03/clickhouse-monitoring",
+      title: "ClickHouse Monitoring",
+    },
+    {
+      slug: "/2026/07/open-managed-agents",
+      title: "Open Managed Agents",
+    },
+  ],
+}));
+
+import { ProjectBlogLinks } from "../src/components/ProjectBlogLinks";
+import { blogPostHref, resolveBlogPosts } from "../src/data/blog-posts";
+import { apps } from "../src/data/projects";
+
+describe("resolveBlogPosts", () => {
+  it("keeps known slugs and drops unknowns", () => {
+    expect(
+      resolveBlogPosts([
+        "/missing",
+        "/2024/03/clickhouse-monitoring",
+        "/2026/07/open-managed-agents",
+      ])
+    ).toEqual([
+      {
+        slug: "/2024/03/clickhouse-monitoring",
+        title: "ClickHouse Monitoring",
+      },
+      {
+        slug: "/2026/07/open-managed-agents",
+        title: "Open Managed Agents",
+      },
+    ]);
+  });
+
+  it("returns an empty list when slugs are missing or unknown", () => {
+    expect(resolveBlogPosts(undefined)).toEqual([]);
+    expect(resolveBlogPosts([])).toEqual([]);
+    expect(resolveBlogPosts(["/does-not-exist"])).toEqual([]);
+  });
+
+  it("honors the optional limit", () => {
+    expect(
+      resolveBlogPosts(
+        ["/2024/03/clickhouse-monitoring", "/2026/07/open-managed-agents"],
+        1
+      )
+    ).toEqual([
+      {
+        slug: "/2024/03/clickhouse-monitoring",
+        title: "ClickHouse Monitoring",
+      },
+    ]);
+  });
+});
+
+describe("ProjectBlogLinks", () => {
+  it("renders blog post titles as links on the project card", () => {
+    const html = renderToStaticMarkup(
+      createElement(ProjectBlogLinks, {
+        slugs: ["/2024/03/clickhouse-monitoring"],
+        heading: "Related posts",
+      })
+    );
+
+    expect(html).toContain("Related posts");
+    expect(html).toContain("ClickHouse Monitoring");
+    expect(html).toContain(
+      'href="https://blog.duyet.net/2024/03/clickhouse-monitoring"'
+    );
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("renders nothing when no valid posts resolve", () => {
+    expect(
+      renderToStaticMarkup(
+        createElement(ProjectBlogLinks, { slugs: ["/does-not-exist"] })
+      )
+    ).toBe("");
+    expect(renderToStaticMarkup(createElement(ProjectBlogLinks))).toBe("");
+  });
+
+  it("renders links for shipped project blogPosts slugs", () => {
+    const chmonitor = apps.find((app) => app.name === "ClickHouse Monitoring");
+    expect(chmonitor?.blogPosts).toContain("/2024/03/clickhouse-monitoring");
+
+    const html = renderToStaticMarkup(
+      createElement(ProjectBlogLinks, { slugs: chmonitor?.blogPosts })
+    );
+    expect(html).toContain(blogPostHref("/2024/03/clickhouse-monitoring"));
+  });
+});

--- a/apps/home/src/components.projects/ProjectGrid.tsx
+++ b/apps/home/src/components.projects/ProjectGrid.tsx
@@ -1,8 +1,15 @@
 import { Reveal } from "@duyet/components";
+import { ArrowUpRight } from "lucide-react";
 import { ProjectCardHeader } from "../components/ProjectCardHeader";
 import { Badge } from "../components/ui/badge";
 import type { AppItem } from "../data/projects";
 import { categoryOf } from "./filter-utils";
+import rawBlogPosts from "../../../blog/public/posts-data.json";
+
+type BlogPost = { slug: string; title: string };
+const blogBySlug = new Map<string, BlogPost>(
+  (rawBlogPosts as BlogPost[]).map((p) => [p.slug, p]),
+);
 
 export function ProjectGrid({ items }: { items: AppItem[] }) {
   return (
@@ -42,6 +49,25 @@ export function ProjectGrid({ items }: { items: AppItem[] }) {
                   </Badge>
                 </div>
               </div>
+              {item.blogPosts ? (
+                <div className="mt-2 flex flex-col gap-0.5">
+                  {item.blogPosts
+                    .map((slug) => blogBySlug.get(slug))
+                    .filter((p): p is BlogPost => p !== undefined)
+                    .slice(0, 2)
+                    .map((post) => (
+                      <a
+                        key={post.slug}
+                        href={`https://blog.duyet.net${post.slug}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="rd-ulink text-[11.5px] leading-snug inline-flex items-center gap-1"
+                      >
+                        {post.title} <ArrowUpRight size={10} />
+                      </a>
+                    ))}
+                </div>
+              ) : null}
             </div>
           </Reveal>
         );

--- a/apps/home/src/components.projects/ProjectGrid.tsx
+++ b/apps/home/src/components.projects/ProjectGrid.tsx
@@ -1,4 +1,5 @@
 import { Reveal } from "@duyet/components";
+import { ProjectBlogLinks } from "../components/ProjectBlogLinks";
 import { ProjectCardHeader } from "../components/ProjectCardHeader";
 import { Badge } from "../components/ui/badge";
 import type { AppItem } from "../data/projects";
@@ -42,6 +43,12 @@ export function ProjectGrid({ items }: { items: AppItem[] }) {
                   </Badge>
                 </div>
               </div>
+              <ProjectBlogLinks
+                slugs={item.blogPosts}
+                limit={2}
+                className="mt-2 flex flex-col gap-0.5"
+                linkClassName="rd-ulink text-[11.5px] leading-snug inline-flex items-center gap-1"
+              />
             </div>
           </Reveal>
         );

--- a/apps/home/src/components.projects/ProjectList.tsx
+++ b/apps/home/src/components.projects/ProjectList.tsx
@@ -1,8 +1,15 @@
 import { Link } from "@tanstack/react-router";
+import { ArrowUpRight } from "lucide-react";
 import { addUtmParams } from "../../app/lib/utm";
 import { Badge } from "../components/ui/badge";
 import type { AppItem } from "../data/projects";
 import { ColoredDomain } from "./ColoredDomain";
+import rawBlogPosts from "../../../blog/public/posts-data.json";
+
+type BlogPost = { slug: string; title: string };
+const blogBySlug = new Map<string, BlogPost>(
+  (rawBlogPosts as BlogPost[]).map((p) => [p.slug, p]),
+);
 
 function Logo({
   logo,
@@ -89,7 +96,12 @@ export function ProjectList({ items }: { items: AppItem[] }) {
         const rowClass =
           "rd-row flex items-center gap-4 no-underline text-inherit cursor-pointer";
 
-        return isExternal ? (
+        const blogPosts =
+          item.blogPosts
+            ?.map((slug) => blogBySlug.get(slug))
+            .filter((p): p is BlogPost => p !== undefined) ?? [];
+
+        const row = isExternal ? (
           <a
             key={item.name}
             href={href}
@@ -103,6 +115,30 @@ export function ProjectList({ items }: { items: AppItem[] }) {
           <Link key={item.name} to={href} className={rowClass}>
             {inner}
           </Link>
+        );
+
+        if (blogPosts.length === 0) return row;
+
+        return (
+          <div key={item.name} className="flex flex-col">
+            {row}
+            <div className="flex items-center gap-3 px-4 pb-3 mt-[-6px]">
+              <span className="text-[11px] font-[var(--font-mono)] text-[var(--rd-text-3)] uppercase tracking-wider">
+                Posts
+              </span>
+              {blogPosts.map((post) => (
+                <a
+                  key={post.slug}
+                  href={`https://blog.duyet.net${post.slug}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="rd-ulink text-[12px] inline-flex items-center gap-1"
+                >
+                  {post.title} <ArrowUpRight size={10} />
+                </a>
+              ))}
+            </div>
+          </div>
         );
       })}
     </div>

--- a/apps/home/src/components.projects/ProjectList.tsx
+++ b/apps/home/src/components.projects/ProjectList.tsx
@@ -1,6 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import { addUtmParams } from "../../app/lib/utm";
+import { ProjectBlogLinks } from "../components/ProjectBlogLinks";
 import { Badge } from "../components/ui/badge";
+import { resolveBlogPosts } from "../data/blog-posts";
 import type { AppItem } from "../data/projects";
 import { ColoredDomain } from "./ColoredDomain";
 
@@ -89,7 +91,9 @@ export function ProjectList({ items }: { items: AppItem[] }) {
         const rowClass =
           "rd-row flex items-center gap-4 no-underline text-inherit cursor-pointer";
 
-        return isExternal ? (
+        const blogPosts = resolveBlogPosts(item.blogPosts);
+
+        const row = isExternal ? (
           <a
             key={item.name}
             href={href}
@@ -103,6 +107,21 @@ export function ProjectList({ items }: { items: AppItem[] }) {
           <Link key={item.name} to={href} className={rowClass}>
             {inner}
           </Link>
+        );
+
+        if (blogPosts.length === 0) return row;
+
+        return (
+          <div key={item.name} className="flex flex-col">
+            {row}
+            <ProjectBlogLinks
+              slugs={item.blogPosts}
+              heading="Posts"
+              className="flex items-center gap-3 px-4 pb-3 mt-[-6px]"
+              headingClassName="text-[11px] font-[var(--font-mono)] text-[var(--rd-text-3)] uppercase tracking-wider"
+              linkClassName="rd-ulink text-[12px] inline-flex items-center gap-1"
+            />
+          </div>
         );
       })}
     </div>

--- a/apps/home/src/components/ProjectBlogLinks.tsx
+++ b/apps/home/src/components/ProjectBlogLinks.tsx
@@ -1,0 +1,40 @@
+import { ArrowUpRight } from "lucide-react";
+import { blogPostHref, resolveBlogPosts } from "../data/blog-posts";
+
+export function ProjectBlogLinks({
+  slugs,
+  limit,
+  heading,
+  className,
+  headingClassName = "text-[11px] font-[var(--font-mono)] text-[var(--rd-text-3)] mb-1.5 uppercase tracking-wider",
+  linkClassName,
+  iconSize = 10,
+}: {
+  slugs?: string[];
+  limit?: number;
+  heading?: string;
+  className?: string;
+  headingClassName?: string;
+  linkClassName?: string;
+  iconSize?: number;
+}) {
+  const posts = resolveBlogPosts(slugs, limit);
+  if (posts.length === 0) return null;
+
+  return (
+    <div className={className}>
+      {heading ? <p className={headingClassName}>{heading}</p> : null}
+      {posts.map((post) => (
+        <a
+          key={post.slug}
+          href={blogPostHref(post.slug)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linkClassName}
+        >
+          {post.title} <ArrowUpRight size={iconSize} className="inline" />
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/apps/home/src/components/WorkBento.tsx
+++ b/apps/home/src/components/WorkBento.tsx
@@ -32,6 +32,46 @@ import { addUtmParams } from "../../app/lib/utm";
 import type { AppItem } from "../data/projects";
 import { ProjectCardHeader } from "./ProjectCardHeader";
 import { Badge } from "./ui/badge";
+import rawBlogPosts from "../../../blog/public/posts-data.json";
+
+type BlogPost = {
+  slug: string;
+  title: string;
+};
+
+const blogBySlug = new Map<string, BlogPost>(
+  (rawBlogPosts as BlogPost[]).map((p) => [p.slug, p]),
+);
+
+function BlogLinks({ slugs }: { slugs: string[] }) {
+  const posts = slugs
+    .map((slug) => blogBySlug.get(slug))
+    .filter((p): p is BlogPost => p !== undefined);
+
+  if (!posts.length) return null;
+
+  return (
+    <div className="mt-3">
+      <p className="text-[11px] font-[var(--font-mono)] text-[var(--rd-text-3)] mb-1.5 uppercase tracking-wider">
+        Related posts
+      </p>
+      <ul className="flex flex-col gap-1">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <a
+              href={`https://blog.duyet.net${post.slug}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rd-ulink text-[12.5px] leading-snug"
+            >
+              {post.title} <ArrowUpRight size={11} className="inline" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 interface WorkBentoProps {
   selectedProjects: { item: AppItem; tag: string }[];
@@ -240,6 +280,10 @@ export function WorkBento({ selectedProjects }: WorkBentoProps) {
                       Visit project <ArrowUpRight size={13} />
                     </a>
                   </div>
+
+                  {item.blogPosts ? (
+                    <BlogLinks slugs={item.blogPosts} />
+                  ) : null}
 
                   <Media item={item} />
                 </motion.div>

--- a/apps/home/src/components/WorkBento.tsx
+++ b/apps/home/src/components/WorkBento.tsx
@@ -29,6 +29,7 @@ import {
 import { useState } from "react";
 import { addUtmParams } from "../../app/lib/utm";
 import type { AppItem } from "../data/projects";
+import { ProjectBlogLinks } from "./ProjectBlogLinks";
 import { ProjectCardHeader } from "./ProjectCardHeader";
 import { Badge } from "./ui/badge";
 
@@ -209,6 +210,14 @@ export function WorkBento({ selectedProjects }: WorkBentoProps) {
                     Visit project <ArrowUpRight size={13} />
                   </a>
                 </div>
+
+                <ProjectBlogLinks
+                  slugs={item.blogPosts}
+                  heading="Related posts"
+                  className="mt-3 flex flex-col gap-1"
+                  linkClassName="rd-ulink text-[12.5px] leading-snug"
+                  iconSize={11}
+                />
 
                 <Media item={item} />
               </div>

--- a/apps/home/src/data/blog-posts.ts
+++ b/apps/home/src/data/blog-posts.ts
@@ -1,0 +1,25 @@
+import rawBlogPosts from "../../../blog/public/posts-data.json";
+
+export type BlogPost = {
+  slug: string;
+  title: string;
+};
+
+const blogBySlug = new Map<string, BlogPost>(
+  (rawBlogPosts as BlogPost[]).map((post) => [post.slug, post])
+);
+
+/** Resolve project `blogPosts` slugs to known blog entries, dropping unknowns. */
+export function resolveBlogPosts(
+  slugs: string[] | undefined,
+  limit?: number
+): BlogPost[] {
+  const posts = (slugs ?? [])
+    .map((slug) => blogBySlug.get(slug))
+    .filter((post): post is BlogPost => post !== undefined);
+  return limit === undefined ? posts : posts.slice(0, limit);
+}
+
+export function blogPostHref(slug: string): string {
+  return `https://blog.duyet.net${slug}`;
+}

--- a/apps/home/src/data/projects.ts
+++ b/apps/home/src/data/projects.ts
@@ -34,6 +34,11 @@ export interface AppItem {
   logo?: string;
   /** Optional dark-mode logo URL. If provided, used when user prefers dark mode. */
   logoDark?: string;
+  /**
+   * Blog post slugs to link from this project card. Each slug is a path like
+   * "/2026/06/goal-and-loop" — rendered as a link to https://blog.duyet.net{slug}.
+   */
+  blogPosts?: string[];
 }
 
 const hostOf = (url: string) => new URL(url).host;
@@ -81,6 +86,7 @@ export const apps: AppItem[] = [
     iconName: "Database",
     logo: "https://chmonitor.dev/brand/logo-chmonitor-avatar-solid.svg",
     tags: ["Data", "AI"],
+    blogPosts: ["/2024/03/clickhouse-monitoring"],
   },
   {
     name: "ShareHTML",
@@ -135,6 +141,7 @@ export const apps: AppItem[] = [
     logo: "https://cdn.simpleicons.org/modelcontextprotocol",
     logoDark: "https://cdn.simpleicons.org/modelcontextprotocol/ffffff",
     tags: ["AI", "Tool"],
+    blogPosts: ["/2026/01/coding-agent"],
   },
   {
     name: "Claude Codex Plugins",
@@ -146,6 +153,7 @@ export const apps: AppItem[] = [
     tone: "bg-[#4f6f62]",
     iconName: "Puzzle",
     tags: ["AI", "TypeScript"],
+    blogPosts: ["/2026/01/coding-agent/duyet-claude-plugins"],
   },
   {
     name: "Stamps",
@@ -233,6 +241,7 @@ export const apps: AppItem[] = [
     domain: "github.com/duyet/ccr",
     iconName: "Bot",
     tags: ["AI", "TypeScript"],
+    blogPosts: ["/2026/01/coding-agent/claude-code"],
   },
   {
     name: "Codex & Claude Plugins",
@@ -247,6 +256,7 @@ export const apps: AppItem[] = [
     logo: "https://cdn.simpleicons.org/anthropic",
     logoDark: "https://cdn.simpleicons.org/anthropic/ffffff",
     tags: ["AI", "TypeScript"],
+    blogPosts: ["/2026/01/coding-agent/duyet-claude-plugins", "/2026/01/coding-agent/opencode"],
   },
   {
     name: "duyet MCP Server",
@@ -438,5 +448,18 @@ export const apps: AppItem[] = [
     iconName: "Cpu",
     logo: "https://raw.githubusercontent.com/duyet/build-agent/refs/heads/main/assets/logo.svg",
     tags: ["AI", "Tool"],
+    blogPosts: ["/2026/06/goal-and-loop", "/2026/07/open-managed-agents"],
+  },
+  {
+    name: "OMA",
+    href: "https://github.com/duyet/oma",
+    host: "github.com",
+    utmContent: "oma_bento",
+    description:
+      "Open Managed Agents — a self-hosted control plane on Cloudflare that drives agents on any sandbox backend from one UI and one API.",
+    domain: "github.com/duyet/oma",
+    iconName: "Cpu",
+    tags: ["AI", "Infra"],
+    blogPosts: ["/2026/07/open-managed-agents"],
   },
 ];

--- a/apps/home/src/data/projects.ts
+++ b/apps/home/src/data/projects.ts
@@ -34,6 +34,11 @@ export interface AppItem {
   logo?: string;
   /** Optional dark-mode logo URL. If provided, used when user prefers dark mode. */
   logoDark?: string;
+  /**
+   * Blog post slugs to link from this project card. Each slug is a path like
+   * "/2026/06/goal-and-loop" — rendered as a link to https://blog.duyet.net{slug}.
+   */
+  blogPosts?: string[];
 }
 
 const hostOf = (url: string) => new URL(url).host;
@@ -81,6 +86,7 @@ export const apps: AppItem[] = [
     iconName: "Database",
     logo: "https://chmonitor.dev/brand/logo-chmonitor-avatar-solid.svg",
     tags: ["Data", "AI"],
+    blogPosts: ["/2024/03/clickhouse-monitoring"],
   },
   {
     name: "ShareHTML",
@@ -135,6 +141,7 @@ export const apps: AppItem[] = [
     logo: "https://cdn.simpleicons.org/modelcontextprotocol",
     logoDark: "https://cdn.simpleicons.org/modelcontextprotocol/ffffff",
     tags: ["AI", "Tool"],
+    blogPosts: ["/2026/01/coding-agent"],
   },
   {
     name: "Claude Codex Plugins",
@@ -146,6 +153,7 @@ export const apps: AppItem[] = [
     tone: "bg-[#4f6f62]",
     iconName: "Puzzle",
     tags: ["AI", "TypeScript"],
+    blogPosts: ["/2026/01/coding-agent/duyet-claude-plugins"],
   },
   {
     name: "Stamps",
@@ -233,6 +241,7 @@ export const apps: AppItem[] = [
     domain: "github.com/duyet/ccr",
     iconName: "Bot",
     tags: ["AI", "TypeScript"],
+    blogPosts: ["/2026/01/coding-agent/claude-code"],
   },
   {
     name: "Codex & Claude Plugins",
@@ -247,6 +256,10 @@ export const apps: AppItem[] = [
     logo: "https://cdn.simpleicons.org/anthropic",
     logoDark: "https://cdn.simpleicons.org/anthropic/ffffff",
     tags: ["AI", "TypeScript"],
+    blogPosts: [
+      "/2026/01/coding-agent/duyet-claude-plugins",
+      "/2026/01/coding-agent/opencode",
+    ],
   },
   {
     name: "duyet MCP Server",
@@ -438,5 +451,18 @@ export const apps: AppItem[] = [
     iconName: "Cpu",
     logo: "https://raw.githubusercontent.com/duyet/build-agent/refs/heads/main/assets/logo.svg",
     tags: ["AI", "Tool"],
+    blogPosts: ["/2026/06/goal-and-loop", "/2026/07/open-managed-agents"],
+  },
+  {
+    name: "OMA",
+    href: "https://github.com/duyet/oma",
+    host: "github.com",
+    utmContent: "oma_bento",
+    description:
+      "Open Managed Agents — a self-hosted control plane on Cloudflare that drives agents on any sandbox backend from one UI and one API.",
+    domain: "github.com/duyet/oma",
+    iconName: "Cpu",
+    tags: ["AI", "Infra"],
+    blogPosts: ["/2026/07/open-managed-agents"],
   },
 ];

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -54,6 +54,7 @@ const SELECTED: { name: string; tag: string }[] = [
   { name: "ClickHouse Monitoring", tag: "Data" },
   { name: "Agent State", tag: "AI" },
   { name: "MCP Tools", tag: "AI" },
+  { name: "OMA", tag: "AI Infra" },
   { name: "LLM over DNS", tag: "AI Infra" },
   { name: "ccusage → ClickHouse", tag: "Data" },
   { name: "Clauduck", tag: "Data" },

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -55,6 +55,7 @@ const SELECTED: { name: string; tag: string }[] = [
   { name: "ClickHouse Monitoring", tag: "Data" },
   { name: "Agent State", tag: "AI" },
   { name: "MCP Tools", tag: "AI" },
+  { name: "OMA", tag: "AI Infra" },
   { name: "LLM over DNS", tag: "AI Infra" },
   { name: "ccusage → ClickHouse", tag: "Data" },
   { name: "Clauduck", tag: "Data" },


### PR DESCRIPTION
Wire blog post slugs into the project data model and render them as "Related posts" links in three views:

- **WorkBento** expanded cards (landing page) — blog links shown in the expanded detail panel  
- **ProjectGrid** cards (projects page) — blog links shown below badges  
- **ProjectList** rows (projects page) — blog links shown below the row

Also adds **OMA** to the featured SELECTED set on the landing page.