### PR TITLE
fix(news): render Clerk auth buttons only from the app-wide provider module

### DIFF
--- a/.github/workflows/cf-deploy-preview.yml
+++ b/.github/workflows/cf-deploy-preview.yml
@@ -251,6 +251,33 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # @duyet/libs' markdownToHtml imports the WASM markdown converter, and
+      # any app pulling in @duyet/libs fails to build without it — not just
+      # blog. Build it for every app in the matrix.
+      - name: Setup Rust toolchain (WASM markdown)
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry & build
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasm-
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
+        with:
+          version: v0.15.0
+
+      - name: Build WASM packages (markdown converter)
+        run: pnpm run wasm:build:release
+
       - name: Build app
         id: build
         run: |

--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -280,14 +280,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Setup Rust toolchain (blog WASM markdown)
-        if: matrix.app == 'blog'
+      # @duyet/libs' markdownToHtml imports the WASM markdown converter, and
+      # any app pulling in @duyet/libs fails to build without it — not just
+      # blog. Build it for every app in the matrix.
+      - name: Setup Rust toolchain (WASM markdown)
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry & build
-        if: matrix.app == 'blog'
         uses: actions/cache@v6
         with:
           path: |
@@ -299,13 +300,11 @@ jobs:
             ${{ runner.os }}-cargo-wasm-
 
       - name: Install wasm-pack
-        if: matrix.app == 'blog'
         uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0
         with:
           version: v0.15.0
 
       - name: Build WASM packages (markdown converter)
-        if: matrix.app == 'blog'
         run: pnpm run wasm:build:release
 
       - name: Tailscale

--- a/.github/workflows/cf-worker-deploy.yml
+++ b/.github/workflows/cf-worker-deploy.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           submodules: false
 
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
         id: filter
         with:
           filters: |
@@ -254,7 +254,7 @@ jobs:
         with:
           submodules: false
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 24
 

--- a/.github/workflows/cf-worker-deploy.yml
+++ b/.github/workflows/cf-worker-deploy.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'apps/agent-api/**'
       - 'apps/api/**'
+      - 'apps/news/**'
+      # news bundles @duyet/{components,libs,urls,config} into its client
+      # build, so shared-package changes ship to it too.
+      - 'packages/**'
   workflow_dispatch:
     inputs:
       worker:
@@ -17,6 +21,7 @@ on:
         options:
           - agents-api
           - duyet-api
+          - news
           - all
 
 env:
@@ -29,12 +34,39 @@ permissions:
   deployments: write
 
 jobs:
