### PR TITLE
fix(burns): keep daily-chart tooltip readable on trailing bars

### DIFF
--- a/apps/burns/src/components/DailyChart.tsx
+++ b/apps/burns/src/components/DailyChart.tsx
@@ -214,18 +214,22 @@ export function DailyChart({
           hoveredDay &&
           (() => {
             const pct = hovered * barWidth + barWidth / 2;
-            const left = Math.min(Math.max(pct, 0), 100);
-            const transform =
-              pct < 18
-                ? "translateX(0)"
-                : pct > 82
-                  ? "translateX(-100%)"
-                  : "translateX(-50%)";
+            // Abspos width is the leftover space after `left`. Pin with
+            // `right` on the trailing edge so the box can grow leftward.
+            const edge =
+              pct < 18 ? "start" : pct > 82 ? "end" : "center";
+            const style =
+              edge === "start"
+                ? { left: 0, right: "auto", transform: "none" }
+                : edge === "end"
+                  ? { left: "auto", right: 0, transform: "none" }
+                  : {
+                      left: `${pct}%`,
+                      right: "auto",
+                      transform: "translateX(-50%)",
+                    };
             return (
-              <div
-                className="burns-tooltip"
-                style={{ left: `${left}%`, transform }}
-              >
+              <div className="burns-tooltip" style={style}>
                 <div className="burns-tooltip-title">
                   {label(hoveredDay.date, true)}
                 </div>

--- a/apps/burns/src/styles.css
+++ b/apps/burns/src/styles.css
@@ -297,8 +297,9 @@ body {
   position: absolute;
   bottom: calc(100% + 8px);
   padding: 8px 10px;
+  width: max-content;
   min-width: 200px;
-  max-width: min(380px, calc(100vw - 24px));
+  max-width: min(380px, calc(100% - 16px));
   background: var(--canvas);
   border: 1px solid var(--hairline);
   color: var(--ink);


### PR DESCRIPTION
## Summary
- Daily-chart hover tooltip overlapped names and totals on the right-hand bars.
- Absolute `left` near the trailing edge shrinks CSS available width; pin those bars with `right: 0` and `width: max-content`.

## Test plan
- [ ] Open burns.duyet.net daily chart
- [ ] Hover first, middle, and last bars
- [ ] Confirm source names, token counts, and costs stay in columns

## Summary by Sourcery

Improve daily chart tooltip positioning so labels remain readable on trailing bars.

Bug Fixes:
- Fix daily chart hover tooltip overlapping content on bars near the chart edges.

Enhancements:
- Adjust tooltip sizing and max-width constraints so the hover card can expand leftward without clipping on narrow trailing space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart tooltip positioning near screen edges so tooltips remain fully visible.
  * Updated tooltip sizing to fit within its containing chart while preserving a minimum readable width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->