### PR TITLE
fix(ci): discover Pages apps so kb deploys

### DIFF
--- a/.github/workflows/cf-deploy-preview.yml
+++ b/.github/workflows/cf-deploy-preview.yml
@@ -9,6 +9,9 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.npmrc'
+      - '.github/workflows/cf-deploy-preview.yml'
+      - 'scripts/cf-pages-apps.ts'
+      - 'scripts/cf-deploy-matrix.ts'
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -25,95 +28,24 @@ jobs:
     name: Detect changed apps
     runs-on: ubuntu-latest
     outputs:
-      agent-ui: ${{ steps.filter.outputs.agent-ui }}
-      blog: ${{ steps.filter.outputs.blog }}
-      cv: ${{ steps.filter.outputs.cv }}
-      home: ${{ steps.filter.outputs.home }}
-      homelab: ${{ steps.filter.outputs.homelab }}
-      insights: ${{ steps.filter.outputs.insights }}
-      llm-timeline: ${{ steps.filter.outputs.llm-timeline }}
-      photos: ${{ steps.filter.outputs.photos }}
-      ai-percentage: ${{ steps.filter.outputs.ai-percentage }}
-      x-algo: ${{ steps.filter.outputs.x-algo }}
-      packages: ${{ steps.filter.outputs.packages }}
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
         with:
+          fetch-depth: 0
           submodules: false
 
-      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
-        id: filter
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          filters: |
-            agent-ui:
-              - 'apps/agent-ui/**'
-            blog:
-              - 'apps/blog/**'
-            cv:
-              - 'apps/cv/**'
-            home:
-              - 'apps/home/**'
-            homelab:
-              - 'apps/homelab/**'
-            insights:
-              - 'apps/insights/**'
-            llm-timeline:
-              - 'apps/llm-timeline/**'
-            photos:
-              - 'apps/photos/**'
-            ai-percentage:
-              - 'apps/ai-percentage/**'
-            x-algo:
-              - 'apps/x-algo/**'
-            packages:
-              - 'packages/**'
+          node-version: 24
 
       - name: Set deployment matrix
         id: set-matrix
         run: |