+  detect-changes:
+    name: Detect changed workers
+    runs-on: ubuntu-latest
+    outputs:
+      agents-api: ${{ steps.filter.outputs.agents-api }}
+      duyet-api: ${{ steps.filter.outputs.duyet-api }}
+      news: ${{ steps.filter.outputs.news }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
+        with:
+          submodules: false
+
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        id: filter
+        with:
+          filters: |
+            agents-api:
+              - 'apps/agent-api/**'
+            duyet-api:
+              - 'apps/api/**'
+            news:
+              - 'apps/news/**'
+              - 'packages/**'
+
   deploy-agents-api:
     name: Deploy duyet-agents-api Worker
+    needs: detect-changes
     if: |
-      github.event_name != 'workflow_dispatch' ||
-      github.event.inputs.worker == 'all' ||
-      github.event.inputs.worker == 'agents-api'
+      (github.event_name == 'workflow_dispatch' &&
+        (github.event.inputs.worker == 'all' ||
+         github.event.inputs.worker == 'agents-api')) ||
+      (github.event_name != 'workflow_dispatch' &&
+        needs.detect-changes.outputs.agents-api == 'true')
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -140,10 +172,13 @@ jobs:
 
   deploy-duyet-api:
     name: Deploy duyet-api Worker
+    needs: detect-changes
     if: |
-      github.event_name != 'workflow_dispatch' ||
-      github.event.inputs.worker == 'all' ||
-      github.event.inputs.worker == 'duyet-api'
+      (github.event_name == 'workflow_dispatch' &&
+        (github.event.inputs.worker == 'all' ||
+         github.event.inputs.worker == 'duyet-api')) ||
+      (github.event_name != 'workflow_dispatch' &&
+        needs.detect-changes.outputs.duyet-api == 'true')
     runs-on: ubuntu-latest
     environment:
       name: production
@@ -201,3 +236,56 @@ jobs:
         working-directory: apps/api
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-news:
+    name: Deploy duyet-news Worker
+    needs: detect-changes
+    if: |
+      (github.event_name == 'workflow_dispatch' &&
+        (github.event.inputs.worker == 'all' ||
+         github.event.inputs.worker == 'news')) ||
+      (github.event_name != 'workflow_dispatch' &&
+        needs.detect-changes.outputs.news == 'true')
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
+        with:
+          submodules: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.5.0
+        with:
+          node-version: 24
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy Worker to Cloudflare
+        run: |
+          cd apps/news
+          pnpm run deploy
+        env:
+          NODE_ENV: production
+          # Baked into the client bundle at build time — without it the
+          # header's sign-in button renders as unavailable.
+          VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deployment summary
+        run: |
+          echo "### ✅ Deployed Worker" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Worker**: duyet-news" >> $GITHUB_STEP_SUMMARY
+          echo "- **Location**: apps/news/" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL**: https://news.duyet.net" >> $GITHUB_STEP_SUMMARY
+
+      # The repo's own post-deploy checks: SSR shell, feed/story/system APIs,
+      # every static route, and the admin/subscribe rejection paths.
+      - name: Smoke test
+        run: |
+          cd apps/news
+          pnpm run smoke

--- a/apps/blog/public/llms-full.txt
+++ b/apps/blog/public/llms-full.txt
@@ -1265,12 +1265,12 @@ While people are still scared of vibe coding, I ship it to production. For me, A
 I didn't stop writing, tons of drafts in my [obsidian](https://obsidian.md/), none published because they became outdated before I could finish them. I want to kick off this first 2026 post as my [digital garden](https://joelhooks.com/digital-garden/) - a place to reflect on what I'm thinking and doing in this LLM era. This post will be updated from time to time.
 
 <div class="not-prose my-8 rounded-2xl border border-border dark:border-white/10 p-6 sm:p-8">
-  <p class="text-[0.7rem] uppercase tracking-[0.2em] font-mono text-terracotta">Updated Jun 2026</p>
+  <p class="text-[0.7rem] uppercase tracking-[0.2em] font-mono text-terracotta">Updated Aug 2026</p>
   <p class="text-2xl font-serif text-foreground mt-2">Top on my list</p>
   <div class="mt-5 border-t border-border dark:border-white/10 divide-y divide-border dark:divide-white/10">
     <div class="grid grid-cols-1 sm:grid-cols-[9rem_1fr] gap-1 sm:gap-4 py-3.5">
       <span class="text-xs uppercase tracking-wide font-mono text-terracotta">Coding Agent</span>
-      <span class="text-foreground"><a href="/2026/01/coding-agent/claude-code" class="underline underline-offset-2">Claude Code</a>, <a href="/2026/01/coding-agent/opencode" class="underline underline-offset-2">opencode</a></span>
+      <span class="text-foreground">Grok Build, <a href="/2026/01/coding-agent/claude-code" class="underline underline-offset-2">Claude Code</a></span>
     </div>
     <div class="grid grid-cols-1 sm:grid-cols-[9rem_1fr] gap-1 sm:gap-4 py-3.5">
       <span class="text-xs uppercase tracking-wide font-mono text-terracotta">Code Review</span>
@@ -1280,7 +1280,7 @@ I didn't stop writing, tons of drafts in my [obsidian](https://obsidian.md/), no
     </div>
     <div class="grid grid-cols-1 sm:grid-cols-[9rem_1fr] gap-1 sm:gap-4 py-3.5">
       <span class="text-xs uppercase tracking-wide font-mono text-terracotta">Model</span>
-      <span class="text-foreground"><a href="/2026/01/coding-agent/z-claude-mi-claude-or-claude" class="underline underline-offset-2">Fable 5</a>, <a href="/2026/01/coding-agent/z-claude-mi-claude-or-claude" class="underline underline-offset-2">Opus 4.8</a>, <a href="/2026/01/coding-agent/z-claude-mi-claude-or-claude" class="underline underline-offset-2">GLM 5.1</a></span>
+      <span class="text-foreground"><a href="/2026/01/coding-agent/z-claude-mi-claude-or-claude" class="underline underline-offset-2">Fable 5</a>, Grok 4.6</span>
     </div>
     <div class="grid grid-cols-1 sm:grid-cols-[9rem_1fr] gap-1 sm:gap-4 py-3.5">
       <span class="text-xs uppercase tracking-wide font-mono text-terracotta">Provider</span>

--- a/apps/blog/public/ping.json
+++ b/apps/blog/public/ping.json
@@ -1,1 +1,1 @@
-{"status":"ok","timestamp":"2026-08-05T08:41:17.720Z"}
+{"status":"ok","timestamp":"2026-08-17T03:09:29.064Z"}

--- a/apps/blog/public/rss.xml
+++ b/apps/blog/public/rss.xml
@@ -4,7 +4,7 @@
         <description><![CDATA[Sr. Data Engineer. Rustacean at night]]></description>
         <link>https://blog.duyet.net</link>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Wed, 05 Aug 2026 08:41:17 GMT</lastBuildDate>
+        <lastBuildDate>Mon, 17 Aug 2026 03:09:28 GMT</lastBuildDate>
         <atom:link href="https://blog.duyet.net/rss.xml" rel="self" type="application/rss+xml"/>
         <item>
             <title><![CDATA[I am building anyrouter.dev]]></title>

--- a/apps/blog/public/sitemap.xml
+++ b/apps/blog/public/sitemap.xml
@@ -1270,91 +1270,91 @@
   </url>
   <url>
     <loc>https://blog.duyet.net/category/javascript</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/git</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/software-engineering</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/news</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/linux</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/data</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/web</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/data-engineering</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/project</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/infrastructure</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/story</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/machine-learning</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/productivity</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/rust</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category/ai</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/feed</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/category</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/tags</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/archives</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/featured</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/series</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-17</lastmod>
   </url>
   <url>
     <loc>https://blog.duyet.net/notes</loc>

--- a/apps/blog/src/routeTree.gen.ts
+++ b/apps/blog/src/routeTree.gen.ts
@@ -9,79 +9,29 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as AboutRouteImport } from './routes/about'
-import { Route as AiRouteImport } from './routes/ai'
-import { Route as ArchivesRouteImport } from './routes/archives'
-import { Route as CategoryRouteImport } from './routes/category'
-import { Route as FeaturedRouteImport } from './routes/featured'
-import { Route as FeedRouteImport } from './routes/feed'
-import { Route as HtmlSitemapRouteImport } from './routes/html-sitemap'
-import { Route as NotesRouteImport } from './routes/notes'
-import { Route as RobotsRouteImport } from './routes/robots'
-import { Route as SearchRouteImport } from './routes/search'
-import { Route as SeriesRouteImport } from './routes/series'
 import { Route as TagsRouteImport } from './routes/tags'
