### PR TITLE
fix(burns): stop labeling gemini as Antigravity and refresh UX

### DIFF
--- a/apps/burns/package.json
+++ b/apps/burns/package.json
@@ -9,6 +9,8 @@
     "dev": "vite dev --port 3010",
     "fmt": "biome format --write .",
     "lint": "biome lint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "cf:deploy:prod": "../../scripts/cf-deploy-prod.sh burns duyet-burns"
   },
   "dependencies": {

--- a/apps/burns/public/token-data.json
+++ b/apps/burns/public/token-data.json
@@ -1,31 +1,32 @@
 {
-  "generatedAt": "2026-08-08T19:11:36.278Z",
+  "generatedAt": "2026-08-14T05:28:05.530Z",
   "firstDate": "2025-08-02",
-  "lastDate": "2026-08-09",
+  "lastDate": "2026-08-14",
   "sources": [
-    "Google Antigravity",
-    "Z.AI",
-    "opencode",
     "Claude Code",
+    "Z.AI",
     "Codex",
-    "Grok",
+    "Google Antigravity",
+    "opencode",
     "OpenClaw",
+    "Grok",
+    "Gemini CLI",
     "Hermes",
     "pi"
   ],
   "totals": {
-    "input_tokens": 4446520828,
-    "output_tokens": 341006263,
-    "cache_creation_tokens": 2148165785,
-    "cache_read_tokens": 104365293761,
-    "total_tokens": 111300986637,
-    "total_cost": 229509.18
+    "input_tokens": 4503925139,
+    "output_tokens": 351462577,
+    "cache_creation_tokens": 2212217303,
+    "cache_read_tokens": 107893928391,
+    "total_tokens": 114961533410,
+    "total_cost": 233056.11
   },
   "source_totals": [
     {
       "source": "Claude Code",
-      "total_tokens": 72910671570,
-      "cost": 48523.97
+      "total_tokens": 75891713682,
+      "cost": 52130.13
     },
     {
       "source": "Z.AI",
@@ -39,8 +40,8 @@
     },
     {
       "source": "Google Antigravity",
-      "total_tokens": 4833642482,
-      "cost": 916.4
+      "total_tokens": 4515308139,
+      "cost": 859.85
     },
     {
       "source": "opencode",
@@ -54,13 +55,18 @@
     },
     {
       "source": "Grok",
-      "total_tokens": 296518838,
-      "cost": 214.16
+      "total_tokens": 875820347,
+      "cost": 136.57
+    },
+    {
+      "source": "Gemini CLI",
+      "total_tokens": 404158241,
+      "cost": 75.74
     },
     {
       "source": "Hermes",
-      "total_tokens": 152630802,
-      "cost": 165121.31
+      "total_tokens": 167010056,
+      "cost": 165120.48
     },
     {
       "source": "pi",
@@ -70,39 +76,209 @@
   ],
   "daily": [
     {
-      "date": "2026-08-09",
-      "input_tokens": 807715,
-      "output_tokens": 5941,
-      "cache_creation_tokens": 0,
-      "cache_read_tokens": 0,
-      "total_tokens": 813656,
-      "cost": 0,
+      "date": "2026-08-14",
+      "input_tokens": 8226558,
+      "output_tokens": 1886474,
+      "cache_creation_tokens": 5525275,
+      "cache_read_tokens": 458625616,
+      "total_tokens": 474263923,
+      "cost": 554.46,
       "by_source": [
         {
           "source": "Claude Code",
-          "total_tokens": 813656,
+          "total_tokens": 269084662,
+          "cost": 546.43
+        },
+        {
+          "source": "Grok",
+          "total_tokens": 189062888,
+          "cost": 4.8
+        },
+        {
+          "source": "Google Antigravity",
+          "total_tokens": 14303983,
+          "cost": 3.23
+        },
+        {
+          "source": "Hermes",
+          "total_tokens": 1812390,
+          "cost": 0
+        }
+      ]
+    },
+    {
+      "date": "2026-08-13",
+      "input_tokens": 8302408,
+      "output_tokens": 2810064,
+      "cache_creation_tokens": 20729132,
+      "cache_read_tokens": 1232639627,
+      "total_tokens": 1264481231,
+      "cost": 1153.04,
+      "by_source": [
+        {
+          "source": "Claude Code",
+          "total_tokens": 1208348227,
+          "cost": 1149.61
+        },
+        {
+          "source": "Grok",
+          "total_tokens": 39711617,
+          "cost": 0.2
+        },
+        {
+          "source": "Google Antigravity",
+          "total_tokens": 14303983,
+          "cost": 3.23
+        },
+        {
+          "source": "Hermes",
+          "total_tokens": 2117404,
+          "cost": 0
+        }
+      ]
+    },
+    {
+      "date": "2026-08-12",
+      "input_tokens": 14153183,
+      "output_tokens": 2703284,
+      "cache_creation_tokens": 17865981,
+      "cache_read_tokens": 845427328,
+      "total_tokens": 880149776,
+      "cost": 1036.61,
+      "by_source": [
+        {
+          "source": "Claude Code",
+          "total_tokens": 701836598,
+          "cost": 997.55
+        },
+        {
+          "source": "Grok",
+          "total_tokens": 163239177,
+          "cost": 35.83
+        },
+        {
+          "source": "Google Antigravity",
+          "total_tokens": 14303983,
+          "cost": 3.23
+        },
+        {
+          "source": "Hermes",
+          "total_tokens": 770018,
+          "cost": 0
+        }
+      ]
+    },
+    {
+      "date": "2026-08-11",
+      "input_tokens": 8147838,
+      "output_tokens": 2026490,
+      "cache_creation_tokens": 14876224,
+      "cache_read_tokens": 626248836,
+      "total_tokens": 651299388,
+      "cost": 643.04,
+      "by_source": [
+        {
+          "source": "Claude Code",
+          "total_tokens": 575892617,
+          "cost": 626.41
+        },
+        {
+          "source": "Grok",
+          "total_tokens": 58625030,
+          "cost": 13.4
+        },
+        {
+          "source": "Google Antigravity",
+          "total_tokens": 14303983,
+          "cost": 3.23
+        },
+        {
+          "source": "Hermes",
+          "total_tokens": 2477758,
+          "cost": 0
+        }
+      ]
+    },
+    {
+      "date": "2026-08-10",
+      "input_tokens": 11229859,
+      "output_tokens": 921949,
+      "cache_creation_tokens": 5054906,
+      "cache_read_tokens": 284829966,
+      "total_tokens": 302036680,
+      "cost": 165.39,
+      "by_source": [
+        {
+          "source": "Claude Code",
+          "total_tokens": 201394664,
+          "cost": 161.35
+        },
+        {
+          "source": "Grok",
+          "total_tokens": 85012809,
+          "cost": 0.81
+        },
+        {
+          "source": "Google Antigravity",
+          "total_tokens": 14303983,
+          "cost": 3.23
+        },
+        {
+          "source": "Hermes",
+          "total_tokens": 1325224,
+          "cost": 0
+        }
+      ]
+    },
+    {
+      "date": "2026-08-09",
+      "input_tokens": 10854554,
+      "output_tokens": 525978,
+      "cache_creation_tokens": 0,
+      "cache_read_tokens": 118756505,
+      "total_tokens": 130137037,
+      "cost": 170.66,
+      "by_source": [
+        {
+          "source": "Grok",
+          "total_tokens": 84657594,
+          "cost": 42.61
+        },
+        {
+          "source": "Claude Code",
+          "total_tokens": 25299000,
+          "cost": 124.82
+        },
+        {
+          "source": "Google Antigravity",
+          "total_tokens": 14303983,
+          "cost": 3.23
+        },
+        {
+          "source": "Hermes",
+          "total_tokens": 5876460,
           "cost": 0
         }
       ]
     },
     {
       "date": "2026-08-08",
-      "input_tokens": 3974237,
-      "output_tokens": 475230,
+      "input_tokens": 3118696,
+      "output_tokens": 382250,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 70453593,
-      "total_tokens": 74903060,
-      "cost": 37.73,
+      "cache_read_tokens": 64533721,
+      "total_tokens": 68034667,
+      "cost": 24.12,
       "by_source": [
         {
           "source": "Grok",
-          "total_tokens": 60285211,
-          "cost": 34.31
+          "total_tokens": 53416818,
+          "cost": 20.89
         },
         {
           "source": "Google Antigravity",
           "total_tokens": 14303983,
-          "cost": 3.42
+          "cost": 3.23
         },
         {
           "source": "Hermes",
@@ -113,12 +289,12 @@
     },
     {
       "date": "2026-08-07",
-      "input_tokens": 11459820,
-      "output_tokens": 1891867,
+      "input_tokens": 9612987,
+      "output_tokens": 1572863,
       "cache_creation_tokens": 8013817,
-      "cache_read_tokens": 411687896,
-      "total_tokens": 433053400,
-      "cost": 418.07,
+      "cache_read_tokens": 379714520,
+      "total_tokens": 398914187,
+      "cost": 322.67,
       "by_source": [
         {
           "source": "Claude Code",
@@ -127,8 +303,8 @@
         },
         {
           "source": "Grok",
-          "total_tokens": 150992629,
-          "cost": 113.43
+          "total_tokens": 116853416,
+          "cost": 18.03
         },
         {
           "source": "Google Antigravity",
@@ -149,12 +325,12 @@
       "cache_creation_tokens": 0,
       "cache_read_tokens": 45922338,
       "total_tokens": 47860500,
-      "cost": 33.91,
+      "cost": 0.19,
       "by_source": [
         {
           "source": "Grok",
           "total_tokens": 44951830,
-          "cost": 33.72
+          "cost": 0
         },
         {
           "source": "Hermes",
@@ -175,7 +351,7 @@
       "cache_creation_tokens": 11475676,
       "cache_read_tokens": 901912792,
       "total_tokens": 917405449,
-      "cost": 566.69,
+      "cost": 533.99,
       "by_source": [
         {
           "source": "Claude Code",
@@ -185,7 +361,7 @@
         {
           "source": "Grok",
           "total_tokens": 40289168,
-          "cost": 32.7
+          "cost": 0
         },
         {
           "source": "Hermes",
@@ -1911,7 +2087,7 @@
       "cache_creation_tokens": 8771785,
       "cache_read_tokens": 684867379,
       "total_tokens": 765433835,
-      "cost": 419.14,
+      "cost": 419.12,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1936,7 +2112,7 @@
         {
           "source": "Hermes",
           "total_tokens": 447429,
-          "cost": 0.02
+          "cost": 0
         }
       ]
     },
@@ -1978,7 +2154,7 @@
       "cache_creation_tokens": 9526013,
       "cache_read_tokens": 698694276,
       "total_tokens": 717524613,
-      "cost": 379.73,
+      "cost": 379.19,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1998,7 +2174,7 @@
         {
           "source": "Hermes",
           "total_tokens": 5164648,
-          "cost": 0.54
+          "cost": 0
         }
       ]
     },
@@ -2081,7 +2257,7 @@
       "cache_creation_tokens": 2860492,
       "cache_read_tokens": 324365072,
       "total_tokens": 341290875,
-      "cost": 25205.8,
+      "cost": 25205.78,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2106,7 +2282,7 @@
         {
           "source": "Hermes",
           "total_tokens": 21516057,
-          "cost": 25029.34
+          "cost": 25029.32
         },
         {
           "source": "opencode",
@@ -2234,8 +2410,8 @@
       "by_source": [
         {
           "source": "Google Antigravity",
-          "total_tokens": 266740048,
-          "cost": 64.1
+          "total_tokens": 265720344,
+          "cost": 63.07
         },
         {
           "source": "Claude Code",
@@ -2261,6 +2437,11 @@
           "source": "Hermes",
           "total_tokens": 2018024,
           "cost": 0
+        },
+        {
+          "source": "Gemini CLI",
+          "total_tokens": 1019704,
+          "cost": 1.03
         }
       ]
     },
@@ -2285,13 +2466,18 @@
         },
         {
           "source": "Google Antigravity",
-          "total_tokens": 235047550,
-          "cost": 53.42
+          "total_tokens": 205718976,
+          "cost": 48.83
         },
         {
           "source": "opencode",
           "total_tokens": 103981987,
           "cost": 0
+        },
+        {
+          "source": "Gemini CLI",
+          "total_tokens": 29328574,
+          "cost": 4.59
         },
         {
           "source": "Hermes",
@@ -2753,7 +2939,7 @@
           "cost": 25.8
         },
         {
-          "source": "Google Antigravity",
+          "source": "Gemini CLI",
           "total_tokens": 10125532,
           "cost": 4.11
         },
@@ -2833,7 +3019,7 @@
       "cache_creation_tokens": 11774124,
       "cache_read_tokens": 1106522845,
       "total_tokens": 1132769408,
-      "cost": 28553.14,
+      "cost": 28553.08,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2853,7 +3039,7 @@
         {
           "source": "Hermes",
           "total_tokens": 9104465,
-          "cost": 27758.16
+          "cost": 27758.1
         }
       ]
     },
@@ -2864,7 +3050,7 @@
       "cache_creation_tokens": 7863155,
       "cache_read_tokens": 745190497,
       "total_tokens": 773387799,
-      "cost": 504.87,
+      "cost": 504.84,
       "by_source": [
         {
           "source": "Codex",
@@ -2884,7 +3070,7 @@
         {
           "source": "Hermes",
           "total_tokens": 534749,
-          "cost": 0.03
+          "cost": 0
         }
       ]
     },
@@ -2980,7 +3166,7 @@
           "cost": 30.44
         },
         {
-          "source": "Google Antigravity",
+          "source": "Gemini CLI",
           "total_tokens": 56586046,
           "cost": 19.67
         },
@@ -3001,7 +3187,7 @@
       "cost": 187.07,
       "by_source": [
         {
-          "source": "Google Antigravity",
+          "source": "Gemini CLI",
           "total_tokens": 160130863,
           "cost": 26.82
         },
@@ -3153,7 +3339,7 @@
       "cache_creation_tokens": 971002,
       "cache_read_tokens": 130305268,
       "total_tokens": 140171661,
-      "cost": 27.43,
+      "cost": 27.4,
       "by_source": [
         {
           "source": "opencode",
@@ -3171,7 +3357,7 @@
           "cost": 8.61
         },
         {
-          "source": "Google Antigravity",
+          "source": "Gemini CLI",
           "total_tokens": 12299802,
           "cost": 2.3
         },
@@ -3183,7 +3369,7 @@
         {
           "source": "Hermes",
           "total_tokens": 203696,
-          "cost": 0.03
+          "cost": 0
         }
       ]
     },
@@ -3194,7 +3380,7 @@
       "cache_creation_tokens": 0,
       "cache_read_tokens": 130217607,
       "total_tokens": 138484181,
-      "cost": 112.18,
+      "cost": 112.05,
       "by_source": [
         {
           "source": "Codex",
@@ -3214,7 +3400,7 @@
         {
           "source": "Hermes",
           "total_tokens": 1019390,
-          "cost": 0.13
+          "cost": 0
         }
       ]
     },
@@ -3462,7 +3648,7 @@
       "cost": 63.8,
       "by_source": [
         {
-          "source": "Google Antigravity",
+          "source": "Gemini CLI",
           "total_tokens": 134667720,
           "cost": 17.22
         },

--- a/apps/burns/public/token-data.json
+++ b/apps/burns/public/token-data.json
@@ -1,12 +1,11 @@
 {
-  "generatedAt": "2026-08-14T05:28:05.530Z",
+  "generatedAt": "2026-08-14T06:19:07.904Z",
   "firstDate": "2025-08-02",
   "lastDate": "2026-08-14",
   "sources": [
     "Claude Code",
     "Z.AI",
     "Codex",
-    "Google Antigravity",
     "opencode",
     "OpenClaw",
     "Grok",
@@ -15,12 +14,12 @@
     "pi"
   ],
   "totals": {
-    "input_tokens": 4503925139,
-    "output_tokens": 351462577,
+    "input_tokens": 4248158232,
+    "output_tokens": 336352045,
     "cache_creation_tokens": 2212217303,
-    "cache_read_tokens": 107893928391,
-    "total_tokens": 114961533410,
-    "total_cost": 233056.11
+    "cache_read_tokens": 103649497691,
+    "total_tokens": 110446225271,
+    "total_cost": 232196.26
   },
   "source_totals": [
     {
@@ -37,11 +36,6 @@
       "source": "Codex",
       "total_tokens": 11180305332,
       "cost": 6234.5
-    },
-    {
-      "source": "Google Antigravity",
-      "total_tokens": 4515308139,
-      "cost": 859.85
     },
     {
       "source": "opencode",
@@ -77,12 +71,12 @@
   "daily": [
     {
       "date": "2026-08-14",
-      "input_tokens": 8226558,
-      "output_tokens": 1886474,
+      "input_tokens": 7560927,
+      "output_tokens": 1843987,
       "cache_creation_tokens": 5525275,
-      "cache_read_tokens": 458625616,
-      "total_tokens": 474263923,
-      "cost": 554.46,
+      "cache_read_tokens": 445029751,
+      "total_tokens": 459959940,
+      "cost": 551.23,
       "by_source": [
         {
           "source": "Claude Code",
@@ -95,11 +89,6 @@
           "cost": 4.8
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.23
-        },
-        {
           "source": "Hermes",
           "total_tokens": 1812390,
           "cost": 0
@@ -108,12 +97,12 @@
     },
     {
       "date": "2026-08-13",
-      "input_tokens": 8302408,
-      "output_tokens": 2810064,
+      "input_tokens": 7636777,
+      "output_tokens": 2767577,
       "cache_creation_tokens": 20729132,
-      "cache_read_tokens": 1232639627,
-      "total_tokens": 1264481231,
-      "cost": 1153.04,
+      "cache_read_tokens": 1219043762,
+      "total_tokens": 1250177248,
+      "cost": 1149.81,
       "by_source": [
         {
           "source": "Claude Code",
@@ -126,11 +115,6 @@
           "cost": 0.2
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.23
-        },
-        {
           "source": "Hermes",
           "total_tokens": 2117404,
           "cost": 0
@@ -139,12 +123,12 @@
     },
     {
       "date": "2026-08-12",
-      "input_tokens": 14153183,
-      "output_tokens": 2703284,
+      "input_tokens": 13487552,
+      "output_tokens": 2660797,
       "cache_creation_tokens": 17865981,
-      "cache_read_tokens": 845427328,
-      "total_tokens": 880149776,
-      "cost": 1036.61,
+      "cache_read_tokens": 831831463,
+      "total_tokens": 865845793,
+      "cost": 1033.38,
       "by_source": [
         {
           "source": "Claude Code",
@@ -157,11 +141,6 @@
           "cost": 35.83
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.23
-        },
-        {
           "source": "Hermes",
           "total_tokens": 770018,
           "cost": 0
@@ -170,12 +149,12 @@
     },
     {
       "date": "2026-08-11",
-      "input_tokens": 8147838,
-      "output_tokens": 2026490,
+      "input_tokens": 7482207,
+      "output_tokens": 1984003,
       "cache_creation_tokens": 14876224,
-      "cache_read_tokens": 626248836,
-      "total_tokens": 651299388,
-      "cost": 643.04,
+      "cache_read_tokens": 612652971,
+      "total_tokens": 636995405,
+      "cost": 639.81,
       "by_source": [
         {
           "source": "Claude Code",
@@ -188,11 +167,6 @@
           "cost": 13.4
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.23
-        },
-        {
           "source": "Hermes",
           "total_tokens": 2477758,
           "cost": 0
@@ -201,12 +175,12 @@
     },
     {
       "date": "2026-08-10",
-      "input_tokens": 11229859,
-      "output_tokens": 921949,
+      "input_tokens": 10564228,
+      "output_tokens": 879462,
       "cache_creation_tokens": 5054906,
-      "cache_read_tokens": 284829966,
-      "total_tokens": 302036680,
-      "cost": 165.39,
+      "cache_read_tokens": 271234101,
+      "total_tokens": 287732697,
+      "cost": 162.16,
       "by_source": [
         {
           "source": "Claude Code",
@@ -219,11 +193,6 @@
           "cost": 0.81
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.23
-        },
-        {
           "source": "Hermes",
           "total_tokens": 1325224,
           "cost": 0
@@ -232,12 +201,12 @@
     },
     {
       "date": "2026-08-09",
-      "input_tokens": 10854554,
-      "output_tokens": 525978,
+      "input_tokens": 10188923,
+      "output_tokens": 483491,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 118756505,
-      "total_tokens": 130137037,
-      "cost": 170.66,
+      "cache_read_tokens": 105160640,
+      "total_tokens": 115833054,
+      "cost": 167.43,
       "by_source": [
         {
           "source": "Grok",
@@ -250,11 +219,6 @@
           "cost": 124.82
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.23
-        },
-        {
           "source": "Hermes",
           "total_tokens": 5876460,
           "cost": 0
@@ -263,22 +227,17 @@
     },
     {
       "date": "2026-08-08",
-      "input_tokens": 3118696,
-      "output_tokens": 382250,
+      "input_tokens": 2453065,
+      "output_tokens": 339763,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 64533721,
-      "total_tokens": 68034667,
-      "cost": 24.12,
+      "cache_read_tokens": 50937856,
+      "total_tokens": 53730684,
+      "cost": 20.89,
       "by_source": [
         {
           "source": "Grok",
           "total_tokens": 53416818,
           "cost": 20.89
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.23
         },
         {
           "source": "Hermes",
@@ -289,12 +248,12 @@
     },
     {
       "date": "2026-08-07",
-      "input_tokens": 9612987,
-      "output_tokens": 1572863,
+      "input_tokens": 8947356,
+      "output_tokens": 1530376,
       "cache_creation_tokens": 8013817,
-      "cache_read_tokens": 379714520,
-      "total_tokens": 398914187,
-      "cost": 322.67,
+      "cache_read_tokens": 366118655,
+      "total_tokens": 384610204,
+      "cost": 319.25,
       "by_source": [
         {
           "source": "Claude Code",
@@ -307,11 +266,6 @@
           "cost": 18.03
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
-        },
-        {
           "source": "Hermes",
           "total_tokens": 1778553,
           "cost": 0
@@ -320,12 +274,12 @@
     },
     {
       "date": "2026-08-06",
-      "input_tokens": 1766714,
-      "output_tokens": 171448,
+      "input_tokens": 1729197,
+      "output_tokens": 169053,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 45922338,
-      "total_tokens": 47860500,
-      "cost": 0.19,
+      "cache_read_tokens": 45156032,
+      "total_tokens": 47054282,
+      "cost": 0,
       "by_source": [
         {
           "source": "Grok",
@@ -336,22 +290,17 @@
           "source": "Hermes",
           "total_tokens": 2102452,
           "cost": 0
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 806218,
-          "cost": 0.19
         }
       ]
     },
     {
       "date": "2026-08-05",
-      "input_tokens": 2436634,
-      "output_tokens": 1580347,
+      "input_tokens": 2399117,
+      "output_tokens": 1577952,
       "cache_creation_tokens": 11475676,
-      "cache_read_tokens": 901912792,
-      "total_tokens": 917405449,
-      "cost": 533.99,
+      "cache_read_tokens": 901146486,
+      "total_tokens": 916599231,
+      "cost": 533.8,
       "by_source": [
         {
           "source": "Claude Code",
@@ -367,22 +316,17 @@
           "source": "Hermes",
           "total_tokens": 2714404,
           "cost": 0
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 806218,
-          "cost": 0.19
         }
       ]
     },
     {
       "date": "2026-08-04",
-      "input_tokens": 1996181,
-      "output_tokens": 2420411,
+      "input_tokens": 1958664,
+      "output_tokens": 2418016,
       "cache_creation_tokens": 31078333,
-      "cache_read_tokens": 728993145,
-      "total_tokens": 764488070,
-      "cost": 601.28,
+      "cache_read_tokens": 728226839,
+      "total_tokens": 763681852,
+      "cost": 601.09,
       "by_source": [
         {
           "source": "Claude Code",
@@ -398,22 +342,17 @@
           "source": "Hermes",
           "total_tokens": 2954363,
           "cost": 0
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 806218,
-          "cost": 0.19
         }
       ]
     },
     {
       "date": "2026-08-03",
-      "input_tokens": 3639508,
-      "output_tokens": 3213021,
+      "input_tokens": 3601991,
+      "output_tokens": 3210626,
       "cache_creation_tokens": 25181574,
-      "cache_read_tokens": 1057139142,
-      "total_tokens": 1089173245,
-      "cost": 900.29,
+      "cache_read_tokens": 1056372836,
+      "total_tokens": 1088367027,
+      "cost": 900.1,
       "by_source": [
         {
           "source": "Claude Code",
@@ -429,22 +368,17 @@
           "source": "Hermes",
           "total_tokens": 1620412,
           "cost": 0
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 806218,
-          "cost": 0.19
         }
       ]
     },
     {
       "date": "2026-08-02",
-      "input_tokens": 1947150,
-      "output_tokens": 1042648,
+      "input_tokens": 1281519,
+      "output_tokens": 1000161,
       "cache_creation_tokens": 4719381,
-      "cache_read_tokens": 259127932,
-      "total_tokens": 266837111,
-      "cost": 188.71,
+      "cache_read_tokens": 245532067,
+      "total_tokens": 252533128,
+      "cost": 185.29,
       "by_source": [
         {
           "source": "Claude Code",
@@ -457,11 +391,6 @@
           "cost": 9.64
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
-        },
-        {
           "source": "Hermes",
           "total_tokens": 667735,
           "cost": 0
@@ -470,22 +399,17 @@
     },
     {
       "date": "2026-08-01",
-      "input_tokens": 1019600,
-      "output_tokens": 1748234,
+      "input_tokens": 353969,
+      "output_tokens": 1705747,
       "cache_creation_tokens": 15418466,
-      "cache_read_tokens": 582105413,
-      "total_tokens": 600291713,
-      "cost": 632.55,
+      "cache_read_tokens": 568509548,
+      "total_tokens": 585987730,
+      "cost": 629.13,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 585636770,
           "cost": 629.13
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -496,22 +420,17 @@
     },
     {
       "date": "2026-07-31",
-      "input_tokens": 1486023,
-      "output_tokens": 3365645,
+      "input_tokens": 820392,
+      "output_tokens": 3323158,
       "cache_creation_tokens": 29968351,
-      "cache_read_tokens": 1291393000,
-      "total_tokens": 1326213019,
-      "cost": 1148.22,
+      "cache_read_tokens": 1277797135,
+      "total_tokens": 1311909036,
+      "cost": 1144.8,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 1310461119,
           "cost": 1144.8
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -522,22 +441,17 @@
     },
     {
       "date": "2026-07-30",
-      "input_tokens": 1625154,
-      "output_tokens": 607597,
+      "input_tokens": 959523,
+      "output_tokens": 565110,
       "cache_creation_tokens": 4375754,
-      "cache_read_tokens": 174833494,
-      "total_tokens": 181441999,
-      "cost": 152.64,
+      "cache_read_tokens": 161237629,
+      "total_tokens": 167138016,
+      "cost": 149.22,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 165558184,
           "cost": 149.22
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -548,22 +462,17 @@
     },
     {
       "date": "2026-07-29",
-      "input_tokens": 1966817,
-      "output_tokens": 582584,
+      "input_tokens": 1301186,
+      "output_tokens": 540097,
       "cache_creation_tokens": 2089120,
-      "cache_read_tokens": 153709047,
-      "total_tokens": 158347568,
-      "cost": 101.84,
+      "cache_read_tokens": 140113182,
+      "total_tokens": 144043585,
+      "cost": 98.42,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 135150041,
           "cost": 98.42
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "opencode",
@@ -579,12 +488,12 @@
     },
     {
       "date": "2026-07-28",
-      "input_tokens": 39604995,
-      "output_tokens": 1747414,
+      "input_tokens": 38939364,
+      "output_tokens": 1704927,
       "cache_creation_tokens": 11057545,
-      "cache_read_tokens": 469650112,
-      "total_tokens": 522060066,
-      "cost": 325.41,
+      "cache_read_tokens": 456054247,
+      "total_tokens": 507756083,
+      "cost": 321.99,
       "by_source": [
         {
           "source": "Claude Code",
@@ -597,11 +506,6 @@
           "cost": 0
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
-        },
-        {
           "source": "Hermes",
           "total_tokens": 1853858,
           "cost": 0
@@ -610,22 +514,17 @@
     },
     {
       "date": "2026-07-27",
-      "input_tokens": 1609947,
-      "output_tokens": 2242968,
+      "input_tokens": 944316,
+      "output_tokens": 2200481,
       "cache_creation_tokens": 16576218,
-      "cache_read_tokens": 743049428,
-      "total_tokens": 763478561,
-      "cost": 542.24,
+      "cache_read_tokens": 729453563,
+      "total_tokens": 749174578,
+      "cost": 538.82,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 746630208,
           "cost": 538.71
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -641,22 +540,17 @@
     },
     {
       "date": "2026-07-26",
-      "input_tokens": 1280331,
-      "output_tokens": 1369634,
+      "input_tokens": 614700,
+      "output_tokens": 1327147,
       "cache_creation_tokens": 7694197,
-      "cache_read_tokens": 541883591,
-      "total_tokens": 552227753,
-      "cost": 289.39,
+      "cache_read_tokens": 528287726,
+      "total_tokens": 537923770,
+      "cost": 285.97,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 537315832,
           "cost": 285.97
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -667,22 +561,17 @@
     },
     {
       "date": "2026-07-25",
-      "input_tokens": 1133410,
-      "output_tokens": 6590446,
+      "input_tokens": 467779,
+      "output_tokens": 6547959,
       "cache_creation_tokens": 50561225,
-      "cache_read_tokens": 2515868685,
-      "total_tokens": 2574153766,
-      "cost": 1398.25,
+      "cache_read_tokens": 2502272820,
+      "total_tokens": 2559849783,
+      "cost": 1394.83,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 2559182267,
           "cost": 1394.83
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -693,22 +582,17 @@
     },
     {
       "date": "2026-07-24",
-      "input_tokens": 879727,
-      "output_tokens": 2793235,
+      "input_tokens": 214096,
+      "output_tokens": 2750748,
       "cache_creation_tokens": 21330626,
-      "cache_read_tokens": 841663096,
-      "total_tokens": 866666684,
-      "cost": 772.12,
+      "cache_read_tokens": 828067231,
+      "total_tokens": 852362701,
+      "cost": 768.7,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 851202653,
           "cost": 768.7
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -719,18 +603,13 @@
     },
     {
       "date": "2026-07-23",
-      "input_tokens": 1003485,
-      "output_tokens": 146861,
+      "input_tokens": 259344,
+      "output_tokens": 104786,
       "cache_creation_tokens": 597712,
-      "cache_read_tokens": 12362451,
-      "total_tokens": 14110509,
-      "cost": 12.01,
+      "cache_read_tokens": 7008162,
+      "total_tokens": 7970004,
+      "cost": 11.12,
       "by_source": [
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 6140505,
-          "cost": 0.89
-        },
         {
           "source": "Hermes",
           "total_tokens": 5229785,
@@ -745,22 +624,17 @@
     },
     {
       "date": "2026-07-22",
-      "input_tokens": 72102269,
-      "output_tokens": 423106,
+      "input_tokens": 71436638,
+      "output_tokens": 380619,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 160864069,
-      "total_tokens": 233389444,
-      "cost": 30.98,
+      "cache_read_tokens": 147268204,
+      "total_tokens": 219085461,
+      "cost": 27.56,
       "by_source": [
         {
           "source": "opencode",
           "total_tokens": 217550156,
           "cost": 11.12
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -776,22 +650,17 @@
     },
     {
       "date": "2026-07-21",
-      "input_tokens": 2243410,
-      "output_tokens": 147556,
+      "input_tokens": 1577779,
+      "output_tokens": 105069,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 99084633,
-      "total_tokens": 101475599,
-      "cost": 6.71,
+      "cache_read_tokens": 85488768,
+      "total_tokens": 87171616,
+      "cost": 3.29,
       "by_source": [
         {
           "source": "opencode",
           "total_tokens": 84940699,
           "cost": 0.42
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -807,12 +676,12 @@
     },
     {
       "date": "2026-07-20",
-      "input_tokens": 52268139,
-      "output_tokens": 2068936,
+      "input_tokens": 51602508,
+      "output_tokens": 2026449,
       "cache_creation_tokens": 12704531,
-      "cache_read_tokens": 594093480,
-      "total_tokens": 661135086,
-      "cost": 513.77,
+      "cache_read_tokens": 580497615,
+      "total_tokens": 646831103,
+      "cost": 510.35,
       "by_source": [
         {
           "source": "Claude Code",
@@ -830,11 +699,6 @@
           "cost": 7.89
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
-        },
-        {
           "source": "Hermes",
           "total_tokens": 671128,
           "cost": 0
@@ -843,12 +707,12 @@
     },
     {
       "date": "2026-07-19",
-      "input_tokens": 1865593,
-      "output_tokens": 2105902,
+      "input_tokens": 1199962,
+      "output_tokens": 2063415,
       "cache_creation_tokens": 19151141,
-      "cache_read_tokens": 723119064,
-      "total_tokens": 746241700,
-      "cost": 603.78,
+      "cache_read_tokens": 709523199,
+      "total_tokens": 731937717,
+      "cost": 600.36,
       "by_source": [
         {
           "source": "Claude Code",
@@ -861,11 +725,6 @@
           "cost": 9.07
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
-        },
-        {
           "source": "Hermes",
           "total_tokens": 1054556,
           "cost": 0
@@ -874,12 +733,12 @@
     },
     {
       "date": "2026-07-18",
-      "input_tokens": 10801712,
-      "output_tokens": 6242140,
+      "input_tokens": 10136081,
+      "output_tokens": 6199653,
       "cache_creation_tokens": 54766978,
-      "cache_read_tokens": 2009415141,
-      "total_tokens": 2081225971,
-      "cost": 1659.46,
+      "cache_read_tokens": 1995819276,
+      "total_tokens": 2066921988,
+      "cost": 1656.04,
       "by_source": [
         {
           "source": "Claude Code",
@@ -890,11 +749,6 @@
           "source": "opencode",
           "total_tokens": 18091885,
           "cost": 1.38
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -910,12 +764,12 @@
     },
     {
       "date": "2026-07-17",
-      "input_tokens": 9185769,
-      "output_tokens": 9490631,
+      "input_tokens": 8520138,
+      "output_tokens": 9448144,
       "cache_creation_tokens": 55605400,
-      "cache_read_tokens": 2538499889,
-      "total_tokens": 2612781689,
-      "cost": 1480.5,
+      "cache_read_tokens": 2524904024,
+      "total_tokens": 2598477706,
+      "cost": 1477.08,
       "by_source": [
         {
           "source": "Claude Code",
@@ -928,11 +782,6 @@
           "cost": 1.37
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
-        },
-        {
           "source": "Hermes",
           "total_tokens": 806744,
           "cost": 0
@@ -941,22 +790,17 @@
     },
     {
       "date": "2026-07-16",
-      "input_tokens": 1402633,
-      "output_tokens": 6189385,
+      "input_tokens": 737002,
+      "output_tokens": 6146898,
       "cache_creation_tokens": 46763956,
-      "cache_read_tokens": 1888531768,
-      "total_tokens": 1942887742,
-      "cost": 1655.89,
+      "cache_read_tokens": 1874935903,
+      "total_tokens": 1928583759,
+      "cost": 1652.47,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 1919227154,
           "cost": 1652.18
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "opencode",
@@ -977,12 +821,12 @@
     },
     {
       "date": "2026-07-15",
-      "input_tokens": 14582973,
-      "output_tokens": 966992,
+      "input_tokens": 13465012,
+      "output_tokens": 939201,
       "cache_creation_tokens": 3923262,
-      "cache_read_tokens": 282004745,
-      "total_tokens": 301477972,
-      "cost": 207.26,
+      "cache_read_tokens": 278788238,
+      "total_tokens": 297115713,
+      "cost": 202.71,
       "by_source": [
         {
           "source": "Claude Code",
@@ -995,11 +839,6 @@
           "cost": 2.25
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 4362259,
-          "cost": 4.55
-        },
-        {
           "source": "Hermes",
           "total_tokens": 2018309,
           "cost": 0
@@ -1008,12 +847,12 @@
     },
     {
       "date": "2026-07-14",
-      "input_tokens": 1343383,
-      "output_tokens": 796153,
+      "input_tokens": 677752,
+      "output_tokens": 753666,
       "cache_creation_tokens": 4286211,
-      "cache_read_tokens": 268639670,
-      "total_tokens": 275065417,
-      "cost": 290.4,
+      "cache_read_tokens": 255043805,
+      "total_tokens": 260761434,
+      "cost": 286.98,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1026,11 +865,6 @@
           "cost": 0.12
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
-        },
-        {
           "source": "Hermes",
           "total_tokens": 905300,
           "cost": 0
@@ -1039,22 +873,17 @@
     },
     {
       "date": "2026-07-13",
-      "input_tokens": 1322099,
-      "output_tokens": 1113533,
+      "input_tokens": 656468,
+      "output_tokens": 1071046,
       "cache_creation_tokens": 7589950,
-      "cache_read_tokens": 382837757,
-      "total_tokens": 392863339,
-      "cost": 291.37,
+      "cache_read_tokens": 369241892,
+      "total_tokens": 378559356,
+      "cost": 287.95,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 373132850,
           "cost": 287.67
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14303983,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -1070,22 +899,17 @@
     },
     {
       "date": "2026-07-12",
-      "input_tokens": 7028198,
-      "output_tokens": 1878640,
+      "input_tokens": 365618,
+      "output_tokens": 1610249,
       "cache_creation_tokens": 13168766,
-      "cache_read_tokens": 560734969,
-      "total_tokens": 582810573,
-      "cost": 339.51,
+      "cache_read_tokens": 493296595,
+      "total_tokens": 508441228,
+      "cost": 330.25,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 507255781,
           "cost": 330.25
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 74369345,
-          "cost": 9.26
         },
         {
           "source": "Hermes",
@@ -1096,22 +920,17 @@
     },
     {
       "date": "2026-07-11",
-      "input_tokens": 4262211,
-      "output_tokens": 4734202,
+      "input_tokens": 3596798,
+      "output_tokens": 4691729,
       "cache_creation_tokens": 37079714,
-      "cache_read_tokens": 1531134289,
-      "total_tokens": 1577210416,
-      "cost": 1237.41,
+      "cache_read_tokens": 1517542882,
+      "total_tokens": 1562911123,
+      "cost": 1233.99,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 1559818327,
           "cost": 1233.99
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14299293,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -1122,22 +941,17 @@
     },
     {
       "date": "2026-07-10",
-      "input_tokens": 13586630,
-      "output_tokens": 8579370,
+      "input_tokens": 12921217,
+      "output_tokens": 8536897,
       "cache_creation_tokens": 74794714,
-      "cache_read_tokens": 2118982441,
-      "total_tokens": 2215943155,
-      "cost": 1719.25,
+      "cache_read_tokens": 2105391034,
+      "total_tokens": 2201643862,
+      "cost": 1715.83,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 2189995081,
           "cost": 1715.76
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14299293,
-          "cost": 3.42
         },
         {
           "source": "opencode",
@@ -1153,22 +967,17 @@
     },
     {
       "date": "2026-07-09",
-      "input_tokens": 20937234,
-      "output_tokens": 468586,
+      "input_tokens": 20271821,
+      "output_tokens": 426113,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 283136603,
-      "total_tokens": 304542423,
-      "cost": 7.22,
+      "cache_read_tokens": 269545196,
+      "total_tokens": 290243130,
+      "cost": 3.8,
       "by_source": [
         {
           "source": "opencode",
           "total_tokens": 289325436,
           "cost": 3.8
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14299293,
-          "cost": 3.42
         },
         {
           "source": "Hermes",
@@ -1179,22 +988,17 @@
     },
     {
       "date": "2026-07-08",
-      "input_tokens": 57424925,
-      "output_tokens": 818154,
+      "input_tokens": 50144911,
+      "output_tokens": 525689,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 290071153,
-      "total_tokens": 348314232,
-      "cost": 37.2,
+      "cache_read_tokens": 237123936,
+      "total_tokens": 287794536,
+      "cost": 30.03,
       "by_source": [
         {
           "source": "opencode",
           "total_tokens": 287395855,
           "cost": 30.03
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 60519696,
-          "cost": 7.17
         },
         {
           "source": "Hermes",
@@ -1205,18 +1009,13 @@
     },
     {
       "date": "2026-07-07",
-      "input_tokens": 24883498,
-      "output_tokens": 652774,
+      "input_tokens": 11468230,
+      "output_tokens": 175858,
       "cache_creation_tokens": 119159,
-      "cache_read_tokens": 171834132,
-      "total_tokens": 197489563,
-      "cost": 31.98,
+      "cache_read_tokens": 39425696,
+      "total_tokens": 51188943,
+      "cost": 4.33,
       "by_source": [
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 146300620,
-          "cost": 27.65
-        },
         {
           "source": "opencode",
           "total_tokens": 45643548,
@@ -1241,22 +1040,17 @@
     },
     {
       "date": "2026-07-06",
-      "input_tokens": 19294872,
-      "output_tokens": 3660447,
+      "input_tokens": 9032650,
+      "output_tokens": 3189840,
       "cache_creation_tokens": 21774978,
-      "cache_read_tokens": 964549327,
-      "total_tokens": 1009279624,
-      "cost": 373.65,
+      "cache_read_tokens": 798047888,
+      "total_tokens": 832045356,
+      "cost": 354.86,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 731604638,
           "cost": 325.62
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 177234268,
-          "cost": 18.79
         },
         {
           "source": "Z.AI",
@@ -1272,12 +1066,12 @@
     },
     {
       "date": "2026-07-05",
-      "input_tokens": 2246317,
-      "output_tokens": 2162349,
+      "input_tokens": 1696879,
+      "output_tokens": 2127278,
       "cache_creation_tokens": 13837658,
-      "cache_read_tokens": 989430097,
-      "total_tokens": 1007676421,
-      "cost": 353.57,
+      "cache_read_tokens": 978207526,
+      "total_tokens": 995869341,
+      "cost": 350.75,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1290,11 +1084,6 @@
           "cost": 7.59
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 11807080,
-          "cost": 2.82
-        },
-        {
           "source": "Hermes",
           "total_tokens": 381700,
           "cost": 0
@@ -1303,22 +1092,17 @@
     },
     {
       "date": "2026-07-04",
-      "input_tokens": 4963539,
-      "output_tokens": 7290926,
+      "input_tokens": 4414101,
+      "output_tokens": 7255855,
       "cache_creation_tokens": 49343162,
-      "cache_read_tokens": 3005600096,
-      "total_tokens": 3067197723,
-      "cost": 1129.8,
+      "cache_read_tokens": 2994377525,
+      "total_tokens": 3055390643,
+      "cost": 1126.98,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 3053729740,
           "cost": 1126.98
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 11807080,
-          "cost": 2.82
         },
         {
           "source": "Hermes",
@@ -1329,22 +1113,17 @@
     },
     {
       "date": "2026-07-03",
-      "input_tokens": 11003243,
-      "output_tokens": 13399533,
+      "input_tokens": 10453805,
+      "output_tokens": 13364462,
       "cache_creation_tokens": 71913220,
-      "cache_read_tokens": 2569433366,
-      "total_tokens": 2665749362,
-      "cost": 1433.46,
+      "cache_read_tokens": 2558210795,
+      "total_tokens": 2653942282,
+      "cost": 1430.64,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 2652514651,
           "cost": 1430.64
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 11807080,
-          "cost": 2.82
         },
         {
           "source": "Hermes",
@@ -1355,22 +1134,17 @@
     },
     {
       "date": "2026-07-02",
-      "input_tokens": 2641028,
-      "output_tokens": 459437,
+      "input_tokens": 1091511,
+      "output_tokens": 361276,
       "cache_creation_tokens": 3367581,
-      "cache_read_tokens": 95887137,
-      "total_tokens": 102355183,
-      "cost": 46.87,
+      "cache_read_tokens": 58114424,
+      "total_tokens": 62934792,
+      "cost": 43.91,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 62150966,
           "cost": 43.91
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 39420391,
-          "cost": 2.96
         },
         {
           "source": "Hermes",
@@ -1381,22 +1155,17 @@
     },
     {
       "date": "2026-07-01",
-      "input_tokens": 53520642,
-      "output_tokens": 945388,
+      "input_tokens": 48371968,
+      "output_tokens": 692126,
       "cache_creation_tokens": 2343133,
-      "cache_read_tokens": 380192460,
-      "total_tokens": 437001623,
-      "cost": 85.82,
+      "cache_read_tokens": 293188297,
+      "total_tokens": 344595524,
+      "cost": 63.78,
       "by_source": [
         {
           "source": "opencode",
           "total_tokens": 275403331,
           "cost": 34.65
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 92406099,
-          "cost": 22.04
         },
         {
           "source": "Claude Code",
@@ -1412,22 +1181,17 @@
     },
     {
       "date": "2026-06-30",
-      "input_tokens": 32835586,
-      "output_tokens": 3596412,
+      "input_tokens": 26971062,
+      "output_tokens": 3388591,
       "cache_creation_tokens": 18675902,
-      "cache_read_tokens": 958435706,
-      "total_tokens": 1013543606,
-      "cost": 642.8,
+      "cache_read_tokens": 889581956,
+      "total_tokens": 938617511,
+      "cost": 635.8,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 847849396,
           "cost": 634.24
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 74926095,
-          "cost": 7
         },
         {
           "source": "opencode",
@@ -1448,18 +1212,13 @@
     },
     {
       "date": "2026-06-29",
-      "input_tokens": 2158607,
-      "output_tokens": 130507,
+      "input_tokens": 1610153,
+      "output_tokens": 95499,
       "cache_creation_tokens": 1476668,
-      "cache_read_tokens": 21248207,
-      "total_tokens": 25013989,
-      "cost": 8.34,
+      "cache_read_tokens": 10045732,
+      "total_tokens": 13228052,
+      "cost": 5.52,
       "by_source": [
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 11785937,
-          "cost": 2.82
-        },
         {
           "source": "Claude Code",
           "total_tokens": 10996800,
@@ -1479,22 +1238,17 @@
     },
     {
       "date": "2026-06-28",
-      "input_tokens": 1858508,
-      "output_tokens": 821912,
+      "input_tokens": 1310054,
+      "output_tokens": 786904,
       "cache_creation_tokens": 4512497,
-      "cache_read_tokens": 195426385,
-      "total_tokens": 202619302,
-      "cost": 149.95,
+      "cache_read_tokens": 184223910,
+      "total_tokens": 190833365,
+      "cost": 147.13,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 189917744,
           "cost": 147.13
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 11785937,
-          "cost": 2.82
         },
         {
           "source": "Hermes",
@@ -1505,12 +1259,12 @@
     },
     {
       "date": "2026-06-27",
-      "input_tokens": 2374888,
-      "output_tokens": 2575021,
+      "input_tokens": 1826434,
+      "output_tokens": 2540013,
       "cache_creation_tokens": 12136103,
-      "cache_read_tokens": 657584280,
-      "total_tokens": 674670292,
-      "cost": 484.57,
+      "cache_read_tokens": 646381805,
+      "total_tokens": 662884355,
+      "cost": 481.75,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1523,11 +1277,6 @@
           "cost": 1.59
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 11785937,
-          "cost": 2.82
-        },
-        {
           "source": "Hermes",
           "total_tokens": 625838,
           "cost": 0
@@ -1536,12 +1285,12 @@
     },
     {
       "date": "2026-06-26",
-      "input_tokens": 5997088,
-      "output_tokens": 4808356,
+      "input_tokens": 5448634,
+      "output_tokens": 4773348,
       "cache_creation_tokens": 24231850,
-      "cache_read_tokens": 1123181837,
-      "total_tokens": 1158219131,
-      "cost": 665.5,
+      "cache_read_tokens": 1111979362,
+      "total_tokens": 1146433194,
+      "cost": 662.68,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1554,11 +1303,6 @@
           "cost": 27.14
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 11785937,
-          "cost": 2.82
-        },
-        {
           "source": "Hermes",
           "total_tokens": 737183,
           "cost": 0
@@ -1567,18 +1311,13 @@
     },
     {
       "date": "2026-06-25",
-      "input_tokens": 12797520,
-      "output_tokens": 1183541,
+      "input_tokens": 2819837,
+      "output_tokens": 185450,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 215283795,
-      "total_tokens": 229264856,
-      "cost": 29.82,
+      "cache_read_tokens": 45026432,
+      "total_tokens": 48031719,
+      "cost": 6.54,
       "by_source": [
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 181233137,
-          "cost": 23.28
-        },
         {
           "source": "opencode",
           "total_tokens": 24002057,
@@ -1624,22 +1363,17 @@
     },
     {
       "date": "2026-06-23",
-      "input_tokens": 14569255,
-      "output_tokens": 2419121,
+      "input_tokens": 4126267,
+      "output_tokens": 1999806,
       "cache_creation_tokens": 12214618,
-      "cache_read_tokens": 707214473,
-      "total_tokens": 736417467,
-      "cost": 352.87,
+      "cache_read_tokens": 579003443,
+      "total_tokens": 597344134,
+      "cost": 335.99,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 519840726,
           "cost": 335.24
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 139073333,
-          "cost": 16.88
         },
         {
           "source": "opencode",
@@ -1660,12 +1394,12 @@
     },
     {
       "date": "2026-06-22",
-      "input_tokens": 6527997,
-      "output_tokens": 4530620,
+      "input_tokens": 5872132,
+      "output_tokens": 4457830,
       "cache_creation_tokens": 31845163,
-      "cache_read_tokens": 1234790401,
-      "total_tokens": 1277694181,
-      "cost": 835.92,
+      "cache_read_tokens": 1221195179,
+      "total_tokens": 1263370304,
+      "cost": 834.69,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1676,11 +1410,6 @@
           "source": "opencode",
           "total_tokens": 73991549,
           "cost": 0.08
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 14323877,
-          "cost": 1.23
         },
         {
           "source": "Z.AI",
@@ -1696,22 +1425,17 @@
     },
     {
       "date": "2026-06-21",
-      "input_tokens": 4213962,
-      "output_tokens": 4434969,
+      "input_tokens": 3665705,
+      "output_tokens": 4399974,
       "cache_creation_tokens": 21768490,
-      "cache_read_tokens": 1148964474,
-      "total_tokens": 1179381895,
-      "cost": 873.8,
+      "cache_read_tokens": 1137766027,
+      "total_tokens": 1167600196,
+      "cost": 870.98,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 1164072491,
           "cost": 870.2
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 11781699,
-          "cost": 2.82
         },
         {
           "source": "Z.AI",
@@ -1727,22 +1451,17 @@
     },
     {
       "date": "2026-06-20",
-      "input_tokens": 3571303,
-      "output_tokens": 3596661,
+      "input_tokens": 3023046,
+      "output_tokens": 3561666,
       "cache_creation_tokens": 20347594,
-      "cache_read_tokens": 1093865426,
-      "total_tokens": 1121380984,
-      "cost": 804.86,
+      "cache_read_tokens": 1082666979,
+      "total_tokens": 1109599285,
+      "cost": 802.04,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 1101317979,
           "cost": 800.27
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 11781699,
-          "cost": 2.82
         },
         {
           "source": "Z.AI",
@@ -1758,22 +1477,17 @@
     },
     {
       "date": "2026-06-19",
-      "input_tokens": 2549128,
-      "output_tokens": 3409949,
+      "input_tokens": 2000871,
+      "output_tokens": 3374954,
       "cache_creation_tokens": 15349510,
-      "cache_read_tokens": 875636598,
-      "total_tokens": 896945185,
-      "cost": 656.56,
+      "cache_read_tokens": 864438151,
+      "total_tokens": 885163486,
+      "cost": 653.74,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 883181029,
           "cost": 653.08
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 11781699,
-          "cost": 2.82
         },
         {
           "source": "Z.AI",
@@ -1789,12 +1503,12 @@
     },
     {
       "date": "2026-06-18",
-      "input_tokens": 12313799,
-      "output_tokens": 11210551,
+      "input_tokens": 11974492,
+      "output_tokens": 11184398,
       "cache_creation_tokens": 46675370,
-      "cache_read_tokens": 2033299410,
-      "total_tokens": 2103499130,
-      "cost": 1546.87,
+      "cache_read_tokens": 2029632278,
+      "total_tokens": 2099466538,
+      "cost": 1534.32,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1807,11 +1521,6 @@
           "cost": 55.71
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 4032592,
-          "cost": 12.55
-        },
-        {
           "source": "Hermes",
           "total_tokens": 1156855,
           "cost": 0
@@ -1820,12 +1529,12 @@
     },
     {
       "date": "2026-06-17",
-      "input_tokens": 5339623,
-      "output_tokens": 5604996,
+      "input_tokens": 4791366,
+      "output_tokens": 5570001,
       "cache_creation_tokens": 33015533,
-      "cache_read_tokens": 1208492225,
-      "total_tokens": 1252452377,
-      "cost": 802.56,
+      "cache_read_tokens": 1197293778,
+      "total_tokens": 1240670678,
+      "cost": 799.74,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1838,11 +1547,6 @@
           "cost": 16.36
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 11781699,
-          "cost": 2.82
-        },
-        {
           "source": "Hermes",
           "total_tokens": 1064601,
           "cost": 0
@@ -1851,12 +1555,12 @@
     },
     {
       "date": "2026-06-16",
-      "input_tokens": 90199951,
-      "output_tokens": 3172446,
+      "input_tokens": 89750844,
+      "output_tokens": 3138068,
       "cache_creation_tokens": 3184910,
-      "cache_read_tokens": 821797789,
-      "total_tokens": 918355096,
-      "cost": 268.49,
+      "cache_read_tokens": 818146252,
+      "total_tokens": 914220074,
+      "cost": 253.88,
       "by_source": [
         {
           "source": "Z.AI",
@@ -1874,11 +1578,6 @@
           "cost": 133.7
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 4135022,
-          "cost": 14.61
-        },
-        {
           "source": "Hermes",
           "total_tokens": 726375,
           "cost": 0
@@ -1887,12 +1586,12 @@
     },
     {
       "date": "2026-06-15",
-      "input_tokens": 20945406,
-      "output_tokens": 2669224,
+      "input_tokens": 14937449,
+      "output_tokens": 2323939,
       "cache_creation_tokens": 5092729,
-      "cache_read_tokens": 503039862,
-      "total_tokens": 531747221,
-      "cost": 131.71,
+      "cache_read_tokens": 417224080,
+      "total_tokens": 439578197,
+      "cost": 119.43,
       "by_source": [
         {
           "source": "Z.AI",
@@ -1903,11 +1602,6 @@
           "source": "Claude Code",
           "total_tokens": 142332007,
           "cost": 98.76
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 92169024,
-          "cost": 12.28
         },
         {
           "source": "opencode",
@@ -1923,12 +1617,12 @@
     },
     {
       "date": "2026-06-14",
-      "input_tokens": 27677633,
-      "output_tokens": 6429530,
+      "input_tokens": 18460114,
+      "output_tokens": 5788896,
       "cache_creation_tokens": 17670511,
-      "cache_read_tokens": 1080351578,
-      "total_tokens": 1132129252,
-      "cost": 473.93,
+      "cache_read_tokens": 960727596,
+      "total_tokens": 1002647117,
+      "cost": 461.42,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1939,11 +1633,6 @@
           "source": "Z.AI",
           "total_tokens": 369345705,
           "cost": 3.53
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 129482135,
-          "cost": 12.51
         },
         {
           "source": "Codex",
@@ -1964,12 +1653,12 @@
     },
     {
       "date": "2026-06-13",
-      "input_tokens": 24454983,
-      "output_tokens": 4061112,
+      "input_tokens": 12960106,
+      "output_tokens": 3318508,
       "cache_creation_tokens": 11644001,
-      "cache_read_tokens": 903107248,
-      "total_tokens": 943267344,
-      "cost": 561.24,
+      "cache_read_tokens": 775267069,
+      "total_tokens": 803189684,
+      "cost": 546.87,
       "by_source": [
         {
           "source": "Claude Code",
@@ -1980,11 +1669,6 @@
           "source": "Z.AI",
           "total_tokens": 181543189,
           "cost": 41.36
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 140077660,
-          "cost": 14.37
         },
         {
           "source": "Codex",
@@ -2000,12 +1684,12 @@
     },
     {
       "date": "2026-06-12",
-      "input_tokens": 27170991,
-      "output_tokens": 3218594,
+      "input_tokens": 20768197,
+      "output_tokens": 2655342,
       "cache_creation_tokens": 12252137,
-      "cache_read_tokens": 850732077,
-      "total_tokens": 893373799,
-      "cost": 742.54,
+      "cache_read_tokens": 759463980,
+      "total_tokens": 795139656,
+      "cost": 733.08,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2016,11 +1700,6 @@
           "source": "Z.AI",
           "total_tokens": 353134584,
           "cost": 113.89
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 98234143,
-          "cost": 9.46
         },
         {
           "source": "opencode",
@@ -2041,12 +1720,12 @@
     },
     {
       "date": "2026-06-11",
-      "input_tokens": 21980546,
-      "output_tokens": 2226218,
+      "input_tokens": 21524003,
+      "output_tokens": 2197077,
       "cache_creation_tokens": 5450388,
-      "cache_read_tokens": 631677297,
-      "total_tokens": 661334449,
-      "cost": 454.11,
+      "cache_read_tokens": 622352166,
+      "total_tokens": 651523634,
+      "cost": 451.76,
       "by_source": [
         {
           "source": "Z.AI",
@@ -2069,11 +1748,6 @@
           "cost": 0.07
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 9810815,
-          "cost": 2.35
-        },
-        {
           "source": "Hermes",
           "total_tokens": 1464864,
           "cost": 0
@@ -2082,12 +1756,12 @@
     },
     {
       "date": "2026-06-10",
-      "input_tokens": 69116379,
-      "output_tokens": 2678292,
+      "input_tokens": 62338301,
+      "output_tokens": 2240778,
       "cache_creation_tokens": 8771785,
-      "cache_read_tokens": 684867379,
-      "total_tokens": 765433835,
-      "cost": 419.12,
+      "cache_read_tokens": 625916775,
+      "total_tokens": 699267639,
+      "cost": 411.47,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2098,11 +1772,6 @@
           "source": "Z.AI",
           "total_tokens": 278642259,
           "cost": 80.96
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 66166196,
-          "cost": 7.65
         },
         {
           "source": "opencode",
@@ -2118,12 +1787,12 @@
     },
     {
       "date": "2026-06-09",
-      "input_tokens": 6515184,
-      "output_tokens": 1162537,
+      "input_tokens": 6059076,
+      "output_tokens": 1133424,
       "cache_creation_tokens": 3097151,
-      "cache_read_tokens": 419075893,
-      "total_tokens": 429850765,
-      "cost": 202.68,
+      "cache_read_tokens": 409759642,
+      "total_tokens": 420049293,
+      "cost": 200.34,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2136,11 +1805,6 @@
           "cost": 51.46
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 9801472,
-          "cost": 2.34
-        },
-        {
           "source": "Hermes",
           "total_tokens": 398712,
           "cost": 0
@@ -2149,12 +1813,12 @@
     },
     {
       "date": "2026-06-08",
-      "input_tokens": 6718995,
-      "output_tokens": 2585329,
+      "input_tokens": 6262887,
+      "output_tokens": 2556216,
       "cache_creation_tokens": 9526013,
-      "cache_read_tokens": 698694276,
-      "total_tokens": 717524613,
-      "cost": 379.19,
+      "cache_read_tokens": 689378025,
+      "total_tokens": 707723141,
+      "cost": 376.85,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2167,11 +1831,6 @@
           "cost": 48.32
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 9801472,
-          "cost": 2.34
-        },
-        {
           "source": "Hermes",
           "total_tokens": 5164648,
           "cost": 0
@@ -2180,12 +1839,12 @@
     },
     {
       "date": "2026-06-07",
-      "input_tokens": 230571510,
-      "output_tokens": 1995718,
+      "input_tokens": 230115402,
+      "output_tokens": 1966605,
       "cache_creation_tokens": 6587432,
-      "cache_read_tokens": 564352497,
-      "total_tokens": 803507157,
-      "cost": 14404.59,
+      "cache_read_tokens": 555036246,
+      "total_tokens": 793705685,
+      "cost": 14402.25,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2203,11 +1862,6 @@
           "cost": 51.52
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 9801472,
-          "cost": 2.34
-        },
-        {
           "source": "Hermes",
           "total_tokens": 603337,
           "cost": 14083.94
@@ -2216,12 +1870,12 @@
     },
     {
       "date": "2026-06-06",
-      "input_tokens": 132263591,
-      "output_tokens": 869427,
+      "input_tokens": 125652472,
+      "output_tokens": 506099,
       "cache_creation_tokens": 0,
-      "cache_read_tokens": 223213629,
-      "total_tokens": 356346647,
-      "cost": 14350.73,
+      "cache_read_tokens": 148144071,
+      "total_tokens": 274302642,
+      "cost": 14338.55,
       "by_source": [
         {
           "source": "opencode",
@@ -2232,11 +1886,6 @@
           "source": "Codex",
           "total_tokens": 123070116,
           "cost": 77.28
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 82044005,
-          "cost": 12.18
         },
         {
           "source": "Hermes",
@@ -2252,22 +1901,17 @@
     },
     {
       "date": "2026-06-05",
-      "input_tokens": 12828399,
-      "output_tokens": 1236912,
+      "input_tokens": 7074876,
+      "output_tokens": 910426,
       "cache_creation_tokens": 2860492,
-      "cache_read_tokens": 324365072,
-      "total_tokens": 341290875,
-      "cost": 25205.78,
+      "cache_read_tokens": 234201048,
+      "total_tokens": 245046842,
+      "cost": 25185.89,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 140039017,
           "cost": 99.99
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 96244033,
-          "cost": 19.89
         },
         {
           "source": "Codex",
@@ -2293,12 +1937,12 @@
     },
     {
       "date": "2026-06-04",
-      "input_tokens": 15460133,
-      "output_tokens": 3970310,
+      "input_tokens": 7418742,
+      "output_tokens": 3400109,
       "cache_creation_tokens": 17899973,
-      "cache_read_tokens": 1020217331,
-      "total_tokens": 1057547747,
-      "cost": 794.88,
+      "cache_read_tokens": 842025197,
+      "total_tokens": 870744021,
+      "cost": 776.41,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2309,11 +1953,6 @@
           "source": "Z.AI",
           "total_tokens": 193624199,
           "cost": 279.53
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 186803726,
-          "cost": 18.47
         },
         {
           "source": "Hermes",
@@ -2329,12 +1968,12 @@
     },
     {
       "date": "2026-06-03",
-      "input_tokens": 16022849,
-      "output_tokens": 3954688,
+      "input_tokens": 7778746,
+      "output_tokens": 3511288,
       "cache_creation_tokens": 19719419,
-      "cache_read_tokens": 941791672,
-      "total_tokens": 981488628,
-      "cost": 739.31,
+      "cache_read_tokens": 782372078,
+      "total_tokens": 813381531,
+      "cost": 725.89,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2345,11 +1984,6 @@
           "source": "Z.AI",
           "total_tokens": 179710677,
           "cost": 257.92
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 168107097,
-          "cost": 13.42
         },
         {
           "source": "Codex",
@@ -2365,12 +1999,12 @@
     },
     {
       "date": "2026-06-02",
-      "input_tokens": 12318097,
-      "output_tokens": 2256496,
+      "input_tokens": 8658526,
+      "output_tokens": 1980627,
       "cache_creation_tokens": 6653728,
-      "cache_read_tokens": 529111944,
-      "total_tokens": 550340265,
-      "cost": 678.48,
+      "cache_read_tokens": 458250542,
+      "total_tokens": 475543423,
+      "cost": 668.21,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2381,11 +2015,6 @@
           "source": "Z.AI",
           "total_tokens": 157436575,
           "cost": 211.49
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 74796842,
-          "cost": 10.27
         },
         {
           "source": "Codex",
@@ -2401,18 +2030,13 @@
     },
     {
       "date": "2026-06-01",
-      "input_tokens": 28138628,
-      "output_tokens": 2668521,
+      "input_tokens": 15818918,
+      "output_tokens": 1925141,
       "cache_creation_tokens": 3698942,
-      "cache_read_tokens": 753902452,
-      "total_tokens": 788408543,
-      "cost": 479.18,
+      "cache_read_tokens": 501245198,
+      "total_tokens": 522688199,
+      "cost": 416.11,
       "by_source": [
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 265720344,
-          "cost": 63.07
-        },
         {
           "source": "Claude Code",
           "total_tokens": 207284207,
@@ -2447,12 +2071,12 @@
     },
     {
       "date": "2026-05-31",
-      "input_tokens": 25641607,
-      "output_tokens": 2817830,
+      "input_tokens": 16103767,
+      "output_tokens": 2242310,
       "cache_creation_tokens": 6885877,
-      "cache_read_tokens": 832172404,
-      "total_tokens": 867517718,
-      "cost": 617.46,
+      "cache_read_tokens": 636566788,
+      "total_tokens": 661798742,
+      "cost": 568.63,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2463,11 +2087,6 @@
           "source": "Z.AI",
           "total_tokens": 238511835,
           "cost": 349.08
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 205718976,
-          "cost": 48.83
         },
         {
           "source": "opencode",
@@ -2488,12 +2107,12 @@
     },
     {
       "date": "2026-05-30",
-      "input_tokens": 13424411,
-      "output_tokens": 3648968,
+      "input_tokens": 9450311,
+      "output_tokens": 3409168,
       "cache_creation_tokens": 16910792,
-      "cache_read_tokens": 948597163,
-      "total_tokens": 982581334,
-      "cost": 925.4,
+      "cache_read_tokens": 867094823,
+      "total_tokens": 896865094,
+      "cost": 905.06,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2504,11 +2123,6 @@
           "source": "Z.AI",
           "total_tokens": 337361613,
           "cost": 494.48
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 85716240,
-          "cost": 20.34
         },
         {
           "source": "Hermes",
@@ -2550,22 +2164,17 @@
     },
     {
       "date": "2026-05-28",
-      "input_tokens": 12846839,
-      "output_tokens": 1994730,
+      "input_tokens": 924539,
+      "output_tokens": 1275330,
       "cache_creation_tokens": 7969423,
-      "cache_read_tokens": 601074875,
-      "total_tokens": 623885867,
-      "cost": 31572.41,
+      "cache_read_tokens": 356567855,
+      "total_tokens": 366737147,
+      "cost": 31511.38,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 347827896,
           "cost": 231.1
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 257148720,
-          "cost": 61.03
         },
         {
           "source": "Z.AI",
@@ -2586,22 +2195,17 @@
     },
     {
       "date": "2026-05-27",
-      "input_tokens": 2398679,
-      "output_tokens": 702411,
+      "input_tokens": 1007744,
+      "output_tokens": 618481,
       "cache_creation_tokens": 4275090,
-      "cache_read_tokens": 224365871,
-      "total_tokens": 231742051,
-      "cost": 144.43,
+      "cache_read_tokens": 195840052,
+      "total_tokens": 201741367,
+      "cost": 137.31,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 198980945,
           "cost": 134.01
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 30000684,
-          "cost": 7.12
         },
         {
           "source": "Codex",
@@ -2617,22 +2221,17 @@
     },
     {
       "date": "2026-05-26",
-      "input_tokens": 2286053,
-      "output_tokens": 979379,
+      "input_tokens": 1093823,
+      "output_tokens": 907439,
       "cache_creation_tokens": 5057353,
-      "cache_read_tokens": 326623577,
-      "total_tokens": 334946362,
-      "cost": 181.16,
+      "cache_read_tokens": 302172875,
+      "total_tokens": 309231490,
+      "cost": 175.06,
       "by_source": [
         {
           "source": "Claude Code",
           "total_tokens": 304124032,
           "cost": 170.64
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 25714872,
-          "cost": 6.1
         },
         {
           "source": "Codex",
@@ -2648,18 +2247,13 @@
     },
     {
       "date": "2026-05-25",
-      "input_tokens": 6164549,
-      "output_tokens": 613769,
+      "input_tokens": 4694,
+      "output_tokens": 242079,
       "cache_creation_tokens": 1594438,
-      "cache_read_tokens": 220283609,
-      "total_tokens": 228656365,
-      "cost": 94.51,
+      "cache_read_tokens": 93954982,
+      "total_tokens": 95796193,
+      "cost": 62.98,
       "by_source": [
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 132860172,
-          "cost": 31.53
-        },
         {
           "source": "Claude Code",
           "total_tokens": 95791551,
@@ -2700,12 +2294,12 @@
     },
     {
       "date": "2026-05-23",
-      "input_tokens": 9732389,
-      "output_tokens": 2537867,
+      "input_tokens": 6155699,
+      "output_tokens": 2322047,
       "cache_creation_tokens": 11458988,
-      "cache_read_tokens": 753082092,
-      "total_tokens": 776811336,
-      "cost": 521.46,
+      "cache_read_tokens": 679729986,
+      "total_tokens": 699666720,
+      "cost": 503.15,
       "by_source": [
         {
           "source": "Claude Code",
@@ -2723,11 +2317,6 @@
           "cost": 124.2
         },
         {
-          "source": "Google Antigravity",
-          "total_tokens": 77144616,
-          "cost": 18.31
-        },
-        {
           "source": "Hermes",
           "total_tokens": 13381,
           "cost": 0
@@ -2736,12 +2325,12 @@
     },
     {
       "date": "2026-05-22",
-      "input_tokens": 19884051,
-      "output_tokens": 1911333,
+      "input_tokens": 15115131,
+      "output_tokens": 1623573,
       "cache_creation_tokens": 3758166,
-      "cache_read_tokens": 734530444,
-      "total_tokens": 760083994,
-      "cost": 1494.37,
+      "cache_read_tokens": 636727636,
+      "total_tokens": 657224506,
+      "cost": 1469.96,
       "by_source": [
         {
           "source": "Codex",
@@ -2752,11 +2341,6 @@
           "source": "Claude Code",
           "total_tokens": 112299793,
           "cost": 82.9
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 102859488,
-          "cost": 24.41
         },
         {
           "source": "Z.AI",
@@ -2777,12 +2361,12 @@
     },
     {
       "date": "2026-05-21",
-      "input_tokens": 25605661,
-      "output_tokens": 2400454,
+      "input_tokens": 20638036,
+      "output_tokens": 2100704,
       "cache_creation_tokens": 1952004,
-      "cache_read_tokens": 937473479,
-      "total_tokens": 967431598,
-      "cost": 2879.12,
+      "cache_read_tokens": 835595554,
+      "total_tokens": 860286298,
+      "cost": 2853.69,
       "by_source": [
         {
           "source": "Codex",
@@ -2793,11 +2377,6 @@
           "source": "Claude Code",
           "total_tokens": 123930549,
           "cost": 89.43
-        },
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 107145300,
-          "cost": 25.43
         },
         {
           "source": "opencode",
@@ -2818,18 +2397,13 @@
     },
     {
       "date": "2026-05-20",
-      "input_tokens": 40247429,
-      "output_tokens": 3769562,
+      "input_tokens": 18389879,
+      "output_tokens": 2450662,
       "cache_creation_tokens": 4772697,
-      "cache_read_tokens": 1379307791,
-      "total_tokens": 1428097479,
-      "cost": 1171.71,
+      "cache_read_tokens": 931044921,
+      "total_tokens": 956658159,
+      "cost": 1059.81,
       "by_source": [
-        {
-          "source": "Google Antigravity",
-          "total_tokens": 471439320,
-          "cost": 111.9
-        },
         {
           "source": "Codex",
           "total_tokens": 450317166,

--- a/apps/burns/public/token-data.json
+++ b/apps/burns/public/token-data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-14T06:19:07.904Z",
+  "generatedAt": "2026-08-14T08:26:45.853Z",
   "firstDate": "2025-08-02",
   "lastDate": "2026-08-14",
   "sources": [
@@ -14,12 +14,12 @@
     "pi"
   ],
   "totals": {
-    "input_tokens": 4248158232,
-    "output_tokens": 336352045,
+    "input_tokens": 4250270649,
+    "output_tokens": 336521086,
     "cache_creation_tokens": 2212217303,
-    "cache_read_tokens": 103649497691,
-    "total_tokens": 110446225271,
-    "total_cost": 232196.26
+    "cache_read_tokens": 103691878747,
+    "total_tokens": 110490887785,
+    "total_cost": 232221.39
   },
   "source_totals": [
     {
@@ -49,8 +49,8 @@
     },
     {
       "source": "Grok",
-      "total_tokens": 875820347,
-      "cost": 136.57
+      "total_tokens": 920482861,
+      "cost": 161.7
     },
     {
       "source": "Gemini CLI",
@@ -71,12 +71,12 @@
   "daily": [
     {
       "date": "2026-08-14",
-      "input_tokens": 7560927,
-      "output_tokens": 1843987,
+      "input_tokens": 9673344,
+      "output_tokens": 2013028,
       "cache_creation_tokens": 5525275,
-      "cache_read_tokens": 445029751,
-      "total_tokens": 459959940,
-      "cost": 551.23,
+      "cache_read_tokens": 487410807,
+      "total_tokens": 504622454,
+      "cost": 576.36,
       "by_source": [
         {
           "source": "Claude Code",
@@ -85,8 +85,8 @@
         },
         {
           "source": "Grok",
-          "total_tokens": 189062888,
-          "cost": 4.8
+          "total_tokens": 233725402,
+          "cost": 29.93
         },
         {
           "source": "Hermes",

--- a/apps/burns/scripts/fetch-burns-data.ts
+++ b/apps/burns/scripts/fetch-burns-data.ts
@@ -3,35 +3,24 @@
 import { Database } from "duckdb-async";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { normalizeSource } from "../src/lib/sources";
 
 const MOTHERDUCK_TOKEN = process.env.MOTHERDUCK_TOKEN;
 
 const OUTPUT_DIR = join(import.meta.dirname, "..", "public");
 const OUTPUT_FILE = join(OUTPUT_DIR, "token-data.json");
 
-/** SQL CASE that maps raw source/model → display agent names. */
-const AGENT_CASE = `
-  CASE
-    WHEN source IN ('antigravity', 'gemini') THEN 'Google Antigravity'
-    WHEN source = 'opencode' THEN 'opencode'
-    WHEN source = 'codex' THEN 'Codex'
-    WHEN source = 'grok' THEN 'Grok'
-    WHEN source = 'hermes' THEN 'Hermes'
-    WHEN source = 'openclaw' THEN 'OpenClaw'
-    WHEN source = 'pi' THEN 'pi'
-    WHEN source = 'ccusage' AND (
-      lower(coalesce(model_name, '')) LIKE '%glm%'
-      OR lower(coalesce(model_name, '')) LIKE '%z-ai%'
-      OR lower(coalesce(model_name, '')) LIKE '%zai%'
-    ) THEN 'Z.AI'
-    WHEN source = 'ccusage' THEN 'Claude Code'
-    WHEN lower(coalesce(model_name, '')) LIKE '%glm%'
-      OR lower(coalesce(model_name, '')) LIKE '%z-ai%'
-      OR lower(coalesce(model_name, '')) LIKE '%zai%'
-      THEN 'Z.AI'
-    ELSE source
-  END
-`;
+type SourceAgg = { source: string; total_tokens: number; cost: number };
+
+function mergeSource(map: Map<string, SourceAgg>, source: string, tokens: number, cost: number) {
+  const existing = map.get(source);
+  if (existing) {
+    existing.total_tokens += tokens;
+    existing.cost += cost;
+    return;
+  }
+  map.set(source, { source, total_tokens: tokens, cost });
+}
 
 async function main() {
   if (!MOTHERDUCK_TOKEN) {
@@ -93,68 +82,51 @@ async function main() {
   const sourceRows = await db.all(`
     SELECT
       date,
-      ${AGENT_CASE} as source,
+      source,
+      model_name,
       COALESCE(SUM(total_tokens), 0) as total_tokens,
       COALESCE(SUM(cost), 0)         as cost
     FROM ccusage_events
     WHERE record_type = 'daily'
-    GROUP BY date, ${AGENT_CASE}
+    GROUP BY date, source, model_name
     ORDER BY date DESC
   `);
 
-  console.log("Fetching all-time per-agent totals...");
-  const sourceTotalRows = await db.all(`
-    SELECT
-      ${AGENT_CASE} as source,
-      COALESCE(SUM(total_tokens), 0) as total_tokens,
-      COALESCE(SUM(cost), 0)         as cost
-    FROM ccusage_events
-    WHERE record_type = 'daily'
-    GROUP BY ${AGENT_CASE}
-    ORDER BY total_tokens DESC
-  `);
+  const byDateMaps = new Map<string, Map<string, SourceAgg>>();
+  const allTime = new Map<string, SourceAgg>();
 
-  const byDate = new Map<string, { source: string; total_tokens: number; cost: number }[]>();
   for (const row of sourceRows) {
+    const tokens = parseNum(row.total_tokens);
+    const cost = parseNum(row.cost);
+    if (tokens === 0 && cost === 0) continue;
+
+    const source = normalizeSource(String(row.source ?? ""), String(row.model_name ?? ""));
     const date = formatDate(row.date);
-    const entry = {
-      source: String(row.source),
-      total_tokens: parseNum(row.total_tokens),
-      cost: Math.round(parseNum(row.cost) * 100) / 100,
-    };
-    // Drop zero-token, zero-cost noise rows
-    if (entry.total_tokens === 0 && entry.cost === 0) continue;
-    if (!byDate.has(date)) byDate.set(date, []);
-    byDate.get(date)!.push(entry);
+    if (!byDateMaps.has(date)) byDateMaps.set(date, new Map());
+    mergeSource(byDateMaps.get(date)!, source, tokens, cost);
+    mergeSource(allTime, source, tokens, cost);
   }
 
-  // Sort each day's agents by tokens desc
-  for (const entries of byDate.values()) {
-    entries.sort((a, b) => b.total_tokens - a.total_tokens);
+  const byDate = new Map<string, SourceAgg[]>();
+  for (const [date, map] of byDateMaps) {
+    const entries = [...map.values()]
+      .map((e) => ({
+        ...e,
+        cost: Math.round(e.cost * 100) / 100,
+      }))
+      .sort((a, b) => b.total_tokens - a.total_tokens);
+    byDate.set(date, entries);
   }
 
-  const source_totals = sourceTotalRows
-    .map((row) => ({
-      source: String(row.source),
-      total_tokens: parseNum(row.total_tokens),
-      cost: Math.round(parseNum(row.cost) * 100) / 100,
+  const source_totals = [...allTime.values()]
+    .map((e) => ({
+      ...e,
+      cost: Math.round(e.cost * 100) / 100,
     }))
-    .filter((e) => e.total_tokens > 0 || e.cost > 0);
+    .filter((e) => e.total_tokens > 0 || e.cost > 0)
+    .sort((a, b) => b.total_tokens - a.total_tokens);
 
-  // Logo row order: known display agents first, then any extras by tokens
-  const preferred = [
-    "Google Antigravity",
-    "Z.AI",
-    "opencode",
-    "Claude Code",
-    "Codex",
-    "Grok",
-  ];
-  const known = new Set(source_totals.map((s) => s.source));
-  const sources = [
-    ...preferred.filter((s) => known.has(s)),
-    ...source_totals.map((s) => s.source).filter((s) => !preferred.includes(s)),
-  ];
+  const sources = source_totals.map((s) => s.source);
 
   const data = {
     generatedAt: new Date().toISOString(),

--- a/apps/burns/scripts/fetch-burns-data.ts
+++ b/apps/burns/scripts/fetch-burns-data.ts
@@ -10,9 +10,18 @@ const MOTHERDUCK_TOKEN = process.env.MOTHERDUCK_TOKEN;
 const OUTPUT_DIR = join(import.meta.dirname, "..", "public");
 const OUTPUT_FILE = join(OUTPUT_DIR, "token-data.json");
 
-type SourceAgg = { source: string; total_tokens: number; cost: number };
+interface SourceAgg {
+  source: string;
+  total_tokens: number;
+  cost: number;
+}
 
-function mergeSource(map: Map<string, SourceAgg>, source: string, tokens: number, cost: number) {
+function mergeSource(
+  map: Map<string, SourceAgg>,
+  source: string,
+  tokens: number,
+  cost: number,
+): void {
   const existing = map.get(source);
   if (existing) {
     existing.total_tokens += tokens;

--- a/apps/burns/src/components/AnimatedCounter.tsx
+++ b/apps/burns/src/components/AnimatedCounter.tsx
@@ -38,21 +38,5 @@ export function AnimatedCounter({ target, duration = 700 }: AnimatedCounterProps
     return () => cancelAnimationFrame(raf);
   }, [target, duration]);
 
-  return (
-    <span
-      style={{
-        display: "block",
-        textAlign: "center",
-        fontFamily: "Garamond, 'Apple Garamond', 'EB Garamond', serif",
-        fontWeight: 400,
-        letterSpacing: "-0.03em",
-        lineHeight: 1.05,
-        fontVariantNumeric: "tabular-nums",
-        fontSize: "clamp(2.5rem, 12vw, 9rem)",
-        color: "var(--ink)",
-      }}
-    >
-      {display}
-    </span>
-  );
+  return <span className="burns-count">{display}</span>;
 }

--- a/apps/burns/src/components/DailyChart.tsx
+++ b/apps/burns/src/components/DailyChart.tsx
@@ -7,8 +7,13 @@ interface DailyChartProps {
   daily: DailyEntry[];
 }
 
-const WINDOW = 90;
+export const WINDOW = 90;
 const CHART_H = 100;
+
+function stackedTotal(d: DailyEntry): number {
+  const sum = (d.by_source ?? []).reduce((acc, s) => acc + s.total_tokens, 0);
+  return sum || d.total_tokens;
+}
 
 export function DailyChart({ daily }: DailyChartProps) {
   const [hovered, setHovered] = useState<number | null>(null);
@@ -16,7 +21,7 @@ export function DailyChart({ daily }: DailyChartProps) {
   if (daily.length === 0) return null;
 
   const recent = daily.slice(0, WINDOW).reverse();
-  const maxTokens = Math.max(...recent.map((d) => d.total_tokens), 1);
+  const maxTokens = Math.max(...recent.map(stackedTotal), 1);
   const barWidth = 100 / recent.length;
 
   const totals = new Map<string, number>();
@@ -51,6 +56,7 @@ export function DailyChart({ daily }: DailyChartProps) {
         <svg
           viewBox={`0 0 100 ${CHART_H}`}
           preserveAspectRatio="none"
+          role="img"
           aria-label="Daily token usage"
         >
           {recent.map((day, i) => {
@@ -65,6 +71,16 @@ export function DailyChart({ daily }: DailyChartProps) {
             const useStack = stack.length > 0;
             let y = CHART_H;
             const dim = hovered !== null && hovered !== i;
+            const barAccess = {
+              role: "button" as const,
+              tabIndex: 0,
+              "aria-label": `${day.date}: ${fmtTokens(day.total_tokens)} tokens, ${fmtCost(day.cost)}`,
+              onMouseEnter: () => setHovered(i),
+              onMouseLeave: () => setHovered(null),
+              onFocus: () => setHovered(i),
+              onBlur: () => setHovered(null),
+              style: { cursor: "pointer" as const },
+            };
 
             if (!useStack) {
               const h = (day.total_tokens / maxTokens) * CHART_H;
@@ -77,9 +93,7 @@ export function DailyChart({ daily }: DailyChartProps) {
                   height={h}
                   fill="var(--muted)"
                   opacity={dim ? 0.35 : 1}
-                  onMouseEnter={() => setHovered(i)}
-                  onMouseLeave={() => setHovered(null)}
-                  style={{ cursor: "pointer" }}
+                  {...barAccess}
                 />
               );
             }
@@ -87,10 +101,8 @@ export function DailyChart({ daily }: DailyChartProps) {
             return (
               <g
                 key={day.date}
-                onMouseEnter={() => setHovered(i)}
-                onMouseLeave={() => setHovered(null)}
-                style={{ cursor: "pointer" }}
                 opacity={dim ? 0.35 : 1}
+                {...barAccess}
               >
                 {stack.map((seg) => {
                   const h = (seg.tokens / maxTokens) * CHART_H;
@@ -113,14 +125,13 @@ export function DailyChart({ daily }: DailyChartProps) {
 
         {hovered !== null && hoveredDay && (() => {
           const pct = hovered * barWidth + barWidth / 2;
-          const flip = pct > 68;
+          const left = Math.min(Math.max(pct, 0), 100);
+          const transform =
+            pct < 18 ? "translateX(0)" : pct > 82 ? "translateX(-100%)" : "translateX(-50%)";
           return (
             <div
               className="burns-tooltip"
-              style={{
-                left: `${pct}%`,
-                transform: `translateX(${flip ? "-100%" : "-50%"})`,
-              }}
+              style={{ left: `${left}%`, transform }}
             >
               <div className="burns-tooltip-title">{formatDay(hoveredDay.date, true)}</div>
               {sources.length > 0 ? (

--- a/apps/burns/src/components/DailyChart.tsx
+++ b/apps/burns/src/components/DailyChart.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { DailyEntry, DailyEntrySource } from "../lib/types";
+import { formatDay } from "../lib/dates";
 import { fmtCost, fmtTokens, normalizeSource, sourceSwatch } from "../lib/sources";
 
 interface DailyChartProps {
@@ -8,18 +9,6 @@ interface DailyChartProps {
 
 const WINDOW = 90;
 const CHART_H = 100;
-
-function shortDate(d: string): string {
-  return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short" });
-}
-
-function longDate(d: string): string {
-  return new Date(d).toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
-}
 
 export function DailyChart({ daily }: DailyChartProps) {
   const [hovered, setHovered] = useState<number | null>(null);
@@ -51,11 +40,10 @@ export function DailyChart({ daily }: DailyChartProps) {
     .filter((s) => s.total_tokens > 0 || s.cost > 0)
     .sort((a, b) => b.total_tokens - a.total_tokens);
 
-  const ticks = [
-    recent[0]?.date,
-    recent[Math.floor(recent.length / 2)]?.date,
-    recent[recent.length - 1]?.date,
-  ].filter(Boolean) as string[];
+  const ticks = [...new Set(
+    [recent[0]?.date, recent[Math.floor(recent.length / 2)]?.date, recent[recent.length - 1]?.date]
+      .filter(Boolean) as string[],
+  )];
 
   return (
     <div className="burns-chart">
@@ -134,7 +122,7 @@ export function DailyChart({ daily }: DailyChartProps) {
                 transform: `translateX(${flip ? "-100%" : "-50%"})`,
               }}
             >
-              <div className="burns-tooltip-title">{longDate(hoveredDay.date)}</div>
+              <div className="burns-tooltip-title">{formatDay(hoveredDay.date, true)}</div>
               {sources.length > 0 ? (
                 <div className="burns-tooltip-grid">
                   {sources.map((s) => (
@@ -166,7 +154,7 @@ export function DailyChart({ daily }: DailyChartProps) {
 
       <div className="burns-chart-axis">
         {ticks.map((d) => (
-          <span key={d}>{shortDate(d)}</span>
+          <span key={d}>{formatDay(d)}</span>
         ))}
       </div>
 

--- a/apps/burns/src/components/DailyChart.tsx
+++ b/apps/burns/src/components/DailyChart.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import type { DailyEntry, DailyEntrySource } from "../lib/types";
 import { formatDay } from "../lib/dates";
 import { fmtCost, fmtTokens, normalizeSource, sourceSwatch } from "../lib/sources";
@@ -15,7 +15,7 @@ function stackedTotal(d: DailyEntry): number {
   return sum || d.total_tokens;
 }
 
-export function DailyChart({ daily }: DailyChartProps) {
+export function DailyChart({ daily }: DailyChartProps): JSX.Element | null {
   const [hovered, setHovered] = useState<number | null>(null);
 
   if (daily.length === 0) return null;

--- a/apps/burns/src/components/DailyChart.tsx
+++ b/apps/burns/src/components/DailyChart.tsx
@@ -1,31 +1,48 @@
-import type { DailyEntry, DailyEntrySource } from "../lib/types";
-import { SOURCE_COLORS, fmtCost, fmtTokens, normalizeSource } from "../lib/sources";
 import { useState } from "react";
+import type { DailyEntry, DailyEntrySource } from "../lib/types";
+import { fmtCost, fmtTokens, normalizeSource, sourceSwatch } from "../lib/sources";
 
 interface DailyChartProps {
   daily: DailyEntry[];
-  firstDate: string | null;
-  lastDate: string | null;
 }
 
-export function DailyChart({ daily, firstDate, lastDate }: DailyChartProps) {
+const WINDOW = 90;
+const CHART_H = 100;
+
+function shortDate(d: string): string {
+  return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short" });
+}
+
+function longDate(d: string): string {
+  return new Date(d).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function DailyChart({ daily }: DailyChartProps) {
   const [hovered, setHovered] = useState<number | null>(null);
 
   if (daily.length === 0) return null;
 
-  const recent = daily.slice(0, 60).reverse();
-  const maxTokens = Math.max(...recent.map((d) => d.total_tokens));
+  const recent = daily.slice(0, WINDOW).reverse();
+  const maxTokens = Math.max(...recent.map((d) => d.total_tokens), 1);
   const barWidth = 100 / recent.length;
-  const chartHeight = 60;
 
-  const format = (d: string) =>
-    new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-  const sinceLabel = firstDate && lastDate
-    ? `${format(firstDate)} — ${format(lastDate)}`
-    : `Last ${recent.length} days`;
+  const totals = new Map<string, number>();
+  for (const day of recent) {
+    for (const s of day.by_source ?? []) {
+      const name = normalizeSource(s.source);
+      totals.set(name, (totals.get(name) ?? 0) + s.total_tokens);
+    }
+  }
+  const legend = [...totals.entries()]
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name]) => name);
 
   const hoveredDay = hovered !== null ? recent[hovered] : null;
-
   const sources = (hoveredDay?.by_source ?? [])
     .map((s: DailyEntrySource) => ({
       ...s,
@@ -34,90 +51,96 @@ export function DailyChart({ daily, firstDate, lastDate }: DailyChartProps) {
     .filter((s) => s.total_tokens > 0 || s.cost > 0)
     .sort((a, b) => b.total_tokens - a.total_tokens);
 
+  const ticks = [
+    recent[0]?.date,
+    recent[Math.floor(recent.length / 2)]?.date,
+    recent[recent.length - 1]?.date,
+  ].filter(Boolean) as string[];
+
   return (
-    <div style={{ width: "100%", maxWidth: 640, margin: "0 auto" }}>
-      <p style={{
-        marginBottom: 8,
-        textAlign: "center",
-        fontSize: 11,
-        letterSpacing: "0.04em",
-        color: "var(--muted-soft)",
-      }}>
-        {sinceLabel}
-      </p>
-      <div style={{ position: "relative", width: "100%" }}>
+    <div className="burns-chart">
+      <div className="burns-chart-frame">
         <svg
-          viewBox={`0 0 100 ${chartHeight}`}
-          style={{ width: "100%", height: 80, display: "block" }}
+          viewBox={`0 0 100 ${CHART_H}`}
           preserveAspectRatio="none"
+          aria-label="Daily token usage"
         >
           {recent.map((day, i) => {
-            const height = maxTokens > 0 ? (day.total_tokens / maxTokens) * chartHeight : 0;
-            const gap = barWidth * 0.2;
-            const w = barWidth - gap;
+            const gap = barWidth * 0.22;
+            const w = Math.max(barWidth - gap, 0.2);
             const x = i * barWidth + gap / 2;
-            const y = chartHeight - height;
+            const stack = (day.by_source ?? [])
+              .map((s) => ({ name: normalizeSource(s.source), tokens: s.total_tokens }))
+              .filter((s) => s.tokens > 0)
+              .sort((a, b) => legend.indexOf(a.name) - legend.indexOf(b.name));
+
+            const useStack = stack.length > 0;
+            let y = CHART_H;
+            const dim = hovered !== null && hovered !== i;
+
+            if (!useStack) {
+              const h = (day.total_tokens / maxTokens) * CHART_H;
+              return (
+                <rect
+                  key={day.date}
+                  x={x}
+                  y={CHART_H - h}
+                  width={w}
+                  height={h}
+                  fill="var(--muted)"
+                  opacity={dim ? 0.35 : 1}
+                  onMouseEnter={() => setHovered(i)}
+                  onMouseLeave={() => setHovered(null)}
+                  style={{ cursor: "pointer" }}
+                />
+              );
+            }
+
             return (
-              <rect
+              <g
                 key={day.date}
-                x={x}
-                y={y}
-                width={w}
-                height={Math.max(height, 0)}
-                fill={hovered === i ? "var(--muted)" : "var(--hairline)"}
-                className="transition-colors"
                 onMouseEnter={() => setHovered(i)}
                 onMouseLeave={() => setHovered(null)}
                 style={{ cursor: "pointer" }}
-              />
+                opacity={dim ? 0.35 : 1}
+              >
+                {stack.map((seg) => {
+                  const h = (seg.tokens / maxTokens) * CHART_H;
+                  y -= h;
+                  return (
+                    <rect
+                      key={`${day.date}-${seg.name}`}
+                      x={x}
+                      y={y}
+                      width={w}
+                      height={h}
+                      fill={sourceSwatch(seg.name)}
+                    />
+                  );
+                })}
+              </g>
             );
           })}
         </svg>
 
         {hovered !== null && hoveredDay && (() => {
-          const barCenter = (hovered * barWidth) + barWidth / 2;
-          const pct = barCenter;
-          const flip = pct > 70;
+          const pct = hovered * barWidth + barWidth / 2;
+          const flip = pct > 68;
           return (
-            <div style={{
-              position: "absolute",
-              bottom: "100%",
-              left: `${pct}%`,
-              transform: `translateX(${flip ? "-100%" : "-50%"})`,
-              marginBottom: 4,
-              padding: "8px 10px",
-              borderRadius: 6,
-              fontSize: 11,
-              fontFamily: "var(--sans)",
-              lineHeight: 1.5,
-              whiteSpace: "nowrap",
-              background: "var(--surface-card)",
-              border: "1px solid var(--hairline)",
-              color: "var(--ink)",
-              boxShadow: "0 2px 8px rgb(0 0 0 / 0.12)",
-              pointerEvents: "none",
-              textAlign: "left",
-              zIndex: 10,
-            }}>
-              <div style={{ fontWeight: 500, marginBottom: 6 }}>{format(hoveredDay.date)}</div>
+            <div
+              className="burns-tooltip"
+              style={{
+                left: `${pct}%`,
+                transform: `translateX(${flip ? "-100%" : "-50%"})`,
+              }}
+            >
+              <div className="burns-tooltip-title">{longDate(hoveredDay.date)}</div>
               {sources.length > 0 ? (
-                <div style={{
-                  display: "grid",
-                  gridTemplateColumns: "8px max-content max-content max-content",
-                  columnGap: 12,
-                  rowGap: 3,
-                  alignItems: "center",
-                  fontVariantNumeric: "tabular-nums",
-                }}>
+                <div className="burns-tooltip-grid">
                   {sources.map((s) => (
                     <div key={s.name} style={{ display: "contents" }}>
-                      <span style={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: 2,
-                        background: SOURCE_COLORS[s.name] ?? "var(--muted)",
-                      }} />
-                      <span style={{ paddingRight: 4 }}>{s.name}</span>
+                      <span className="burns-swatch" style={{ background: sourceSwatch(s.name) }} />
+                      <span>{s.name}</span>
                       <span style={{ color: "var(--muted)", textAlign: "right" }}>
                         {fmtTokens(s.total_tokens)}
                       </span>
@@ -132,16 +155,7 @@ export function DailyChart({ daily, firstDate, lastDate }: DailyChartProps) {
                   {fmtTokens(hoveredDay.total_tokens)} tokens
                 </div>
               )}
-              <div style={{
-                color: "var(--muted)",
-                marginTop: 6,
-                paddingTop: 4,
-                borderTop: "1px solid var(--hairline)",
-                fontVariantNumeric: "tabular-nums",
-                display: "flex",
-                justifyContent: "space-between",
-                gap: 16,
-              }}>
+              <div className="burns-tooltip-foot">
                 <span>{fmtTokens(hoveredDay.total_tokens)} total</span>
                 <span>{fmtCost(hoveredDay.cost)}</span>
               </div>
@@ -149,6 +163,23 @@ export function DailyChart({ daily, firstDate, lastDate }: DailyChartProps) {
           );
         })()}
       </div>
+
+      <div className="burns-chart-axis">
+        {ticks.map((d) => (
+          <span key={d}>{shortDate(d)}</span>
+        ))}
+      </div>
+
+      {legend.length > 0 && (
+        <ul className="burns-legend">
+          {legend.map((name) => (
+            <li key={name}>
+              <span className="burns-swatch" style={{ background: sourceSwatch(name) }} />
+              {name}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/burns/src/components/SourceBreakdown.tsx
+++ b/apps/burns/src/components/SourceBreakdown.tsx
@@ -1,0 +1,38 @@
+import type { SourceTotal } from "../lib/types";
+import { fmtCompactTokens, fmtCost, normalizeSource, sourceSwatch } from "../lib/sources";
+
+interface SourceBreakdownProps {
+  totals: readonly SourceTotal[];
+}
+
+export function SourceBreakdown({ totals }: SourceBreakdownProps) {
+  if (totals.length === 0) return null;
+
+  const rows = [...totals]
+    .map((s) => ({ ...s, source: normalizeSource(s.source) }))
+    .sort((a, b) => b.total_tokens - a.total_tokens);
+
+  const max = Math.max(...rows.map((s) => s.total_tokens), 1);
+
+  return (
+    <ol className="burns-sources">
+      {rows.map((s) => {
+        const pct = Math.max((s.total_tokens / max) * 100, s.total_tokens > 0 ? 0.8 : 0);
+        const color = sourceSwatch(s.source);
+        return (
+          <li key={s.source}>
+            <div className="burns-source-head">
+              <span className="burns-swatch" style={{ background: color }} />
+              <span className="burns-source-name">{s.source}</span>
+              <span className="burns-source-tokens">{fmtCompactTokens(s.total_tokens)}</span>
+              <span className="burns-source-cost">{fmtCost(s.cost)}</span>
+            </div>
+            <div className="burns-source-bar">
+              <i style={{ width: `${pct}%`, background: color }} />
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/burns/src/components/SourceBreakdown.tsx
+++ b/apps/burns/src/components/SourceBreakdown.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import type { SourceTotal } from "../lib/types";
 import { fmtCompactTokens, fmtCost, normalizeSource, sourceSwatch } from "../lib/sources";
 
@@ -5,12 +6,21 @@ interface SourceBreakdownProps {
   totals: readonly SourceTotal[];
 }
 
-export function SourceBreakdown({ totals }: SourceBreakdownProps) {
+export function SourceBreakdown({ totals }: SourceBreakdownProps): JSX.Element | null {
   if (totals.length === 0) return null;
 
-  const rows = [...totals]
-    .map((s) => ({ ...s, source: normalizeSource(s.source) }))
-    .sort((a, b) => b.total_tokens - a.total_tokens);
+  const merged = new Map<string, SourceTotal>();
+  for (const s of totals) {
+    const source = normalizeSource(s.source);
+    const existing = merged.get(source);
+    if (existing) {
+      existing.total_tokens += s.total_tokens;
+      existing.cost += s.cost;
+      continue;
+    }
+    merged.set(source, { ...s, source });
+  }
+  const rows = [...merged.values()].sort((a, b) => b.total_tokens - a.total_tokens);
 
   const max = Math.max(...rows.map((s) => s.total_tokens), 1);
 

--- a/apps/burns/src/components/SourceIcons.tsx
+++ b/apps/burns/src/components/SourceIcons.tsx
@@ -10,6 +10,10 @@ interface SourceIconsProps {
 // Official brand SVGs from glincker/thesvg.
 // Icons using fill="currentColor" auto-revert to white in dark mode via --muted.
 const icons: Record<string, string> = {
+  "Gemini CLI": `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <title>Gemini CLI</title>
+    <path fill="#4B64E8" d="M12 1.6l1.72 7.12L21.2 10.4l-7.48 1.68L12 19.2l-1.72-7.12L2.8 10.4l7.48-1.68L12 1.6z"/>
+  </svg>`,
   "Google Antigravity": `<svg viewBox="0 0 16 15" fill="none" xmlns="http://www.w3.org/2000/svg">
     <mask id="ag-mask" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="16" height="15">
       <path d="M14.0777 13.984C14.945 14.6345 16.2458 14.2008 15.0533 13.0084C11.476 9.53949 12.2349 0 7.79033 0C3.34579 0 4.10461 9.53949 0.527295 13.0084C-0.773543 14.3092 0.635692 14.6345 1.50293 13.984C4.86344 11.7076 4.64663 7.69664 7.79033 7.69664C10.934 7.69664 10.7172 11.7076 14.0777 13.984Z" fill="black"/>
@@ -67,65 +71,44 @@ export function SourceIcons({ sources, sourceTotals = [] }: SourceIconsProps) {
   const totalsByName = new Map(sourceTotals.map((s) => [s.source, s]));
 
   return (
-    <div style={{
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      gap: 16,
-      // Stack above the huge counter so tooltips are not painted under it.
-      position: "relative",
-      zIndex: 30,
-    }}>
+    <div className="burns-icons">
       {sources.map((name) => {
         const svg = icons[name];
-        if (!svg) return null;
         const isHovered = hovered === name;
         const total = totalsByName.get(name);
         const label = DISPLAY_LABELS[name] ?? name;
+        const mark = name === "pi" ? "π" : name.slice(0, 1).toUpperCase();
         return (
           <span
             key={name}
+            className="burns-icon"
             onMouseEnter={() => setHovered(name)}
             onMouseLeave={() => setHovered(null)}
-            style={{
-              display: "block",
-              width: 20,
-              height: 20,
-              flexShrink: 0,
-              color: "var(--muted)",
-              filter: "drop-shadow(0 0 1px rgb(0 0 0 / 0.15))",
-              cursor: "default",
-              position: "relative",
-              opacity: hovered && !isHovered ? 0.45 : 1,
-              transition: "opacity 120ms ease",
-            }}
+            style={{ opacity: hovered && !isHovered ? 0.4 : 1 }}
           >
-            <span
-              style={{ display: "block", width: 20, height: 20 }}
-              dangerouslySetInnerHTML={{ __html: svg }}
-            />
+            {svg ? (
+              <span
+                style={{ display: "block", width: 18, height: 18 }}
+                dangerouslySetInnerHTML={{ __html: svg }}
+              />
+            ) : (
+              <span
+                style={{
+                  display: "flex",
+                  width: 18,
+                  height: 18,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 11,
+                  fontWeight: 500,
+                  letterSpacing: "-0.04em",
+                }}
+              >
+                {mark}
+              </span>
+            )}
             {isHovered && (
-              <span style={{
-                position: "absolute",
-                // Above the icon so it sits over the big number, not under it.
-                bottom: "100%",
-                left: "50%",
-                transform: "translateX(-50%)",
-                marginBottom: 8,
-                padding: "8px 10px",
-                borderRadius: 6,
-                fontSize: 11,
-                fontFamily: "var(--sans)",
-                lineHeight: 1.5,
-                whiteSpace: "nowrap",
-                background: "var(--surface-card)",
-                border: "1px solid var(--hairline)",
-                color: "var(--ink)",
-                boxShadow: "0 4px 16px rgb(0 0 0 / 0.28)",
-                pointerEvents: "none",
-                textAlign: "center",
-                zIndex: 50,
-              }}>
+              <span className="burns-icon-tip">
                 <span style={{ display: "block", fontWeight: 500, marginBottom: 2 }}>
                   {label}
                 </span>

--- a/apps/burns/src/components/SourceIcons.tsx
+++ b/apps/burns/src/components/SourceIcons.tsx
@@ -79,11 +79,15 @@ export function SourceIcons({ sources, sourceTotals = [] }: SourceIconsProps) {
         const label = DISPLAY_LABELS[name] ?? name;
         const mark = name === "pi" ? "π" : name.slice(0, 1).toUpperCase();
         return (
-          <span
+          <button
+            type="button"
             key={name}
             className="burns-icon"
+            aria-label={label}
             onMouseEnter={() => setHovered(name)}
             onMouseLeave={() => setHovered(null)}
+            onFocus={() => setHovered(name)}
+            onBlur={() => setHovered(null)}
             style={{ opacity: hovered && !isHovered ? 0.4 : 1 }}
           >
             {svg ? (
@@ -132,7 +136,7 @@ export function SourceIcons({ sources, sourceTotals = [] }: SourceIconsProps) {
                 )}
               </span>
             )}
-          </span>
+          </button>
         );
       })}
     </div>

--- a/apps/burns/src/components/SourceIcons.tsx
+++ b/apps/burns/src/components/SourceIcons.tsx
@@ -51,6 +51,7 @@ const icons: Record<string, string> = {
 const DISPLAY_LABELS: Record<string, string> = {
   Codex: "Codex (OpenAI)",
   "Claude Code": "Claude Code",
+  "Gemini CLI": "Gemini CLI",
   "Google Antigravity": "Google Antigravity",
   "Z.AI": "Z.AI",
   opencode: "opencode",

--- a/apps/burns/src/components/TokenBreakdown.tsx
+++ b/apps/burns/src/components/TokenBreakdown.tsx
@@ -1,41 +1,47 @@
 import type { TokenTotals } from "../lib/types";
+import { fmtCompactTokens } from "../lib/sources";
 
 interface TokenBreakdownProps {
   totals: TokenTotals;
 }
 
-function fmt(n: number): string {
-  return n.toLocaleString("en-US");
-}
+const MIX = [
+  { key: "input_tokens", label: "Input", swatch: "burns-mix-input" },
+  { key: "output_tokens", label: "Output", swatch: "burns-mix-output" },
+  { key: "cache_creation_tokens", label: "Cache write", swatch: "burns-mix-write" },
+  { key: "cache_read_tokens", label: "Cache read", swatch: "burns-mix-read" },
+] as const;
 
 export function TokenBreakdown({ totals }: TokenBreakdownProps) {
-  const cost = totals.total_cost.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 2,
-  });
+  const parts = MIX.map((m) => ({
+    ...m,
+    value: totals[m.key],
+  }));
+  const sum = parts.reduce((acc, p) => acc + p.value, 0);
 
   return (
-    <p style={{
-      textAlign: "center",
-      fontSize: 11,
-      color: "var(--muted)",
-      fontVariantNumeric: "tabular-nums",
-      lineHeight: 1.6,
-    }}>
-      Input {fmt(totals.input_tokens)}
-      <Sep />
-      Output {fmt(totals.output_tokens)}
-      <Sep />
-      Cache Write {fmt(totals.cache_creation_tokens)}
-      <Sep />
-      Cache Read {fmt(totals.cache_read_tokens)}
-      <Sep />
-      {cost}
-    </p>
+    <div>
+      <div className="burns-mix-bar" aria-hidden="true">
+        {parts.map((p) => {
+          if (p.value <= 0 || sum <= 0) return null;
+          return (
+            <i
+              key={p.key}
+              className={p.swatch}
+              style={{ width: `${(p.value / sum) * 100}%` }}
+            />
+          );
+        })}
+      </div>
+      <ul className="burns-mix-rows">
+        {parts.map((p) => (
+          <li key={p.key} className="burns-mix-row">
+            <span className={`burns-swatch ${p.swatch}`} />
+            <span>{p.label}</span>
+            <span>{fmtCompactTokens(p.value)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
-}
-
-function Sep() {
-  return <span style={{ margin: "0 8px", color: "var(--hairline)" }}>·</span>;
 }

--- a/apps/burns/src/lib/dates.test.ts
+++ b/apps/burns/src/lib/dates.test.ts
@@ -8,11 +8,33 @@ describe("parseDay", () => {
     expect(d.getMonth()).toBe(7);
     expect(d.getDate()).toBe(2);
   });
+
+  test.each([
+    "2025-02-31",
+    "2025-02-29",
+    "2025-13-01",
+    "2025-00-01",
+    "2025-01-00",
+    "2025-1-2",
+    "2025-01",
+    "2025-01-01-extra",
+    "not-a-date",
+    "",
+  ])("rejects %s", (iso) => {
+    expect(Number.isNaN(parseDay(iso).getTime())).toBe(true);
+  });
+
+  test("accepts a real leap day", () => {
+    const d = parseDay("2024-02-29");
+    expect(d.getFullYear()).toBe(2024);
+    expect(d.getMonth()).toBe(1);
+    expect(d.getDate()).toBe(29);
+  });
 });
 
 describe("formatDay", () => {
   test("formats without shifting the calendar day", () => {
-    expect(formatDay("2025-08-02", true)).toContain("2025");
-    expect(formatDay("2025-08-02")).not.toMatch(/31|1 Aug|Jul/);
+    expect(formatDay("2025-08-02", true)).toBe("2 Aug 2025");
+    expect(formatDay("2025-08-02")).toBe("2 Aug");
   });
 });

--- a/apps/burns/src/lib/dates.test.ts
+++ b/apps/burns/src/lib/dates.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { formatDay, parseDay } from "./dates";
+
+describe("parseDay", () => {
+  test("reads YYYY-MM-DD as a local calendar day", () => {
+    const d = parseDay("2025-08-02");
+    expect(d.getFullYear()).toBe(2025);
+    expect(d.getMonth()).toBe(7);
+    expect(d.getDate()).toBe(2);
+  });
+});
+
+describe("formatDay", () => {
+  test("formats without shifting the calendar day", () => {
+    expect(formatDay("2025-08-02", true)).toContain("2025");
+    expect(formatDay("2025-08-02")).not.toMatch(/31|1 Aug|Jul/);
+  });
+});

--- a/apps/burns/src/lib/dates.ts
+++ b/apps/burns/src/lib/dates.ts
@@ -1,11 +1,28 @@
+/** Shared locale for Burns dates and numbers so hero metadata cannot drift. */
+export const BURNS_LOCALE = "en-GB";
+
+const DAY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
 /** Parse a YYYY-MM-DD value as a local calendar day. */
 export function parseDay(iso: string): Date {
-  const [y, m, d] = iso.split("-").map(Number);
-  return new Date(y, (m ?? 1) - 1, d ?? 1);
+  const match = DAY.exec(iso);
+  if (!match) return new Date(Number.NaN);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(year, month - 1, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return new Date(Number.NaN);
+  }
+  return date;
 }
 
-export function formatDay(iso: string, year = false): string {
-  return parseDay(iso).toLocaleDateString("en-GB", {
+export function formatDay(iso: string, year: boolean = false): string {
+  return parseDay(iso).toLocaleDateString(BURNS_LOCALE, {
     day: "numeric",
     month: "short",
     ...(year ? { year: "numeric" as const } : {}),

--- a/apps/burns/src/lib/dates.ts
+++ b/apps/burns/src/lib/dates.ts
@@ -1,0 +1,13 @@
+/** Parse a YYYY-MM-DD value as a local calendar day. */
+export function parseDay(iso: string): Date {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, (m ?? 1) - 1, d ?? 1);
+}
+
+export function formatDay(iso: string, year = false): string {
+  return parseDay(iso).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    ...(year ? { year: "numeric" as const } : {}),
+  });
+}

--- a/apps/burns/src/lib/sources.test.ts
+++ b/apps/burns/src/lib/sources.test.ts
@@ -50,13 +50,20 @@ describe("source colors", () => {
     expect(SOURCE_COLORS["Google Antigravity"]).toBeTruthy();
     expect(sourceSwatch("Gemini CLI")).not.toBe(sourceSwatch("Google Antigravity"));
   });
+
+  test("Z.AI and Grok use distinct swatches", () => {
+    expect(sourceSwatch("Z.AI")).not.toBe(sourceSwatch("Grok"));
+  });
 });
 
 describe("fetch-burns-data mapping", () => {
-  const fetchSrc = readFileSync(join(burnsRoot, "scripts/fetch-burns-data.ts"), "utf8");
+  test("maps gemini and antigravity independently via normalizeSource", () => {
+    expect(normalizeSource("gemini")).toBe("Gemini CLI");
+    expect(normalizeSource("antigravity")).toBe("Google Antigravity");
+    expect(normalizeSource("gemini")).not.toBe(normalizeSource("antigravity"));
 
-  test("uses normalizeSource instead of a gemini→Antigravity CASE", () => {
-    expect(fetchSrc).toContain("normalizeSource");
+    const fetchSrc = readFileSync(join(burnsRoot, "scripts/fetch-burns-data.ts"), "utf8");
+    expect(fetchSrc).toContain("normalizeSource(");
     expect(fetchSrc).not.toContain("IN ('antigravity', 'gemini')");
     expect(fetchSrc).not.toMatch(/source\s*=\s*'gemini'\s+THEN\s+'Google Antigravity'/i);
   });

--- a/apps/burns/src/lib/sources.test.ts
+++ b/apps/burns/src/lib/sources.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
-import { normalizeSource } from "./sources";
+import { SOURCE_COLORS, normalizeSource, sourceSwatch } from "./sources";
 
 const burnsRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -41,6 +41,14 @@ describe("normalizeSource", () => {
 
   test("gemini stays Gemini even when the model looks like GLM", () => {
     expect(normalizeSource("gemini", "glm-4.6")).toBe("Gemini CLI");
+  });
+});
+
+describe("source colors", () => {
+  test("gemini and antigravity use different swatches", () => {
+    expect(SOURCE_COLORS["Gemini CLI"]).toBeTruthy();
+    expect(SOURCE_COLORS["Google Antigravity"]).toBeTruthy();
+    expect(sourceSwatch("Gemini CLI")).not.toBe(sourceSwatch("Google Antigravity"));
   });
 });
 

--- a/apps/burns/src/lib/sources.test.ts
+++ b/apps/burns/src/lib/sources.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { normalizeSource } from "./sources";
+
+const burnsRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+describe("normalizeSource", () => {
+  test("maps only raw antigravity to Google Antigravity", () => {
+    expect(normalizeSource("antigravity")).toBe("Google Antigravity");
+    expect(normalizeSource("google-antigravity")).toBe("Google Antigravity");
+    expect(normalizeSource("Google Antigravity")).toBe("Google Antigravity");
+  });
+
+  test("maps gemini to Gemini CLI, never Antigravity", () => {
+    for (const raw of ["gemini", "Gemini", "gemini-cli", "GEMINI"]) {
+      expect(normalizeSource(raw)).toBe("Gemini CLI");
+      expect(normalizeSource(raw)).not.toBe("Google Antigravity");
+      expect(normalizeSource(raw).toLowerCase()).not.toContain("antigravity");
+    }
+  });
+
+  test("does not treat agy as Antigravity", () => {
+    expect(normalizeSource("agy")).not.toBe("Google Antigravity");
+    expect(normalizeSource("strategy")).not.toBe("Google Antigravity");
+  });
+
+  test("keeps other raw sources on their own names", () => {
+    expect(normalizeSource("ccusage")).toBe("Claude Code");
+    expect(normalizeSource("claude-code")).toBe("Claude Code");
+    expect(normalizeSource("codex")).toBe("Codex");
+    expect(normalizeSource("opencode")).toBe("opencode");
+    expect(normalizeSource("grok")).toBe("Grok");
+    expect(normalizeSource("hermes")).toBe("Hermes");
+    expect(normalizeSource("openclaw")).toBe("OpenClaw");
+    expect(normalizeSource("pi")).toBe("pi");
+    expect(normalizeSource("ccusage", "glm-4.6")).toBe("Z.AI");
+    expect(normalizeSource("unknown-agent")).toBe("unknown-agent");
+  });
+
+  test("gemini stays Gemini even when the model looks like GLM", () => {
+    expect(normalizeSource("gemini", "glm-4.6")).toBe("Gemini CLI");
+  });
+});
+
+describe("fetch-burns-data mapping", () => {
+  const fetchSrc = readFileSync(join(burnsRoot, "scripts/fetch-burns-data.ts"), "utf8");
+
+  test("uses normalizeSource instead of a gemini→Antigravity CASE", () => {
+    expect(fetchSrc).toContain("normalizeSource");
+    expect(fetchSrc).not.toContain("IN ('antigravity', 'gemini')");
+    expect(fetchSrc).not.toMatch(/source\s*=\s*'gemini'\s+THEN\s+'Google Antigravity'/i);
+  });
+});

--- a/apps/burns/src/lib/sources.ts
+++ b/apps/burns/src/lib/sources.ts
@@ -1,34 +1,59 @@
 /** Canonical display names for coding agents shown on burn.duyet.net */
 export const DISPLAY_SOURCES = [
-  "Google Antigravity",
-  "Z.AI",
-  "opencode",
   "Claude Code",
   "Codex",
+  "Gemini CLI",
   "Grok",
+  "opencode",
+  "Z.AI",
+  "Google Antigravity",
+  "Hermes",
+  "OpenClaw",
+  "pi",
 ] as const;
 
 export type DisplaySource = (typeof DISPLAY_SOURCES)[number];
 
 export const SOURCE_COLORS: Record<string, string> = {
-  "Google Antigravity": "#FFE432",
-  "Z.AI": "#111111",
-  Grok: "#1A1A1A",
-  opencode: "#7C3AED",
   "Claude Code": "#D97757",
   Codex: "#10A37F",
+  "Gemini CLI": "#4B64E8",
+  Grok: "#1A1A1A",
+  opencode: "#7C3AED",
+  "Z.AI": "#111111",
+  "Google Antigravity": "#FFE432",
   Hermes: "#6366F1",
   OpenClaw: "#0EA5E9",
   pi: "#F59E0B",
 };
 
-/** Map raw MotherDuck `source` (+ optional model) → display agent name. */
-export function normalizeSource(raw: string, modelName = ""): string {
-  const s = raw.toLowerCase();
-  const m = modelName.toLowerCase();
+const DISPLAY_BY_LOWER = new Map<string, string>(
+  DISPLAY_SOURCES.map((name) => [name.toLowerCase(), name]),
+);
 
-  if (s === "antigravity" || s.includes("antigravity") || s === "gemini" || s.includes("agy")) {
+function isZaiModel(modelName: string): boolean {
+  const m = modelName.toLowerCase();
+  return m.includes("glm") || m.includes("z-ai") || m.includes("zai");
+}
+
+/**
+ * Map raw imported `source` (+ optional model) → display agent name.
+ *
+ * Labels follow the raw source. `gemini` is never Antigravity.
+ */
+export function normalizeSource(raw: string, modelName = ""): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+
+  const s = trimmed.toLowerCase();
+  const known = DISPLAY_BY_LOWER.get(s);
+  if (known) return known;
+
+  if (s === "antigravity" || s.includes("antigravity")) {
     return "Google Antigravity";
+  }
+  if (s === "gemini" || s.includes("gemini")) {
+    return "Gemini CLI";
   }
   if (s === "opencode" || s.includes("opencode")) return "opencode";
   if (s === "codex" || s.includes("codex")) return "Codex";
@@ -37,22 +62,25 @@ export function normalizeSource(raw: string, modelName = ""): string {
   if (s === "openclaw" || s.includes("openclaw")) return "OpenClaw";
   if (s === "pi") return "pi";
 
-  // Z.AI / GLM models often ride Claude Code (ccusage) or openclaw free tiers
-  if (
-    m.includes("glm") ||
-    m.includes("z-ai") ||
-    m.includes("zai") ||
-    s.includes("z.ai") ||
-    s.includes("zai")
-  ) {
+  if (s.includes("z.ai") || s.includes("zai") || isZaiModel(modelName)) {
     return "Z.AI";
   }
 
   if (s === "ccusage" || s.includes("claude")) return "Claude Code";
-  return raw;
+  return trimmed;
 }
 
 export function fmtTokens(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+export function fmtCompactTokens(n: number): string {
+  const abs = Math.abs(n);
+  const sign = n < 0 ? "-" : "";
+  if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(1)}T`;
+  if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${sign}${(abs / 1e3).toFixed(1)}K`;
   return n.toLocaleString("en-US");
 }
 

--- a/apps/burns/src/lib/sources.ts
+++ b/apps/burns/src/lib/sources.ts
@@ -70,6 +70,11 @@ export function normalizeSource(raw: string, modelName = ""): string {
   return trimmed;
 }
 
+export function sourceSwatch(name: string): string {
+  if (name === "Z.AI" || name === "Grok") return "#737373";
+  return SOURCE_COLORS[name] ?? "var(--muted)";
+}
+
 export function fmtTokens(n: number): string {
   return n.toLocaleString("en-US");
 }

--- a/apps/burns/src/lib/sources.ts
+++ b/apps/burns/src/lib/sources.ts
@@ -1,3 +1,5 @@
+import { BURNS_LOCALE } from "./dates";
+
 /** Canonical display names for coding agents shown on burn.duyet.net */
 export const DISPLAY_SOURCES = [
   "Claude Code",
@@ -71,12 +73,13 @@ export function normalizeSource(raw: string, modelName = ""): string {
 }
 
 export function sourceSwatch(name: string): string {
-  if (name === "Z.AI" || name === "Grok") return "#737373";
+  if (name === "Z.AI") return "#737373";
+  if (name === "Grok") return "#9a9994";
   return SOURCE_COLORS[name] ?? "var(--muted)";
 }
 
 export function fmtTokens(n: number): string {
-  return n.toLocaleString("en-US");
+  return n.toLocaleString(BURNS_LOCALE);
 }
 
 export function fmtCompactTokens(n: number): string {
@@ -86,11 +89,11 @@ export function fmtCompactTokens(n: number): string {
   if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(1)}B`;
   if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(1)}M`;
   if (abs >= 1e3) return `${sign}${(abs / 1e3).toFixed(1)}K`;
-  return n.toLocaleString("en-US");
+  return n.toLocaleString(BURNS_LOCALE);
 }
 
 export function fmtCost(n: number): string {
-  return `$${n.toLocaleString("en-US", {
+  return `$${n.toLocaleString(BURNS_LOCALE, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   })}`;

--- a/apps/burns/src/lib/sources.ts
+++ b/apps/burns/src/lib/sources.ts
@@ -30,7 +30,10 @@ export const SOURCE_COLORS: Record<string, string> = {
 };
 
 const DISPLAY_BY_LOWER = new Map<string, string>(
-  DISPLAY_SOURCES.map((name) => [name.toLowerCase(), name]),
+  DISPLAY_SOURCES.map((name: string): [string, string] => [
+    name.toLowerCase(),
+    name,
+  ]),
 );
 
 function isZaiModel(modelName: string): boolean {

--- a/apps/burns/src/routes/__root.tsx
+++ b/apps/burns/src/routes/__root.tsx
@@ -68,14 +68,13 @@ function RootComponent() {
         <link
           rel="stylesheet"
           href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
-          media="print"
-          // @ts-expect-error onLoad is valid on link elements
-          onLoad="this.media='all'"
         />
       </head>
       <body>
         <ThemeProvider>
-          <Outlet />
+          <main>
+            <Outlet />
+          </main>
           <Analytics />
         </ThemeProvider>
         <Scripts />

--- a/apps/burns/src/routes/__root.tsx
+++ b/apps/burns/src/routes/__root.tsx
@@ -3,7 +3,6 @@ import "../styles.css";
 
 import Analytics from "@duyet/components/Analytics";
 import ThemeProvider from "@duyet/components/ThemeProvider";
-import ThemeToggle from "@duyet/components/ThemeToggle";
 import {
   createRootRoute,
   HeadContent,
@@ -13,11 +12,9 @@ import {
 
 function NotFoundComponent() {
   return (
-    <div style={{ display: "flex", minHeight: "50vh", alignItems: "center", justifyContent: "center" }}>
-      <div style={{ textAlign: "center" }}>
-        <h1 style={{ fontSize: "2rem", fontWeight: 600 }}>404</h1>
-        <p style={{ marginTop: 8, color: "var(--muted)" }}>Page not found</p>
-      </div>
+    <div className="burns-page">
+      <h1 className="burns-title">404</h1>
+      <p className="burns-hero-meta">Page not found</p>
     </div>
   );
 }
@@ -28,18 +25,25 @@ export const Route = createRootRoute({
       { charSet: "utf-8" },
       { name: "viewport", content: "width=device-width, initial-scale=1.0" },
       { name: "robots", content: "follow, index" },
-      { title: "Burns | Token Counter" },
+      { title: "Burns · Token usage" },
       {
         name: "description",
-        content: "Total Claude Code token consumption.",
+        content: "Token usage across coding agents.",
+      },
+      {
+        name: "theme-color",
+        content: "#ffffff",
+        media: "(prefers-color-scheme: light)",
+      },
+      {
+        name: "theme-color",
+        content: "#0a0a0a",
+        media: "(prefers-color-scheme: dark)",
       },
     ],
     links: [
       { rel: "icon", href: "/favicon.ico" },
-      {
-        rel: "preconnect",
-        href: "https://fonts.googleapis.com",
-      },
+      { rel: "preconnect", href: "https://fonts.googleapis.com" },
       {
         rel: "preconnect",
         href: "https://fonts.gstatic.com",
@@ -48,7 +52,7 @@ export const Route = createRootRoute({
       {
         rel: "preload",
         as: "style",
-        href: "https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500&family=Inter:wght@300;400;500;600&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap",
       },
     ],
   }),
@@ -63,7 +67,7 @@ function RootComponent() {
         <HeadContent />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500&family=Inter:wght@300;400;500;600&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
           media="print"
           // @ts-expect-error onLoad is valid on link elements
           onLoad="this.media='all'"
@@ -71,15 +75,7 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider>
-          <div style={{ minHeight: "100vh", background: "var(--canvas)", color: "var(--ink)" }}>
-            <main>
-              <Outlet />
-            </main>
-            <footer className="flex flex-col items-center gap-4 px-4 py-8 text-xs text-[var(--muted-soft)]">
-              <ThemeToggle />
-              <a href="https://duyet.net" style={{ color: "var(--muted)", textDecoration: "none" }}>duyet.net</a>
-            </footer>
-          </div>
+          <Outlet />
           <Analytics />
         </ThemeProvider>
         <Scripts />

--- a/apps/burns/src/routes/index.tsx
+++ b/apps/burns/src/routes/index.tsx
@@ -5,6 +5,7 @@ import { DailyChart } from "../components/DailyChart";
 import { SourceBreakdown } from "../components/SourceBreakdown";
 import { SourceIcons } from "../components/SourceIcons";
 import { TokenBreakdown } from "../components/TokenBreakdown";
+import { formatDay } from "../lib/dates";
 import { readPublicJson } from "../lib/read-public-json";
 import { fmtCost } from "../lib/sources";
 import type { TokenData } from "../lib/types";
@@ -19,12 +20,7 @@ export const Route = createFileRoute("/")({
 
 function formatRange(first: string | null, last: string | null): string | null {
   if (!first || !last) return null;
-  const opts: Intl.DateTimeFormatOptions = {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  };
-  return `${new Date(first).toLocaleDateString("en-GB", opts)} — ${new Date(last).toLocaleDateString("en-GB", opts)}`;
+  return `${formatDay(first, true)} — ${formatDay(last, true)}`;
 }
 
 function formatUpdated(iso: string): string | null {

--- a/apps/burns/src/routes/index.tsx
+++ b/apps/burns/src/routes/index.tsx
@@ -1,11 +1,11 @@
 import ThemeToggle from "@duyet/components/ThemeToggle";
 import { createFileRoute } from "@tanstack/react-router";
 import { AnimatedCounter } from "../components/AnimatedCounter";
-import { DailyChart } from "../components/DailyChart";
+import { DailyChart, WINDOW } from "../components/DailyChart";
 import { SourceBreakdown } from "../components/SourceBreakdown";
 import { SourceIcons } from "../components/SourceIcons";
 import { TokenBreakdown } from "../components/TokenBreakdown";
-import { formatDay } from "../lib/dates";
+import { BURNS_LOCALE, formatDay } from "../lib/dates";
 import { readPublicJson } from "../lib/read-public-json";
 import { fmtCost } from "../lib/sources";
 import type { TokenData } from "../lib/types";
@@ -27,7 +27,7 @@ function formatUpdated(iso: string): string | null {
   if (!iso) return null;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return null;
-  return `Updated ${d.toLocaleDateString("en-GB", {
+  return `Updated ${d.toLocaleDateString(BURNS_LOCALE, {
     day: "numeric",
     month: "short",
     year: "numeric",
@@ -66,7 +66,7 @@ function Page() {
       <section className="burns-section">
         <div className="burns-section-head">
           <h2 className="burns-section-title">Daily</h2>
-          <p className="burns-section-meta">Last 90 days</p>
+          <p className="burns-section-meta">{`Last ${WINDOW} days`}</p>
         </div>
         <DailyChart daily={data.daily} />
       </section>

--- a/apps/burns/src/routes/index.tsx
+++ b/apps/burns/src/routes/index.tsx
@@ -2,10 +2,12 @@ import ThemeToggle from "@duyet/components/ThemeToggle";
 import { createFileRoute } from "@tanstack/react-router";
 import { AnimatedCounter } from "../components/AnimatedCounter";
 import { DailyChart } from "../components/DailyChart";
+import { SourceBreakdown } from "../components/SourceBreakdown";
+import { SourceIcons } from "../components/SourceIcons";
 import { TokenBreakdown } from "../components/TokenBreakdown";
 import { readPublicJson } from "../lib/read-public-json";
+import { fmtCost } from "../lib/sources";
 import type { TokenData } from "../lib/types";
-import { SourceIcons } from "../components/SourceIcons";
 
 export const Route = createFileRoute("/")({
   loader: async () => {
@@ -15,77 +17,82 @@ export const Route = createFileRoute("/")({
   component: Page,
 });
 
+function formatRange(first: string | null, last: string | null): string | null {
+  if (!first || !last) return null;
+  const opts: Intl.DateTimeFormatOptions = {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  };
+  return `${new Date(first).toLocaleDateString("en-GB", opts)} — ${new Date(last).toLocaleDateString("en-GB", opts)}`;
+}
+
+function formatUpdated(iso: string): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return `Updated ${d.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  })}`;
+}
+
 function Page() {
   const data = Route.useLoaderData();
+  const range = formatRange(data.firstDate, data.lastDate);
+  const updated = formatUpdated(data.generatedAt);
 
   return (
-    <div style={{
-      display: "flex",
-      height: "100dvh",
-      flexDirection: "column",
-      alignItems: "center",
-      padding: "24px",
-      boxSizing: "border-box",
-      overflow: "hidden",
-    }}>
-      <div style={{
-        flex: 1,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 28,
-      }}>
-        <div style={{ position: "relative", zIndex: 1 }}>
-          <AnimatedCounter target={data.totals.total_tokens} />
-          <div style={{
-            marginTop: 12,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 6,
-            flexWrap: "wrap",
-            position: "relative",
-            zIndex: 30,
-          }}>
-            <SourceIcons
-              sources={data.sources}
-              sourceTotals={data.source_totals ?? []}
-            />
-          </div>
-        </div>
-
-        <div style={{ marginTop: 24, width: "100%" }}>
-          <DailyChart daily={data.daily} firstDate={data.firstDate} lastDate={data.lastDate} />
-        </div>
-
+    <div className="burns-page">
+      <header className="burns-header">
         <div>
-          <TokenBreakdown totals={data.totals} />
+          <p className="burns-eyebrow">Burns</p>
+          <h1 className="burns-title">Token usage</h1>
         </div>
-      </div>
-
-      <div style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        width: "100%",
-        maxWidth: 400,
-        paddingTop: 8,
-        gap: 16,
-      }}>
         <ThemeToggle />
-        <a
-          href="https://duyet.net"
-          style={{
-            fontSize: 11,
-            letterSpacing: "0.04em",
-            color: "var(--muted-soft)",
-            textDecoration: "none",
-          }}
-        >
-          duyet.net
-        </a>
-      </div>
+      </header>
+
+      <section className="burns-hero">
+        <AnimatedCounter target={data.totals.total_tokens} />
+        <p className="burns-hero-kicker">tokens all-time</p>
+        <p className="burns-hero-meta">
+          {fmtCost(data.totals.total_cost)}
+          {range ? ` · ${range}` : ""}
+          {updated ? ` · ${updated}` : ""}
+        </p>
+        <SourceIcons
+          sources={data.sources}
+          sourceTotals={data.source_totals ?? []}
+        />
+      </section>
+
+      <section className="burns-section">
+        <div className="burns-section-head">
+          <h2 className="burns-section-title">Daily</h2>
+          <p className="burns-section-meta">Last 90 days</p>
+        </div>
+        <DailyChart daily={data.daily} />
+      </section>
+
+      <section className="burns-section">
+        <div className="burns-section-head">
+          <h2 className="burns-section-title">By source</h2>
+          <p className="burns-section-meta">All-time</p>
+        </div>
+        <SourceBreakdown totals={data.source_totals ?? []} />
+      </section>
+
+      <section className="burns-section">
+        <div className="burns-section-head">
+          <h2 className="burns-section-title">Token mix</h2>
+        </div>
+        <TokenBreakdown totals={data.totals} />
+      </section>
+
+      <footer className="burns-footer">
+        <a href="https://duyet.net">duyet.net</a>
+      </footer>
     </div>
   );
 }

--- a/apps/burns/src/routes/index.tsx
+++ b/apps/burns/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import ThemeToggle from "@duyet/components/ThemeToggle";
+import type { JSX } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { AnimatedCounter } from "../components/AnimatedCounter";
 import { DailyChart, WINDOW } from "../components/DailyChart";
@@ -34,7 +35,7 @@ function formatUpdated(iso: string): string | null {
   })}`;
 }
 
-function Page() {
+function Page(): JSX.Element {
   const data = Route.useLoaderData();
   const range = formatRange(data.firstDate, data.lastDate);
   const updated = formatUpdated(data.generatedAt);

--- a/apps/burns/src/styles.css
+++ b/apps/burns/src/styles.css
@@ -3,40 +3,399 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-  --canvas: #faf9f5;
-  --ink: #141413;
+  --canvas: #ffffff;
+  --ink: #0c0c0c;
   --background: var(--canvas);
   --foreground: var(--ink);
-  --body: #3d3d3a;
-  --muted: #6c6a64;
-  --muted-foreground: #6c6a64;
-  --muted-soft: #8e8b82;
-  --hairline: #e6dfd8;
-  --coral: #cc785c;
+  --body: #3a3a38;
+  --muted: #6e6d68;
+  --muted-foreground: #6e6d68;
+  --muted-soft: #8c8b85;
+  --hairline: #e8e8e6;
   --surface-card: #ffffff;
-  --on-dark: #faf9f5;
-  --serif: "Cormorant Garamond", "Garamond", "Times New Roman", serif;
-  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --on-dark: #f4f3f1;
+  --sans: "Inter", ui-sans-serif, system-ui, sans-serif;
 }
 
 .dark {
-  --canvas: #0d0e0c;
-  --ink: #f8f8f2;
+  --canvas: #0a0a0a;
+  --ink: #f4f3f1;
   --background: var(--canvas);
   --foreground: var(--ink);
-  --body: #cfcfc8;
-  --muted: #b7b7aa;
-  --muted-foreground: #b7b7aa;
-  --muted-soft: #8e8b82;
-  --hairline: rgba(248, 248, 242, 0.14);
-  --surface-card: #171815;
-  --on-dark: #f8f8f2;
+  --body: #c8c7c2;
+  --muted: #9a9994;
+  --muted-foreground: #9a9994;
+  --muted-soft: #74736e;
+  --hairline: #242424;
+  --surface-card: #111111;
+  --on-dark: #f4f3f1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
 }
 
 body {
   font-family: var(--sans);
   color: var(--ink);
   background: var(--canvas);
-  overflow: hidden;
+}
+
+.burns-page {
+  width: min(720px, 100%);
+  margin: 0 auto;
+  padding: 28px 20px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.burns-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.burns-eyebrow {
   margin: 0;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.burns-title {
+  margin: 4px 0 0;
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.burns-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.burns-count {
+  display: block;
+  font-family: var(--sans);
+  font-size: clamp(2.4rem, 9vw, 4.4rem);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 0.95;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
+.burns-hero-kicker {
+  margin: 0;
+  font-size: 13px;
+  color: var(--body);
+}
+
+.burns-hero-meta {
+  margin: 0;
+  font-size: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.burns-hero .burns-icons {
+  margin-top: 10px;
+}
+
+.burns-section {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-top: 28px;
+  border-top: 1px solid var(--hairline);
+}
+
+.burns-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.burns-section-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+
+.burns-section-meta {
+  margin: 0;
+  font-size: 11px;
+  color: var(--muted-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.burns-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 8px;
+  border-top: 1px solid var(--hairline);
+  font-size: 12px;
+}
+
+.burns-footer a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.burns-footer a:hover {
+  color: var(--ink);
+}
+
+.burns-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.burns-legend li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.burns-swatch {
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgb(12 12 12 / 0.14);
+}
+
+.dark .burns-swatch {
+  box-shadow: inset 0 0 0 1px rgb(244 243 241 / 0.22);
+}
+
+.burns-chart {
+  width: 100%;
+}
+
+.burns-chart-frame {
+  position: relative;
+  width: 100%;
+}
+
+.burns-chart svg {
+  display: block;
+  width: 100%;
+  height: 168px;
+}
+
+.burns-chart-axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--muted-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.burns-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  padding: 8px 10px;
+  min-width: 180px;
+  background: var(--canvas);
+  border: 1px solid var(--hairline);
+  color: var(--ink);
+  font-size: 11px;
+  line-height: 1.5;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.burns-tooltip-title {
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+
+.burns-tooltip-grid {
+  display: grid;
+  grid-template-columns: 8px max-content max-content max-content;
+  column-gap: 10px;
+  row-gap: 3px;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.burns-tooltip-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 6px;
+  padding-top: 4px;
+  border-top: 1px solid var(--hairline);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.burns-sources {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.burns-source-head {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) max-content max-content;
+  gap: 8px 10px;
+  align-items: baseline;
+  font-size: 13px;
+}
+
+.burns-source-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.burns-source-tokens,
+.burns-source-cost {
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.burns-source-bar {
+  height: 3px;
+  margin-top: 6px;
+  background: var(--hairline);
+}
+
+.burns-source-bar > i {
+  display: block;
+  height: 100%;
+}
+
+.burns-mix-bar {
+  display: flex;
+  height: 6px;
+  width: 100%;
+  overflow: hidden;
+}
+
+.burns-mix-bar > i {
+  display: block;
+  height: 100%;
+  min-width: 0;
+}
+
+.burns-mix-input {
+  background: var(--ink);
+}
+
+.burns-mix-output {
+  background: var(--muted);
+}
+
+.burns-mix-write {
+  background: #c4c3bd;
+}
+
+.burns-mix-read {
+  background: #e4e3de;
+}
+
+.dark .burns-mix-write {
+  background: #5a5955;
+}
+
+.dark .burns-mix-read {
+  background: #3a3936;
+}
+
+.burns-mix-rows {
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.burns-mix-row {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) max-content;
+  gap: 8px 10px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--body);
+}
+
+.burns-mix-row span:last-child {
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+.burns-icons {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+
+.burns-icon {
+  display: block;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--muted);
+  position: relative;
+  cursor: default;
+}
+
+.burns-icon-tip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 10px;
+  background: var(--canvas);
+  border: 1px solid var(--hairline);
+  color: var(--ink);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: nowrap;
+  text-align: center;
+  pointer-events: none;
+  z-index: 20;
+}
+
+@media (max-width: 420px) {
+  .burns-page {
+    padding: 20px 16px 40px;
+    gap: 28px;
+  }
+
+  .burns-count {
+    font-size: clamp(2.1rem, 12vw, 3.2rem);
+  }
 }

--- a/apps/burns/src/styles.css
+++ b/apps/burns/src/styles.css
@@ -10,7 +10,7 @@
   --body: #3a3a38;
   --muted: #6e6d68;
   --muted-foreground: #6e6d68;
-  --muted-soft: #8c8b85;
+  --muted-soft: #76756f;
   --hairline: #e8e8e6;
   --surface-card: #ffffff;
   --on-dark: #f4f3f1;
@@ -25,7 +25,7 @@
   --body: #c8c7c2;
   --muted: #9a9994;
   --muted-foreground: #9a9994;
-  --muted-soft: #74736e;
+  --muted-soft: #7a7974;
   --hairline: #242424;
   --surface-card: #111111;
   --on-dark: #f4f3f1;
@@ -205,6 +205,14 @@ body {
   height: 168px;
 }
 
+.burns-chart svg [tabindex]:focus {
+  outline: none;
+}
+
+.burns-chart svg [tabindex]:focus-visible {
+  outline: 1px solid var(--ink);
+}
+
 .burns-chart-axis {
   display: flex;
   justify-content: space-between;
@@ -366,10 +374,23 @@ body {
   display: block;
   width: 18px;
   height: 18px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
   flex-shrink: 0;
   color: var(--muted);
   position: relative;
   cursor: default;
+}
+
+.burns-icon:focus {
+  outline: none;
+}
+
+.burns-icon:focus-visible {
+  outline: 1px solid var(--ink);
+  outline-offset: 3px;
 }
 
 .burns-icon-tip {
@@ -378,12 +399,14 @@ body {
   left: 50%;
   transform: translateX(-50%);
   padding: 8px 10px;
+  max-width: min(220px, calc(100vw - 32px));
   background: var(--canvas);
   border: 1px solid var(--hairline);
   color: var(--ink);
   font-size: 11px;
   line-height: 1.5;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
   text-align: center;
   pointer-events: none;
   z-index: 20;

--- a/apps/burns/src/styles.css
+++ b/apps/burns/src/styles.css
@@ -227,6 +227,7 @@ body {
   bottom: calc(100% + 8px);
   padding: 8px 10px;
   min-width: 180px;
+  max-width: min(280px, calc(100vw - 24px));
   background: var(--canvas);
   border: 1px solid var(--hairline);
   color: var(--ink);
@@ -243,7 +244,7 @@ body {
 
 .burns-tooltip-grid {
   display: grid;
-  grid-template-columns: 8px max-content max-content max-content;
+  grid-template-columns: 8px minmax(0, 1fr) max-content max-content;
   column-gap: 10px;
   row-gap: 3px;
   align-items: center;

--- a/apps/burns/vitest.config.ts
+++ b/apps/burns/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    include: ["**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
Map raw `gemini` to Gemini CLI (never Google Antigravity). Only raw `antigravity` uses that label.

Also: editorial layout, stacked daily chart, source ledger. token-data.json rebuilt after MotherDuck purge — live burn.duyet.net now has no Google Antigravity.

## Summary by Sourcery

Revamp the Burns token usage page with a new editorial layout and chart design while correcting source attribution for Gemini and refreshing supporting utilities.

New Features:
- Introduce a stacked daily usage chart with tooltips, axis labels, and a legend of sources.
- Add an all-time per-source breakdown with bars and compact token counts.
- Add a visual token mix component showing input, output, and cache read/write proportions.
- Expose utility functions for formatting calendar days and compact token values.

Bug Fixes:
- Ensure raw gemini usage is labeled as Gemini CLI instead of Google Antigravity throughout data processing and UI.
- Unify source color handling via a swatch helper so Gemini and Antigravity use distinct visuals.
- Parse and format dates as local calendar days to avoid off-by-one display issues.

Enhancements:
- Redesign the Burns page into a centered, responsive editorial layout with clearer typography and spacing.
- Standardize styling via new Burns-specific CSS classes and remove inline styles from core components.
- Simplify data aggregation logic by replacing SQL CASE mappings with a normalizeSource helper in the fetch script.
- Update meta tags, theme colors, and fonts to match the new design system.

Build:
- Add Vitest configuration and npm scripts to run the test suite for the Burns app.

Tests:
- Add Vitest-based tests for source normalization, source color mapping, and the fetch script’s use of normalizeSource.
- Add tests for date parsing and formatting helpers to ensure calendar-day correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned the Burns dashboard with clearer sections for daily usage, source totals, token mix, costs, and update dates.
  - Added support and visual identification for more usage sources, including Gemini CLI, Grok, Z.AI, Hermes, OpenClaw, and pi.
  - Added proportional token-mix and source-breakdown visualizations.
- **Enhancements**
  - Improved daily charts with up to 90 days of data, stacked source bars, legends, hover states, and tooltips.
  - Added responsive light and dark themes for desktop and mobile viewing.
- **Data Updates**
  - Refreshed usage and cost records through August 14, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->