-          APPS=()
-          PACKAGES_CHANGED="${{ steps.filter.outputs.packages }}"
-
-          if [[ "${{ steps.filter.outputs.agent-ui }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"agent-ui","project":"duyet-agents","domain":"agents.duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.blog }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"blog","project":"duyet-blog","domain":"blog.duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.cv }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"cv","project":"duyet-cv","domain":"cv.duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.home }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"home","project":"duyet-home","domain":"duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.homelab }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"homelab","project":"duyet-homelab","domain":"homelab.duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.insights }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"insights","project":"duyet-insights","domain":"insights.duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.photos }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"photos","project":"duyet-photos","domain":"photos.duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.llm-timeline }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"llm-timeline","project":"duyet-llm-timeline","domain":"llm-timeline.duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.ai-percentage }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"ai-percentage","project":"duyet-ai-percentage","domain":"ai-percentage.duyet.net"}')
-          fi
-          if [[ "${{ steps.filter.outputs.x-algo }}" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-            APPS+=('{"app":"x-algo","project":"duyet-x-algo","domain":"x-algo.duyet.net"}')
-          fi
-
-          if [ ${#APPS[@]} -eq 0 ]; then
-            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
-            echo "No apps to deploy"
-          else
-            MATRIX=$(printf '%s,' "${APPS[@]}" | sed 's/,$//')
-            echo "matrix={\"include\":[$MATRIX]}" >> $GITHUB_OUTPUT
-            echo "Apps to deploy: ${APPS[*]}"
-          fi
+          node --experimental-strip-types scripts/cf-deploy-matrix.ts \
+            --event "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"
 
   typecheck:
     name: Type check

--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -11,29 +11,18 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.npmrc'
+      - '.github/workflows/cf-deploy.yml'
+      - 'scripts/cf-pages-apps.ts'
+      - 'scripts/cf-deploy-matrix.ts'
   schedule:
     # Daily at midnight UTC to rebuild and update data-driven apps (like burns)
     - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       app:
-        description: 'App to deploy (empty=auto-detect, "all"=all apps, or app name e.g. "blog")'
+        description: 'App to deploy (empty=auto-detect, "all"=every Pages app, or an apps/ directory name e.g. "kb")'
         required: false
-        type: choice
-        options:
-          - ''
-          - all
-          - blog
-          - cv
-          - home
-          - homelab
-          - insights
-          - llm-timeline
-          - photos
-          - ai-percentage
-          - agent-ui
-          - burns
-          - x-algo
+        type: string
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -53,95 +42,21 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           submodules: false
 
-      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
-        id: filter
-        if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          filters: |
-            agent-ui:
-              - 'apps/agent-ui/**'
-            blog:
-              - 'apps/blog/**'
-            cv:
-              - 'apps/cv/**'
-            home:
-              - 'apps/home/**'
-            homelab:
-              - 'apps/homelab/**'
-            insights:
-              - 'apps/insights/**'
-            llm-timeline:
-              - 'apps/llm-timeline/**'
-            photos:
-              - 'apps/photos/**'
-            ai-percentage:
-              - 'apps/ai-percentage/**'
-            burns:
-              - 'apps/burns/**'
-            x-algo:
-              - 'apps/x-algo/**'
-            packages:
-              - 'packages/**'
+          node-version: 24
 
       - name: Set deployment matrix
         id: set-matrix
         run: |
-          # App configurations
-          declare -A APPS
-          APPS[agent-ui]='{"app":"agent-ui","project":"duyet-agents","url":"https://agents.duyet.net"}'
-          APPS[blog]='{"app":"blog","project":"duyet-blog","url":"https://blog.duyet.net"}'
-          APPS[cv]='{"app":"cv","project":"duyet-cv","url":"https://cv.duyet.net"}'
-          APPS[home]='{"app":"home","project":"duyet-home","url":"https://duyet.net"}'
-          APPS[homelab]='{"app":"homelab","project":"duyet-homelab","url":"https://homelab.duyet.net"}'
-          APPS[insights]='{"app":"insights","project":"duyet-insights","url":"https://insights.duyet.net"}'
-          APPS[llm-timeline]='{"app":"llm-timeline","project":"duyet-llm-timeline","url":"https://llm-timeline.duyet.net"}'
-          APPS[photos]='{"app":"photos","project":"duyet-photos","url":"https://photos.duyet.net"}'
-          APPS[ai-percentage]='{"app":"ai-percentage","project":"duyet-ai-percentage","url":"https://ai-percentage.duyet.net"}'
-          APPS[burns]='{"app":"burns","project":"duyet-burns","url":"https://duyet-burns.pages.dev"}'
-          APPS[x-algo]='{"app":"x-algo","project":"duyet-x-algo","url":"https://x-algo.duyet.net"}'
-
-          DEPLOY_APPS=()
-
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            INPUT_APP="${{ github.event.inputs.app }}"
-            if [[ "$INPUT_APP" == "all" ]]; then
-              for app in agent-ui blog cv home homelab insights llm-timeline photos ai-percentage burns x-algo; do
-                DEPLOY_APPS+=("${APPS[$app]}")
-              done
-            elif [[ -n "$INPUT_APP" ]]; then
-              # Deploy a specific app by name
-              if [[ -n "${APPS[$INPUT_APP]+isset}" ]]; then
-                DEPLOY_APPS+=("${APPS[$INPUT_APP]}")
-              fi
-            fi
-          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
-            # Scheduled run: deploy burns app daily to fetch latest tokens from MotherDuck
-            DEPLOY_APPS+=("${APPS[burns]}")
-          else
-            # Auto-detect changes
-            PACKAGES_CHANGED="${{ steps.filter.outputs.packages }}"
-            FILTER_OUTPUTS='${{ toJson(steps.filter.outputs) }}'
-
-            for app in agent-ui blog cv home homelab insights llm-timeline photos ai-percentage burns x-algo; do
-              APP_CHANGED=$(echo "$FILTER_OUTPUTS" | jq -r --arg app "$app" '.[$app]')
-              if [[ "$APP_CHANGED" == "true" ]] || [[ "$PACKAGES_CHANGED" == "true" ]]; then
-                DEPLOY_APPS+=("${APPS[$app]}")
-              fi
-            done
-          fi
-
-          # Build matrix JSON
-          if [ ${#DEPLOY_APPS[@]} -eq 0 ]; then
-            echo "matrix={\"include\":[]}" >> $GITHUB_OUTPUT
-            echo "No apps to deploy"
-          else
-            MATRIX=$(printf '%s,' "${DEPLOY_APPS[@]}" | sed 's/,$//')
-            echo "matrix={\"include\":[$MATRIX]}" >> $GITHUB_OUTPUT
-            echo "Apps to deploy: ${DEPLOY_APPS[*]}"
-          fi
+          node --experimental-strip-types scripts/cf-deploy-matrix.ts \
+            --event "${{ github.event_name }}" \
+            --input-app "${{ github.event.inputs.app || '' }}" \
+            --base "${{ github.event.before || github.event.pull_request.base.sha || '' }}" \
+            --head "${{ github.sha }}"
 
   typecheck:
     name: Type check

--- a/apps/kb/CLAUDE.md
+++ b/apps/kb/CLAUDE.md
@@ -11,6 +11,8 @@ time via Vite and served as prerendered HTML on Cloudflare Pages.
 - **Live**: https://kb.duyet.net | https://duyet-kb.pages.dev
 - **Port**: 3009 (development)
 - **Output**: Static SPA (`dist/client/`)
+- **CI**: Cloudflare Pages prod/preview discover this app from `wrangler.toml`
+  (`pages_build_output_dir`) + `cf:deploy:prod`. No hardcoded app list.
 
 ### Submodule
 

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -31,7 +31,7 @@ This repository is the pnpm/Turborepo monorepo for duyet.net public apps, shared
 - `pnpm run test` runs Turbo tests.
 - `pnpm run config` runs workspace config tasks, including app secret syncs where defined.
 - `pnpm run deploy` builds deployable apps, then runs workspace config.
-- `pnpm run cf:deploy` deploys changed Cloudflare Pages apps.
+- `pnpm run cf:deploy` deploys changed Cloudflare Pages apps (same discovery as CI).
 - `pnpm run cf:deploy:prod` runs production Cloudflare deploy tasks through Turbo.
 - `pnpm run cf:deploy -- --force` bypasses git-based change detection and rebuilds all requested Cloudflare Pages apps.
 - `pnpm run wasm:build` builds all Rust crates to WASM via `wasm-pack`.
@@ -73,6 +73,7 @@ This repository is the pnpm/Turborepo monorepo for duyet.net public apps, shared
 ## Deployment Notes
 
 - Cloudflare Pages production deploys happen on pushes to `master` or `main`; PRs receive preview deploys.
+- Pages CI (`cf-deploy.yml`, `cf-deploy-preview.yml`) discovers deployable apps at runtime via `scripts/cf-pages-apps.ts`: any `apps/*` with `pages_build_output_dir` in `wrangler.toml` and a `cf:deploy:prod` script is included. Do not hardcode the app list in the workflow. New Pages apps (for example `kb`) deploy automatically when their tree or `packages/**` changes.
 - A scheduled daily job (cron `0 0 * * *` in `.github/workflows/cf-deploy.yml`) rebuilds and redeploys the `burns` app to refresh its prerendered stats from MotherDuck.
 - Deploy workflows run type checks, tests, and lint before deploy jobs.
 - App-level `cf:deploy:prod` scripts are authoritative when present.

--- a/scripts/cf-deploy-matrix.ts
+++ b/scripts/cf-deploy-matrix.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env tsx
+
+/**
+ * Print a GitHub Actions matrix of Cloudflare Pages apps to deploy.
+ *
+ * Usage:
+ *   pnpm exec tsx scripts/cf-deploy-matrix.ts \
+ *     --event push|pull_request|schedule|workflow_dispatch \
+ *     [--input-app NAME|all] \
+ *     [--base SHA] [--head SHA]
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  discoverPagesApps,
+  selectAppsToDeploy,
+  toDeployMatrix,
+} from "./cf-pages-apps.ts";
+
+function argValue(flag: string): string | undefined {
+  const idx = process.argv.indexOf(flag);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
+function isGitRef(value?: string): value is string {
+  return Boolean(value && !/^0+$/.test(value));
+}
+
+function gitChangedFiles(base?: string, head?: string): string[] {
+  const range = isGitRef(base)
+    ? `${base}...${isGitRef(head) ? head : "HEAD"}`
+    : "HEAD~1...HEAD";
+  const result = spawnSync("git", ["diff", "--name-only", range], {
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) {
+    console.error(result.stderr || `git diff failed for ${range}`);
+    return [];
+  }
+  return result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+const event = argValue("--event") ?? process.env.GITHUB_EVENT_NAME ?? "push";
+const inputApp = argValue("--input-app") ?? "";
+const base = argValue("--base");
+const head = argValue("--head");
+
+const apps = discoverPagesApps();
+const names = Object.keys(apps).sort();
+if (names.length === 0) {
+  console.error("No Cloudflare Pages apps discovered");
+  process.exit(1);
+}
+
+console.error(`Discovered Pages apps: ${names.join(", ")}`);
+
+let changedFiles: string[] | undefined;
+if (event === "push" || event === "pull_request" || inputApp === "") {
+  try {
+    changedFiles = gitChangedFiles(base, head);
+  } catch {
+    changedFiles = [];
+  }
+}
+
+const selected = selectAppsToDeploy({
+  apps,
+  event,
+  inputApp,
+  changedFiles,
+});
+
+const matrix = toDeployMatrix(selected);
+if (selected.length === 0) {
+  console.error("No apps to deploy");
+} else {
+  console.error(`Apps to deploy: ${selected.map((app) => app.name).join(", ")}`);
+}
+
+const encoded = JSON.stringify(matrix);
+process.stdout.write(`${encoded}\n`);
+if (process.env.GITHUB_OUTPUT) {
+  const { appendFileSync } = await import("node:fs");
+  appendFileSync(process.env.GITHUB_OUTPUT, `matrix=${encoded}\n`);
+}

--- a/scripts/cf-deploy.ts
+++ b/scripts/cf-deploy.ts
@@ -20,15 +20,16 @@
  * - With --prod: Production deployment (custom domains like blog.duyet.net)
  *
  * Apps are discovered dynamically from the filesystem:
- * - Any app with a wrangler.toml and "cf:deploy:prod" script is deployable
+ * - Any app with pages_build_output_dir and "cf:deploy:prod" is deployable
  * - Project name is read from wrangler.toml
- * - Domain convention: <app>.duyet.net (except home → duyet.net)
+ * - Domain convention: <app>.duyet.net (see scripts/cf-pages-apps.ts overrides)
  */
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { discoverPagesApps } from "./cf-pages-apps.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -110,87 +111,15 @@ const PRODUCTION_BRANCH =
   DEPLOY_ENV.CF_PAGES_PRODUCTION_BRANCH ||
   "master";
 
-// Apps that require secret syncing (have sensitive env vars)
-const appsWithSecrets = new Set(["blog", "photos", "insights"]);
-
-interface AppConfig {
-  name: string;
-  projectName: string;
-  domain: string;
-  outputDir: string;
-  secrets: boolean;
+// Dynamically discover Cloudflare Pages apps
+const APPS_CONFIG = discoverPagesApps();
+if (Object.keys(APPS_CONFIG).length === 0) {
+  console.error(
+    `[ERROR] No deployable Pages apps discovered in ${join(rootDir, "apps")}. ` +
+      `Ensure apps have pages_build_output_dir in wrangler.toml and a "cf:deploy:prod" script.`,
+  );
+  process.exit(1);
 }
-
-/**
- * Dynamically discover deployable apps from the filesystem.
- * An app is deployable if it has:
- * 1. A wrangler.toml file (Cloudflare Pages project)
- * 2. A "cf:deploy:prod" script in package.json
- *
- * The project name and output directory are read from wrangler.toml.
- * The domain follows the convention: <app>.duyet.net (except home -> duyet.net).
- */
-function discoverApps(): Record<string, AppConfig> {
-  const appsDir = join(rootDir, "apps");
-  const config: Record<string, AppConfig> = {};
-
-  for (const entry of readdirSync(appsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-
-    const appName = entry.name;
-    const appDir = join(appsDir, appName);
-    const wranglerPath = join(appDir, "wrangler.toml");
-    const pkgPath = join(appDir, "package.json");
-
-    if (!existsSync(wranglerPath) || !existsSync(pkgPath)) continue;
-
-    // Check for cf:deploy:prod script via parsed JSON
-    const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
-      scripts?: Record<string, string>;
-    };
-    if (!pkgJson.scripts?.["cf:deploy:prod"]) continue;
-
-    // Parse wrangler.toml
-    const wranglerContent = readFileSync(wranglerPath, "utf-8");
-    const projectMatch = wranglerContent.match(/name\s*=\s*"([^"]+)"/);
-    if (!projectMatch) continue;
-
-    const projectName = projectMatch[1];
-    const domain =
-      appName === "home"
-        ? "duyet.net"
-        : appName === "agent-ui"
-          ? "agents.duyet.net"
-          : `${appName}.duyet.net`;
-
-    // Read pages_build_output_dir from wrangler.toml, default to "dist"
-    const outputDirMatch = wranglerContent.match(
-      /pages_build_output_dir\s*=\s*"([^"]+)"/
-    );
-    const outputDir = outputDirMatch ? outputDirMatch[1] : "dist";
-
-    config[appName] = {
-      name: appName,
-      projectName,
-      domain,
-      outputDir,
-      secrets: appsWithSecrets.has(appName),
-    };
-  }
-
-  if (Object.keys(config).length === 0) {
-    console.error(
-      `[ERROR] No deployable apps discovered in ${appsDir}. ` +
-        `Ensure apps have both wrangler.toml and a "cf:deploy:prod" script in package.json.`
-    );
-    process.exit(1);
-  }
-
-  return config;
-}
-
-// Dynamically discover deployable apps
-const APPS_CONFIG = discoverApps();
 console.log(
   `[INFO] Discovered ${Object.keys(APPS_CONFIG).length} deployable app(s): ${Object.keys(APPS_CONFIG).join(", ")}`
 );

--- a/scripts/cf-pages-apps.test.ts
+++ b/scripts/cf-pages-apps.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_APPS_DIR,
+  discoverPagesApps,
+  domainForApp,
+  selectAppsToDeploy,
+  toDeployMatrix,
+} from "./cf-pages-apps.ts";
+
+describe("domainForApp", () => {
+  it("uses hostname overrides and the default <app>.duyet.net pattern", () => {
+    expect(domainForApp("home")).toBe("duyet.net");
+    expect(domainForApp("agent-ui")).toBe("agents.duyet.net");
+    expect(domainForApp("burns")).toBe("duyet-burns.pages.dev");
+    expect(domainForApp("kb")).toBe("kb.duyet.net");
+  });
+});
+
+describe("discoverPagesApps", () => {
+  it("includes kb and other Pages apps, excludes Workers", () => {
+    const apps = discoverPagesApps(DEFAULT_APPS_DIR);
+    expect(apps.kb?.projectName).toBe("duyet-kb");
+    expect(apps.kb?.url).toBe("https://kb.duyet.net");
+    expect(apps.blog).toBeDefined();
+    expect(apps.burns).toBeDefined();
+    expect(apps["agent-api"]).toBeUndefined();
+    expect(apps.news).toBeUndefined();
+    expect(apps.api).toBeUndefined();
+    expect(apps["paid-api"]).toBeUndefined();
+    expect(apps["agent-assistant"]).toBeUndefined();
+  });
+
+  it("requires pages_build_output_dir and cf:deploy:prod", () => {
+    const root = mkdtempSync(join(tmpdir(), "cf-pages-apps-"));
+    mkdirSync(join(root, "pages-app"));
+    writeFileSync(
+      join(root, "pages-app", "package.json"),
+      JSON.stringify({ scripts: { "cf:deploy:prod": "echo" } }),
+    );
+    writeFileSync(
+      join(root, "pages-app", "wrangler.toml"),
+      'name = "duyet-pages-app"\npages_build_output_dir = "dist/client"\n',
+    );
+    mkdirSync(join(root, "worker"));
+    writeFileSync(
+      join(root, "worker", "package.json"),
+      JSON.stringify({ scripts: { "cf:deploy:prod": "wrangler deploy" } }),
+    );
+    writeFileSync(
+      join(root, "worker", "wrangler.toml"),
+      'name = "duyet-worker"\nmain = "src/index.ts"\n',
+    );
+
+    const apps = discoverPagesApps(root);
+    expect(Object.keys(apps)).toEqual(["pages-app"]);
+    expect(apps["pages-app"].projectName).toBe("duyet-pages-app");
+  });
+});
+
+describe("selectAppsToDeploy", () => {
+  const apps = discoverPagesApps(DEFAULT_APPS_DIR);
+
+  it("deploys only burns on schedule", () => {
+    expect(
+      selectAppsToDeploy({ apps, event: "schedule" }).map((app) => app.name),
+    ).toEqual(["burns"]);
+  });
+
+  it("deploys a named app or all apps on workflow_dispatch", () => {
+    expect(
+      selectAppsToDeploy({
+        apps,
+        event: "workflow_dispatch",
+        inputApp: "kb",
+      }).map((app) => app.name),
+    ).toEqual(["kb"]);
+    expect(
+      selectAppsToDeploy({
+        apps,
+        event: "workflow_dispatch",
+        inputApp: "all",
+      }).map((app) => app.name),
+    ).toEqual(Object.keys(apps).sort());
+  });
+
+  it("deploys only the changed Pages app on push", () => {
+    expect(
+      selectAppsToDeploy({
+        apps,
+        event: "push",
+        changedFiles: [
+          "apps/kb/src/routes/index.tsx",
+          "apps/news/src/index.ts",
+        ],
+      }).map((app) => app.name),
+    ).toEqual(["kb"]);
+  });
+
+  it("deploys every Pages app when deploy discovery files change", () => {
+    expect(
+      selectAppsToDeploy({
+        apps,
+        event: "push",
+        changedFiles: ["scripts/cf-pages-apps.ts"],
+      }).map((app) => app.name),
+    ).toEqual(Object.keys(apps).sort());
+    expect(
+      selectAppsToDeploy({
+        apps,
+        event: "push",
+        changedFiles: ["scripts/cf-pages-apps.ts"],
+      }).some((app) => app.name === "kb"),
+    ).toBe(true);
+  });
+
+  it("deploys every Pages app when shared packages change", () => {
+    expect(
+      selectAppsToDeploy({
+        apps,
+        event: "push",
+        changedFiles: ["packages/components/site-header/SiteHeader.tsx"],
+      }).map((app) => app.name),
+    ).toEqual(Object.keys(apps).sort());
+  });
+
+  it("encodes a GitHub Actions matrix", () => {
+    const matrix = toDeployMatrix(
+      selectAppsToDeploy({
+        apps,
+        event: "workflow_dispatch",
+        inputApp: "kb",
+      }),
+    );
+    expect(matrix).toEqual({
+      include: [
+        {
+          app: "kb",
+          project: "duyet-kb",
+          url: "https://kb.duyet.net",
+          domain: "kb.duyet.net",
+        },
+      ],
+    });
+  });
+});

--- a/scripts/cf-pages-apps.test.ts
+++ b/scripts/cf-pages-apps.test.ts
@@ -99,23 +99,6 @@ describe("selectAppsToDeploy", () => {
     ).toEqual(["kb"]);
   });
 
-  it("deploys every Pages app when deploy discovery files change", () => {
-    expect(
-      selectAppsToDeploy({
-        apps,
-        event: "push",
-        changedFiles: ["scripts/cf-pages-apps.ts"],
-      }).map((app) => app.name),
-    ).toEqual(Object.keys(apps).sort());
-    expect(
-      selectAppsToDeploy({
-        apps,
-        event: "push",
-        changedFiles: ["scripts/cf-pages-apps.ts"],
-      }).some((app) => app.name === "kb"),
-    ).toBe(true);
-  });
-
   it("deploys every Pages app when shared packages change", () => {
     expect(
       selectAppsToDeploy({

--- a/scripts/cf-pages-apps.ts
+++ b/scripts/cf-pages-apps.ts
@@ -95,13 +95,7 @@ const SHARED_CHANGE_PREFIXES = [
   ".npmrc",
 ];
 
-/** Changing discovery/matrix code must re-evaluate every Pages app. */
-const DEPLOY_INFRA_FILES = [
-  "scripts/cf-pages-apps.ts",
-  "scripts/cf-deploy-matrix.ts",
-  ".github/workflows/cf-deploy.yml",
-  ".github/workflows/cf-deploy-preview.yml",
-];
+
 
 export function selectAppsToDeploy(opts: {
   apps: Record<string, PagesApp>;
@@ -137,8 +131,7 @@ export function selectAppsToDeploy(opts: {
       prefix.endsWith("/") ? file.startsWith(prefix) : file === prefix,
     ),
   );
-  const infraChanged = files.some((file) => DEPLOY_INFRA_FILES.includes(file));
-  if (sharedChanged || infraChanged) return pick(names);
+  if (sharedChanged) return pick(names);
 
   const selected = new Set<string>();
   for (const file of files) {

--- a/scripts/cf-pages-apps.ts
+++ b/scripts/cf-pages-apps.ts
@@ -1,0 +1,164 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const DEFAULT_APPS_DIR = join(__dirname, "..", "apps");
+
+const APPS_WITH_SECRETS = new Set(["blog", "photos", "insights"]);
+
+/** Hostnames that do not follow `<app>.duyet.net`. */
+const DOMAIN_OVERRIDES: Record<string, string> = {
+  home: "duyet.net",
+  "agent-ui": "agents.duyet.net",
+  burns: "duyet-burns.pages.dev",
+};
+
+export interface PagesApp {
+  name: string;
+  projectName: string;
+  domain: string;
+  url: string;
+  outputDir: string;
+  secrets: boolean;
+}
+
+export function domainForApp(appName: string): string {
+  return DOMAIN_OVERRIDES[appName] ?? `${appName}.duyet.net`;
+}
+
+function firstTomlString(content: string, key: string): string | undefined {
+  const match = content.match(new RegExp(`^${key}\\s*=\\s*"([^"]+)"`, "m"));
+  return match?.[1];
+}
+
+/**
+ * Cloudflare Pages apps: wrangler.toml has `pages_build_output_dir`,
+ * and package.json defines `cf:deploy:prod`.
+ * Workers (main = …, no pages output dir) are excluded.
+ */
+export function discoverPagesApps(
+  appsDir: string = DEFAULT_APPS_DIR,
+): Record<string, PagesApp> {
+  const config: Record<string, PagesApp> = {};
+
+  if (!existsSync(appsDir)) {
+    return config;
+  }
+
+  for (const entry of readdirSync(appsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const appName = entry.name;
+    const appDir = join(appsDir, appName);
+    const wranglerPath = join(appDir, "wrangler.toml");
+    const pkgPath = join(appDir, "package.json");
+
+    if (!existsSync(wranglerPath) || !existsSync(pkgPath)) continue;
+
+    const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+      scripts?: Record<string, string>;
+    };
+    if (!pkgJson.scripts?.["cf:deploy:prod"]) continue;
+
+    const wranglerContent = readFileSync(wranglerPath, "utf-8");
+    const outputDir = firstTomlString(wranglerContent, "pages_build_output_dir");
+    if (!outputDir) continue;
+
+    const projectName = firstTomlString(wranglerContent, "name");
+    if (!projectName) continue;
+
+    const domain = domainForApp(appName);
+    config[appName] = {
+      name: appName,
+      projectName,
+      domain,
+      url: `https://${domain}`,
+      outputDir,
+      secrets: APPS_WITH_SECRETS.has(appName),
+    };
+  }
+
+  return config;
+}
+
+export function pagesAppNames(appsDir?: string): string[] {
+  return Object.keys(discoverPagesApps(appsDir)).sort();
+}
+
+const SHARED_CHANGE_PREFIXES = [
+  "packages/",
+  "package.json",
+  "pnpm-lock.yaml",
+  ".npmrc",
+];
+
+/** Changing discovery/matrix code must re-evaluate every Pages app. */
+const DEPLOY_INFRA_FILES = [
+  "scripts/cf-pages-apps.ts",
+  "scripts/cf-deploy-matrix.ts",
+  ".github/workflows/cf-deploy.yml",
+  ".github/workflows/cf-deploy-preview.yml",
+];
+
+export function selectAppsToDeploy(opts: {
+  apps: Record<string, PagesApp>;
+  event: string;
+  inputApp?: string;
+  changedFiles?: string[];
+  scheduledApp?: string;
+}): PagesApp[] {
+  const names = Object.keys(opts.apps).sort();
+  const pick = (list: string[]) =>
+    list.filter((name) => opts.apps[name]).map((name) => opts.apps[name]);
+
+  if (opts.event === "schedule") {
+    return pick([opts.scheduledApp ?? "burns"]);
+  }
+
+  if (opts.event === "workflow_dispatch") {
+    const input = opts.inputApp?.trim() ?? "";
+    if (input === "all") return pick(names);
+    if (input) {
+      if (!opts.apps[input]) {
+        throw new Error(
+          `Unknown Pages app "${input}". Available: ${names.join(", ")}`,
+        );
+      }
+      return pick([input]);
+    }
+  }
+
+  const files = opts.changedFiles ?? [];
+  const sharedChanged = files.some((file) =>
+    SHARED_CHANGE_PREFIXES.some((prefix) =>
+      prefix.endsWith("/") ? file.startsWith(prefix) : file === prefix,
+    ),
+  );
+  const infraChanged = files.some((file) => DEPLOY_INFRA_FILES.includes(file));
+  if (sharedChanged || infraChanged) return pick(names);
+
+  const selected = new Set<string>();
+  for (const file of files) {
+    const match = file.match(/^apps\/([^/]+)\//);
+    if (match && opts.apps[match[1]]) {
+      selected.add(match[1]);
+    }
+  }
+  return pick([...selected]);
+}
+
+export function toDeployMatrix(apps: PagesApp[]): {
+  include: Array<{ app: string; project: string; url: string; domain: string }>;
+} {
+  return {
+    include: apps.map((app) => ({
+      app: app.name,
+      project: app.projectName,
+      url: app.url,
+      domain: app.domain,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- Discover Cloudflare Pages apps from `pages_build_output_dir` + `cf:deploy:prod` instead of a hardcoded matrix.
- Include `kb` (`duyet-kb` / kb.duyet.net) so the graph UI ships on master.
- Run deploy when discovery/workflow files change so this landing actually deploys kb.

## Test plan
- [x] local matrix tests
- [ ] Master Deploy to Cloudflare Pages includes Deploy kb
- [ ] https://kb.duyet.net serves the new graph UI

## Summary by Sourcery

Make Cloudflare Pages deployments discoverable from app configuration so all eligible apps, including kb, deploy automatically in CI.

New Features:
- Discover Cloudflare Pages applications from their project configuration and deployment scripts, including the `kb` app.
- Support dynamic production and preview deployment matrices based on app changes, shared changes, schedules, and manual app selection.

Bug Fixes:
- Ensure changes to deployment discovery and workflow files trigger deployments so newly discovered Pages apps are deployed.

Enhancements:
- Centralize Pages app metadata, domain handling, and deployment selection for local and CI use.

CI:
- Replace hardcoded Cloudflare Pages deployment lists and path filters with runtime discovery for production and preview workflows.

Documentation:
- Document runtime Pages app discovery and the automatic deployment behavior for new apps such as `kb`.

Tests:
- Add coverage for Pages app discovery, app selection, domain overrides, and GitHub Actions matrix generation.