-import { Route as CategoryCategoryRouteImport } from './routes/category/$category'
-import { Route as NoteIdRouteImport } from './routes/note/$id'
-import { Route as SeriesSlugRouteImport } from './routes/series/$slug'
+import { Route as SeriesRouteImport } from './routes/series'
+import { Route as SearchRouteImport } from './routes/search'
+import { Route as RobotsRouteImport } from './routes/robots'
+import { Route as NotesRouteImport } from './routes/notes'
+import { Route as HtmlSitemapRouteImport } from './routes/html-sitemap'
+import { Route as FeedRouteImport } from './routes/feed'
+import { Route as FeaturedRouteImport } from './routes/featured'
+import { Route as CategoryRouteImport } from './routes/category'
+import { Route as ArchivesRouteImport } from './routes/archives'
+import { Route as AiRouteImport } from './routes/ai'
+import { Route as AboutRouteImport } from './routes/about'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as TagTagRouteImport } from './routes/tag/$tag'
+import { Route as SeriesSlugRouteImport } from './routes/series/$slug'
+import { Route as NoteIdRouteImport } from './routes/note/$id'
+import { Route as CategoryCategoryRouteImport } from './routes/category/$category'
 import { Route as YearMonthSlugIndexRouteImport } from './routes/$year/$month/$slug/index'
 import { Route as YearMonthSlugChildRouteImport } from './routes/$year/$month/$slug/$child'
 
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AboutRoute = AboutRouteImport.update({
-  id: '/about',
-  path: '/about',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AiRoute = AiRouteImport.update({
-  id: '/ai',
-  path: '/ai',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ArchivesRoute = ArchivesRouteImport.update({
-  id: '/archives',
-  path: '/archives',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const CategoryRoute = CategoryRouteImport.update({
-  id: '/category',
-  path: '/category',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const FeaturedRoute = FeaturedRouteImport.update({
-  id: '/featured',
-  path: '/featured',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const FeedRoute = FeedRouteImport.update({
-  id: '/feed',
-  path: '/feed',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const HtmlSitemapRoute = HtmlSitemapRouteImport.update({
-  id: '/html-sitemap',
-  path: '/html-sitemap',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const NotesRoute = NotesRouteImport.update({
-  id: '/notes',
-  path: '/notes',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const RobotsRoute = RobotsRouteImport.update({
-  id: '/robots',
-  path: '/robots',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SearchRoute = SearchRouteImport.update({
-  id: '/search',
-  path: '/search',
+const TagsRoute = TagsRouteImport.update({
+  id: '/tags',
+  path: '/tags',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SeriesRoute = SeriesRouteImport.update({
@@ -89,19 +39,64 @@ const SeriesRoute = SeriesRouteImport.update({
   path: '/series',
   getParentRoute: () => rootRouteImport,
 } as any)
-const TagsRoute = TagsRouteImport.update({
-  id: '/tags',
-  path: '/tags',
+const SearchRoute = SearchRouteImport.update({
+  id: '/search',
+  path: '/search',
   getParentRoute: () => rootRouteImport,
 } as any)
-const CategoryCategoryRoute = CategoryCategoryRouteImport.update({
-  id: '/$category',
-  path: '/$category',
-  getParentRoute: () => CategoryRoute,
+const RobotsRoute = RobotsRouteImport.update({
+  id: '/robots',
+  path: '/robots',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const NoteIdRoute = NoteIdRouteImport.update({
-  id: '/note/$id',
-  path: '/note/$id',
+const NotesRoute = NotesRouteImport.update({
+  id: '/notes',
+  path: '/notes',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const HtmlSitemapRoute = HtmlSitemapRouteImport.update({
+  id: '/html-sitemap',
+  path: '/html-sitemap',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FeedRoute = FeedRouteImport.update({
+  id: '/feed',
+  path: '/feed',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FeaturedRoute = FeaturedRouteImport.update({
+  id: '/featured',
+  path: '/featured',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CategoryRoute = CategoryRouteImport.update({
+  id: '/category',
+  path: '/category',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ArchivesRoute = ArchivesRouteImport.update({
+  id: '/archives',
+  path: '/archives',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AiRoute = AiRouteImport.update({
+  id: '/ai',
+  path: '/ai',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TagTagRoute = TagTagRouteImport.update({
+  id: '/tag/$tag',
+  path: '/tag/$tag',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SeriesSlugRoute = SeriesSlugRouteImport.update({
@@ -109,10 +104,15 @@ const SeriesSlugRoute = SeriesSlugRouteImport.update({
   path: '/$slug',
   getParentRoute: () => SeriesRoute,
 } as any)
-const TagTagRoute = TagTagRouteImport.update({
-  id: '/tag/$tag',
-  path: '/tag/$tag',
+const NoteIdRoute = NoteIdRouteImport.update({
+  id: '/note/$id',
+  path: '/note/$id',
   getParentRoute: () => rootRouteImport,
+} as any)
+const CategoryCategoryRoute = CategoryCategoryRouteImport.update({
+  id: '/$category',
+  path: '/$category',
+  getParentRoute: () => CategoryRoute,
 } as any)
 const YearMonthSlugIndexRoute = YearMonthSlugIndexRouteImport.update({
   id: '/$year/$month/$slug/',
@@ -277,81 +277,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/about': {
-      id: '/about'
-      path: '/about'
-      fullPath: '/about'
-      preLoaderRoute: typeof AboutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ai': {
-      id: '/ai'
-      path: '/ai'
-      fullPath: '/ai'
-      preLoaderRoute: typeof AiRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/archives': {
-      id: '/archives'
-      path: '/archives'
-      fullPath: '/archives'
-      preLoaderRoute: typeof ArchivesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/category': {
-      id: '/category'
-      path: '/category'
-      fullPath: '/category'
-      preLoaderRoute: typeof CategoryRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/featured': {
-      id: '/featured'
-      path: '/featured'
-      fullPath: '/featured'
-      preLoaderRoute: typeof FeaturedRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/feed': {
-      id: '/feed'
-      path: '/feed'
-      fullPath: '/feed'
-      preLoaderRoute: typeof FeedRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/html-sitemap': {
-      id: '/html-sitemap'
-      path: '/html-sitemap'
-      fullPath: '/html-sitemap'
-      preLoaderRoute: typeof HtmlSitemapRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/notes': {
-      id: '/notes'
-      path: '/notes'
-      fullPath: '/notes'
-      preLoaderRoute: typeof NotesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/robots': {
-      id: '/robots'
-      path: '/robots'
-      fullPath: '/robots'
-      preLoaderRoute: typeof RobotsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/search': {
-      id: '/search'
-      path: '/search'
-      fullPath: '/search'
-      preLoaderRoute: typeof SearchRouteImport
+    '/tags': {
+      id: '/tags'
+      path: '/tags'
+      fullPath: '/tags'
+      preLoaderRoute: typeof TagsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/series': {
@@ -361,25 +291,88 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SeriesRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/tags': {
-      id: '/tags'
-      path: '/tags'
-      fullPath: '/tags'
-      preLoaderRoute: typeof TagsRouteImport
+    '/search': {
+      id: '/search'
+      path: '/search'
+      fullPath: '/search'
+      preLoaderRoute: typeof SearchRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/category/$category': {
-      id: '/category/$category'
-      path: '/$category'
-      fullPath: '/category/$category'
-      preLoaderRoute: typeof CategoryCategoryRouteImport
-      parentRoute: typeof CategoryRoute
+    '/robots': {
+      id: '/robots'
+      path: '/robots'
+      fullPath: '/robots'
+      preLoaderRoute: typeof RobotsRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/note/$id': {
-      id: '/note/$id'
-      path: '/note/$id'
-      fullPath: '/note/$id'
-      preLoaderRoute: typeof NoteIdRouteImport
+    '/notes': {
+      id: '/notes'
+      path: '/notes'
+      fullPath: '/notes'
+      preLoaderRoute: typeof NotesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/html-sitemap': {
+      id: '/html-sitemap'
+      path: '/html-sitemap'
+      fullPath: '/html-sitemap'
+      preLoaderRoute: typeof HtmlSitemapRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/feed': {
+      id: '/feed'
+      path: '/feed'
+      fullPath: '/feed'
+      preLoaderRoute: typeof FeedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/featured': {
+      id: '/featured'
+      path: '/featured'
+      fullPath: '/featured'
+      preLoaderRoute: typeof FeaturedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/category': {
+      id: '/category'
+      path: '/category'
+      fullPath: '/category'
+      preLoaderRoute: typeof CategoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/archives': {
+      id: '/archives'
+      path: '/archives'
+      fullPath: '/archives'
+      preLoaderRoute: typeof ArchivesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ai': {
+      id: '/ai'
+      path: '/ai'
+      fullPath: '/ai'
+      preLoaderRoute: typeof AiRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tag/$tag': {
+      id: '/tag/$tag'
+      path: '/tag/$tag'
+      fullPath: '/tag/$tag'
+      preLoaderRoute: typeof TagTagRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/series/$slug': {
@@ -389,12 +382,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SeriesSlugRouteImport
       parentRoute: typeof SeriesRoute
     }
-    '/tag/$tag': {
-      id: '/tag/$tag'
-      path: '/tag/$tag'
-      fullPath: '/tag/$tag'
-      preLoaderRoute: typeof TagTagRouteImport
+    '/note/$id': {
+      id: '/note/$id'
+      path: '/note/$id'
+      fullPath: '/note/$id'
+      preLoaderRoute: typeof NoteIdRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/category/$category': {
+      id: '/category/$category'
+      path: '/$category'
+      fullPath: '/category/$category'
+      preLoaderRoute: typeof CategoryCategoryRouteImport
+      parentRoute: typeof CategoryRoute
     }
     '/$year/$month/$slug/': {
       id: '/$year/$month/$slug/'

--- a/apps/news/src/components/HeaderBar.tsx
+++ b/apps/news/src/components/HeaderBar.tsx
@@ -1,6 +1,7 @@
 import { AuthButtons, ErrorBoundary } from "@duyet/components";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
+import { useClerkModule } from "../lib/clerk-user";
 import type { Lang } from "../lib/types";
 import { LangToggle } from "./LangToggle";
 import { PrefsPanel } from "./PrefsPanel";
@@ -19,6 +20,10 @@ export function HeaderBar({
   onLangChange: (lang: Lang) => void;
 }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+  // The single app-wide <ClerkProvider> lives in __root.tsx; hand AuthButtons
+  // that exact module so it never renders Clerk primitives before the
+  // provider is mounted.
+  const { mod: clerkModule } = useClerkModule();
   const langToggleDisabled = LANG_TOGGLE_DISABLED_PATHS.has(pathname);
   const tagline =
     lang === "vi" ? "Hôm nay AI có gì mới?" : "What is happening in AI today?";
@@ -56,6 +61,7 @@ export function HeaderBar({
           <ErrorBoundary fallback={null}>
             <AuthButtons
               wrapWithProvider={false}
+              clerkModule={clerkModule}
               signInClassName="h-6 w-6 flex items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
               avatarSize="h-6 w-6"
             />

--- a/apps/news/src/routes/__root.tsx
+++ b/apps/news/src/routes/__root.tsx
@@ -49,8 +49,12 @@ import type { Lang } from "../lib/types";
  */
 function ClerkRootProvider({ children }: { children: ReactNode }) {
   const clerkState = useClerkModuleLoader();
+  // No provider in this subtree, so consumers must not see a module either —
+  // rendering Clerk's SignedIn/SignedOut outside a <ClerkProvider> throws.
   const withoutProvider = (
-    <ClerkModuleContext.Provider value={clerkState}>
+    <ClerkModuleContext.Provider
+      value={{ mod: null, publishableKey: clerkState.publishableKey }}
+    >
       {children}
     </ClerkModuleContext.Provider>
   );

--- a/packages/components/.env.test
+++ b/packages/components/.env.test
@@ -1,0 +1,2 @@
+# Test-only Clerk key so AuthButtons renders its Clerk-backed branches.
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_components

--- a/packages/components/__tests__/AuthButtons.test.tsx
+++ b/packages/components/__tests__/AuthButtons.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { AuthButtons } from "../header/AuthButtons";
+
+// A stand-in for @clerk/clerk-react. The point of wrapWithProvider={false} is
+// that the host has ALREADY mounted the provider from this very module, so
+// these primitives are safe to render immediately.
+const fakeClerkModule = {
+  ClerkProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SignedOut: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SignedIn: () => null,
+  SignInButton: ({ children }: { children: ReactNode }) => <>{children}</>,
+  UserButton: () => null,
+};
+
+// The publishable key AuthButtons reads comes from .env.test — each module
+// gets its own import.meta.env object, so it cannot be stubbed from here.
+describe("AuthButtons with a host-owned ClerkProvider", () => {
+  it("renders on the first render when the module is already available", () => {
+    render(
+      <AuthButtons wrapWithProvider={false} clerkModule={fakeClerkModule} />
+    );
+
+    // Regression: the isOwner ref is set in an effect, so gating on it here
+    // left the button blank forever on any mount where the module was
+    // already present (e.g. a header remount after Clerk had loaded).
+    expect(screen.getByLabelText("Sign in")).toBeTruthy();
+  });
+
+  it("renders nothing until the host supplies the module", () => {
+    // Never import Clerk ourselves — rendering SignedOut before the host's
+    // provider exists is what throws "SignedOut can only be used within
+    // the <ClerkProvider /> component".
+    const { container } = render(
+      <AuthButtons wrapWithProvider={false} clerkModule={null} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/components/header/AuthButtons.tsx
+++ b/packages/components/header/AuthButtons.tsx
@@ -32,8 +32,9 @@ let clerkProviderMounted = false;
  * <AuthButtons className="rounded-lg p-2" />
  *
  * @example
- * // App already has ClerkProvider
- * <AuthButtons wrapWithProvider={false} />
+ * // App already has ClerkProvider — pass the same module the provider was
+ * // mounted from, so we never render SignedIn/SignedOut before it exists.
+ * <AuthButtons wrapWithProvider={false} clerkModule={mod} />
  */
 export function AuthButtons({
   urls,
@@ -43,6 +44,7 @@ export function AuthButtons({
   signedInContent = null,
   signedOutContent = null,
   wrapWithProvider = true,
+  clerkModule: providedModule = null,
 }: {
   urls?: UrlsConfig;
   className?: string;
@@ -51,6 +53,7 @@ export function AuthButtons({
   signedInContent?: React.ReactNode | null;
   signedOutContent?: React.ReactNode | null;
   wrapWithProvider?: boolean;
+  clerkModule?: any;
 } = {}) {
   const importMetaEnv =
     typeof import.meta !== "undefined"
@@ -60,9 +63,16 @@ export function AuthButtons({
       : undefined;
   const publishableKey = importMetaEnv?.VITE_CLERK_PUBLISHABLE_KEY;
 
-  const [clerkModule, setClerkModule] = useState<any>(null);
+  const [ownModule, setOwnModule] = useState<any>(null);
   const [currentUrl, setCurrentUrl] = useState("");
   const isOwner = useRef(false);
+
+  // When the host app owns the <ClerkProvider> it must hand us the very
+  // module that provider was mounted from. Importing our own copy here would
+  // race the host: our import can resolve first and render <SignedOut />
+  // before any provider exists, which Clerk throws on.
+  const hostOwnsProvider = !wrapWithProvider;
+  const clerkModule = hostOwnsProvider ? providedModule : ownModule;
 
   useEffect(() => {
     // Get current page URL for redirect
@@ -71,27 +81,26 @@ export function AuthButtons({
 
   useEffect(() => {
     if (!publishableKey) return;
+    // The host owns the provider and hands us the module — nothing to import
+    // and no singleton to claim.
+    if (hostOwnsProvider) return;
 
-    if (wrapWithProvider) {
-      if (clerkProviderMounted) return;
-      clerkProviderMounted = true;
-      isOwner.current = true;
-    } else {
-      isOwner.current = true;
-    }
+    if (clerkProviderMounted) return;
+    clerkProviderMounted = true;
+    isOwner.current = true;
 
     import("@clerk/clerk-react")
-      .then((mod) => setClerkModule(mod))
+      .then((mod) => setOwnModule(mod))
       .catch(() => {
         // Clerk not available — isOwner stays true so fallback renders
       });
 
     return () => {
-      if (isOwner.current && wrapWithProvider) {
+      if (isOwner.current) {
         clerkProviderMounted = false;
       }
     };
-  }, [publishableKey, wrapWithProvider]);
+  }, [publishableKey, hostOwnsProvider]);
 
   // No publishable key — show unavailable fallback
   if (!publishableKey) {
@@ -106,8 +115,11 @@ export function AuthButtons({
     );
   }
 
-  // Key present but module not loaded yet — show nothing while loading
-  if (!clerkModule || !isOwner.current) {
+  // Key present but module not loaded yet — show nothing while loading.
+  // isOwner only gates the self-import singleton; when the host owns the
+  // provider it is irrelevant (and, being a ref set in an effect, would
+  // wrongly blank us out on a mount where the module is already available).
+  if (!clerkModule || (!hostOwnsProvider && !isOwner.current)) {
     return null;
   }
 


### PR DESCRIPTION
## Problem

news.duyet.net crashed with:

> `@clerk/clerk-react: SignedOut can only be used within the <ClerkProvider /> component.`

## Cause

`AuthButtons` was passed `wrapWithProvider={false}` (news mounts the single app-wide `<ClerkProvider>` in `__root.tsx`), but it still ran its **own** dynamic `import("@clerk/clerk-react")`. Child effects run before parent effects, so that import could resolve first and render `<SignedOut />` before the root provider existed.

Secondary: the root's `ErrorBoundary` fallback still published a non-null Clerk module through `ClerkModuleContext` while rendering children *outside* any provider, so every consumer could hit the same throw.

## Fix

- `AuthButtons` accepts a `clerkModule` prop; when the host owns the provider it uses only that module (no self-import) and renders nothing until it arrives.
- `HeaderBar` passes the shared module from `ClerkModuleContext`.
- The root no-provider fallback now publishes `mod: null`.

## Verification

- `pnpm exec biome lint` on the 3 touched files — clean
- `apps/news`: 404 tests pass; `@duyet/components`: 61 tests pass
- `check-types` in apps/news: only pre-existing errors in `packages/components/ui/{attachment,bubble,button,marker}.tsx` (React type duplication, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmMRJNdmvWKa3p56V2EC1A

## Summary by Sourcery

Ensure Clerk auth UI in the news app only renders using the app-wide ClerkProvider and shared module to avoid crashes when the provider is not yet mounted.

New Features:
- Allow AuthButtons to consume a host-provided Clerk module when the host owns the ClerkProvider.

Bug Fixes:
- Prevent SignedIn/SignedOut from rendering before a ClerkProvider exists by deferring to the shared Clerk module and publishing null when no provider is present.

Enhancements:
- Update HeaderBar to source the Clerk module from a shared context hook and pass it through to AuthButtons.
- Adjust the root ClerkModuleContext fallback to expose only the publishable key without an active Clerk module when no provider is mounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in and authentication button behavior when Clerk is provided by the host application.
  * Prevented authentication components from rendering when no Clerk provider is available.
  * Preserved authentication behavior for applications managing their own provider.
* **Content Updates**
  * Updated blog recommendations, feed metadata, sitemap dates, and service status timestamp.
* **Improvements**
  * Authentication module loading is now more reliable across supported application configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->