### PR TITLE
feat(news): telegram digest admin, audit log, non-fatal TL;DR

### DIFF
--- a/apps/news/migrations/0015_admin_audit.sql
+++ b/apps/news/migrations/0015_admin_audit.sql
@@ -1,0 +1,9 @@
+-- Admin action log (ingest, TL;DR regen, telegram retry, moderation).
+CREATE TABLE IF NOT EXISTS admin_audit (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts INTEGER NOT NULL,
+  action TEXT NOT NULL,
+  detail TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_audit_ts ON admin_audit (ts DESC);

--- a/apps/news/src/components/system/AdminPanel.tsx
+++ b/apps/news/src/components/system/AdminPanel.tsx
@@ -109,6 +109,11 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
   );
   const [tldrBusy, setTldrBusy] = useState(false);
   const [tldrResult, setTldrResult] = useState<string | null>(null);
+  const [notifyBusy, setNotifyBusy] = useState(false);
+  const [notifyResult, setNotifyResult] = useState<string | null>(null);
+  const [audit, setAudit] = useState<
+    { ts: number; action: string; detail?: string | null }[]
+  >([]);
   const [status, setStatus] = useState<unknown>(null);
   const [statusBusy, setStatusBusy] = useState(false);
   const [calls, setCalls] = useState<LlmCall[]>([]);
@@ -150,6 +155,20 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
     }
   }
 
+  async function loadAudit() {
+    try {
+      const res = await authedFetch(admin, "/api/admin/audit");
+      if (res.ok) {
+        const data = (await res.json()) as {
+          audit?: { ts: number; action: string; detail?: string | null }[];
+        };
+        setAudit(Array.isArray(data.audit) ? data.audit : []);
+      }
+    } catch {
+      // keep previous
+    }
+  }
+
   async function loadItems() {
     setItemsBusy(true);
     try {
@@ -168,7 +187,7 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
   async function refreshAll() {
     setRefreshError(false);
     try {
-      await Promise.all([loadStatus(), loadCalls(), loadItems()]);
+      await Promise.all([loadStatus(), loadCalls(), loadItems(), loadAudit()]);
     } catch {
       setRefreshError(true);
     }
@@ -266,6 +285,27 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
       setResult("error — request failed");
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function sendTelegramDigest() {
+    setNotifyBusy(true);
+    setNotifyResult(null);
+    try {
+      const res = await authedFetch(admin, "/api/admin/notify/digest", {
+        method: "POST",
+      });
+      const data = await res.json().catch(() => null);
+      setNotifyResult(
+        res.ok
+          ? `ok — ${JSON.stringify(data)}`
+          : `error (${res.status}) — ${JSON.stringify(data)}`
+      );
+      await loadStatus();
+    } catch {
+      setNotifyResult("error — request failed");
+    } finally {
+      setNotifyBusy(false);
     }
   }
 
@@ -369,11 +409,66 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
         )}
       </div>
 
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={sendTelegramDigest}
+          disabled={notifyBusy}
+          className="rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-muted disabled:opacity-50"
+        >
+          {notifyBusy ? "Sending…" : "Send Telegram digest"}
+        </button>
+        {notifyResult && (
+          <span className="text-xs text-muted-foreground">{notifyResult}</span>
+        )}
+      </div>
+
       {refreshError && (
         <p className="mt-2 text-xs text-muted-foreground">
           Refresh failed.
         </p>
       )}
+
+      <div className="mt-4">
+        <p className="text-xs font-medium text-muted-foreground">
+          Telegram / TL;DR
+        </p>
+        <pre className="mt-1 max-h-32 overflow-auto rounded border border-border p-2 text-xs text-muted-foreground">
+          {status
+            ? JSON.stringify(
+                {
+                  telegram: (status as { telegram?: unknown }).telegram,
+                  latestTldr: (status as { latestTldr?: unknown }).latestTldr,
+                  notifications: (status as { notifications?: unknown })
+                    .notifications,
+                },
+                null,
+                2
+              )
+            : "No status loaded."}
+        </pre>
+      </div>
+
+      <div className="mt-4">
+        <p className="text-xs font-medium text-muted-foreground">Audit log</p>
+        {audit.length === 0 ? (
+          <p className="mt-1 text-xs text-muted-foreground">No audit rows.</p>
+        ) : (
+          <ul className="mt-1 space-y-0.5 text-xs">
+            {audit.map((row) => (
+              <li key={`${row.ts}-${row.action}`}>
+                <span className="tabular-nums text-muted-foreground">
+                  {new Date(row.ts).toISOString()}
+                </span>{" "}
+                <span className="font-medium">{row.action}</span>
+                {row.detail ? (
+                  <span className="text-muted-foreground"> — {row.detail}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
 
       <div className="mt-4">
         <p className="text-xs font-medium text-muted-foreground">

--- a/apps/news/src/routes/__root.tsx
+++ b/apps/news/src/routes/__root.tsx
@@ -90,7 +90,7 @@ const FOOTER_LINKS: {
   { to: "/mcp", label: "MCP", icon: Plug },
   {
     to: "/system",
-    label: "Analytics",
+    label: "System",
     icon: BarChart3,
   },
   {

--- a/apps/news/src/routes/api/admin.$.ts
+++ b/apps/news/src/routes/api/admin.$.ts
@@ -5,11 +5,14 @@ import {
   getLlmCalls,
   getStatus,
   isHandlerError,
+  listAudit,
+  listNotifications,
   listItems,
   listSources,
   pushItems,
   regenerateTldr,
   reprocessToday,
+  retryTelegramDigest,
   triggerIngest,
   updateItem,
   upsertSource,
@@ -196,6 +199,27 @@ async function handle(
     const url = new URL(request.url);
     const result = await listItems(env, url.searchParams.get("limit"));
     return Response.json(result);
+  }
+
+  if (
+    method === "GET" &&
+    segments.length === 1 &&
+    segments[0] === "notifications"
+  ) {
+    return Response.json(await listNotifications(env));
+  }
+
+  if (method === "GET" && segments.length === 1 && segments[0] === "audit") {
+    return Response.json(await listAudit(env));
+  }
+
+  if (
+    method === "POST" &&
+    segments.length === 2 &&
+    segments[0] === "notify" &&
+    segments[1] === "digest"
+  ) {
+    return Response.json(await retryTelegramDigest(env));
   }
 
   return notFound();

--- a/apps/news/worker/__tests__/admin.test.ts
+++ b/apps/news/worker/__tests__/admin.test.ts
@@ -322,6 +322,29 @@ class FakeD1 {
       return this.items.get(id) ?? null;
     }
 
+    if (
+      sql.startsWith(
+        "SELECT date, created_at FROM tldr_snapshots ORDER BY date DESC"
+      )
+    ) {
+      const rows = Array.from(this.tldrSnapshots.values()).sort((a, b) =>
+        String(b.date).localeCompare(String(a.date))
+      );
+      return rows[0] ?? null;
+    }
+
+    if (sql.startsWith("SELECT channel, item_id")) {
+      return { results: [] };
+    }
+
+    if (sql.startsWith("INSERT INTO admin_audit")) {
+      return { success: true };
+    }
+
+    if (sql.startsWith("SELECT ts, action, detail FROM admin_audit")) {
+      return { results: [] };
+    }
+
     if (sql.startsWith("SELECT status, COUNT(*)")) {
       const counts = new Map<string, number>();
       for (const item of this.items.values()) {

--- a/apps/news/worker/__tests__/subscribe.test.ts
+++ b/apps/news/worker/__tests__/subscribe.test.ts
@@ -44,6 +44,14 @@ describe("topBullets", () => {
     expect(topBullets("not json")).toEqual([]);
     expect(topBullets(JSON.stringify({ a: 1 }))).toEqual([]);
   });
+
+  it("promotes item_ids[0] onto item_id for telegram permalinks", () => {
+    expect(
+      topBullets(
+        JSON.stringify([{ text: "hi", item_ids: ["abc", "def"] }])
+      )
+    ).toEqual([{ text: "hi", item_id: "abc" }]);
+  });
 });
 
 describe("snapshotHasBullets", () => {

--- a/apps/news/worker/admin/handlers.ts
+++ b/apps/news/worker/admin/handlers.ts
@@ -1,10 +1,27 @@
 import { scoreItems, setLlmCallLogger, translateItems } from "../llm.js";
 import { createD1LlmCallLogger } from "../llm-call-log.js";
+import { forceSendDigest } from "../notify/index.js";
 import { rankScore } from "../ranking.js";
 import { adapters } from "../sources/registry.js";
 import { ensureDailyTldr, tldrSnapshotDate } from "../tldr.js";
 import { normalizeTopics } from "../topics.js";
 import type { Env } from "../types.js";
+
+export async function writeAudit(
+  env: Env,
+  action: string,
+  detail?: string
+): Promise<void> {
+  try {
+    await env.DB.prepare(
+      "INSERT INTO admin_audit (ts, action, detail) VALUES (?, ?, ?)"
+    )
+      .bind(Date.now(), action, detail ?? null)
+      .run();
+  } catch {
+    // table not migrated yet
+  }
+}
 
 /**
  * Same implementation as the private helper in worker/workflow.ts
@@ -238,6 +255,7 @@ export async function deleteSource(
 
 export async function triggerIngest(env: Env) {
   const instance = await env.NEWS_INGEST.create();
+  await writeAudit(env, "ingest.trigger", instance.id);
   return { id: instance.id };
 }
 
@@ -248,7 +266,57 @@ export async function getStatus(env: Env) {
   const { results: itemsByStatus } = await env.DB.prepare(
     "SELECT status, COUNT(*) as c FROM items GROUP BY status"
   ).all();
-  return { runs: runs ?? [], itemsByStatus: itemsByStatus ?? [] };
+  const latestTldr = await env.DB.prepare(
+    "SELECT date, created_at FROM tldr_snapshots ORDER BY date DESC LIMIT 1"
+  ).first<{ date: string; created_at: number }>();
+  let notifications: unknown[] = [];
+  try {
+    const { results } = await env.DB.prepare(
+      `SELECT channel, item_id, status, attempts, last_error, posted_at
+       FROM notifications ORDER BY posted_at DESC LIMIT 20`
+    ).all();
+    notifications = results ?? [];
+  } catch {
+    notifications = [];
+  }
+  return {
+    runs: runs ?? [],
+    itemsByStatus: itemsByStatus ?? [],
+    telegram: {
+      configured: Boolean(env.TELEGRAM_BOT_TOKEN && env.TELEGRAM_CHAT_ID),
+    },
+    latestTldr: latestTldr ?? null,
+    notifications,
+  };
+}
+
+export async function listNotifications(env: Env) {
+  try {
+    const { results } = await env.DB.prepare(
+      `SELECT channel, item_id, target, status, attempts, message_id, last_error, posted_at
+       FROM notifications ORDER BY posted_at DESC LIMIT 50`
+    ).all();
+    return { notifications: results ?? [] };
+  } catch {
+    return { notifications: [] };
+  }
+}
+
+export async function listAudit(env: Env) {
+  try {
+    const { results } = await env.DB.prepare(
+      "SELECT ts, action, detail FROM admin_audit ORDER BY ts DESC LIMIT 50"
+    ).all();
+    return { audit: results ?? [] };
+  } catch {
+    return { audit: [] };
+  }
+}
+
+export async function retryTelegramDigest(env: Env) {
+  const result = await forceSendDigest(env);
+  await writeAudit(env, "notify.digest", result.reason);
+  return result;
 }
 
 const DEFAULT_LLM_CALLS_LIMIT = 100;
@@ -577,5 +645,11 @@ export async function regenerateTldr(env: Env): Promise<TldrRegenerateResult> {
   await env.DB.prepare("DELETE FROM tldr_snapshots WHERE date = ?")
     .bind(date)
     .run();
-  return ensureDailyTldr(env);
+  const result = await ensureDailyTldr(env);
+  await writeAudit(
+    env,
+    "tldr.regenerate",
+    result.generated ? `ok ${date}` : result.reason
+  );
+  return result;
 }

--- a/apps/news/worker/notify/index.ts
+++ b/apps/news/worker/notify/index.ts
@@ -465,7 +465,7 @@ export async function forceSendDigest(
   const now = Date.now();
   const { date } = getLocalHourAndDate(now, DIGEST_TIMEZONE);
   const key = digestKey(date);
-  let digest = await loadDigest(env, date);
+  const digest = await loadDigest(env, date);
   if (!digest) {
     return { sent: 0, reason: `no TL;DR snapshot for ${date}` };
   }

--- a/apps/news/worker/notify/index.ts
+++ b/apps/news/worker/notify/index.ts
@@ -232,7 +232,7 @@ async function loadDigest(env: Env, date: string): Promise<DailyDigest | null> {
   // the local date always equals the snapshot's UTC date, and a missing
   // snapshot returns null so a later run retries instead of resending an
   // older day's digest.
-  const snapshot = await env.DB.prepare(
+  let snapshot = await env.DB.prepare(
     "SELECT date, bullets_en, bullets_vi FROM tldr_snapshots WHERE date = ?"
   )
     .bind(date)
@@ -241,6 +241,21 @@ async function loadDigest(env: Env, date: string): Promise<DailyDigest | null> {
       bullets_en: string | null;
       bullets_vi: string | null;
     }>();
+  // TL;DR used to key on UTC date; if today's local row is missing, try UTC.
+  if (!snapshot) {
+    const utcDate = new Date().toISOString().slice(0, 10);
+    if (utcDate !== date) {
+      snapshot = await env.DB.prepare(
+        "SELECT date, bullets_en, bullets_vi FROM tldr_snapshots WHERE date = ?"
+      )
+        .bind(utcDate)
+        .first<{
+          date: string;
+          bullets_en: string | null;
+          bullets_vi: string | null;
+        }>();
+    }
+  }
   if (!snapshot) return null;
 
   const raw = topBullets(snapshot.bullets_vi, DIGEST_MAX_BULLETS);
@@ -440,4 +455,41 @@ export async function dispatchStoryNotifications(
   const report: NotifyRunResult = { sent, reasons };
   console.info("notify", report);
   return report;
+}
+
+/** Admin/manual: send today's digest now, ignoring the 08:00 local gate
+ * and overwriting a prior sent/failed row. */
+export async function forceSendDigest(
+  env: Env
+): Promise<{ sent: number; reason: string }> {
+  const now = Date.now();
+  const { date } = getLocalHourAndDate(now, DIGEST_TIMEZONE);
+  const key = digestKey(date);
+  let digest = await loadDigest(env, date);
+  if (!digest) {
+    return { sent: 0, reason: `no TL;DR snapshot for ${date}` };
+  }
+  let sent = 0;
+  for (const notifier of notifiers) {
+    if (!notifier.enabled(env)) {
+      return {
+        sent: 0,
+        reason: `${notifier.id} not configured (missing bot token or chat id)`,
+      };
+    }
+    const target = notifier.target(env);
+    let result: { ok: boolean; messageId?: string; error?: string };
+    try {
+      result = await notifier.sendDigest(env, digest);
+    } catch (error) {
+      result = {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+    await recordDelivery(env, notifier.id, target, key, result);
+    if (result.ok) sent++;
+    else return { sent, reason: result.error ?? "send failed" };
+  }
+  return { sent, reason: sent > 0 ? `sent digest ${date}` : "no channel sent" };
 }

--- a/apps/news/worker/subscribe/send.ts
+++ b/apps/news/worker/subscribe/send.ts
@@ -51,7 +51,14 @@ export function topBullets(
   try {
     const parsed = JSON.parse(bulletsJson);
     if (!Array.isArray(parsed)) return [];
-    return parsed.slice(0, max);
+    return parsed.slice(0, max).map((b: Record<string, unknown>) => {
+      const itemIds = Array.isArray(b.item_ids) ? (b.item_ids as string[]) : [];
+      const item_id =
+        typeof b.item_id === "string" && b.item_id
+          ? b.item_id
+          : itemIds[0];
+      return { text: String(b.text ?? ""), item_id };
+    });
   } catch {
     return [];
   }

--- a/apps/news/worker/workflow.ts
+++ b/apps/news/worker/workflow.ts
@@ -1070,7 +1070,16 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
       );
 
       const tldrStats = await step.do("tldr", async () => {
-        return await ensureDailyTldr(this.env);
+        try {
+          return await ensureDailyTldr(this.env);
+        } catch (error) {
+          console.error("tldr step failed:", error);
+          return {
+            generated: false,
+            tokens: 0,
+            reason: error instanceof Error ? error.message : String(error),
+          };
+        }
       });
       tldrGenerated = tldrStats.generated;
       tldrTokens = tldrStats.tokens;


### PR DESCRIPTION
## Why TL;DR and Telegram were dead

Hourly cron was **commented out** in `wrangler.toml` (Workers Free 5-cron cap). Nothing ran after deploy except manual ingest.

## Fixes
- Re-enable `0 * * * *` so ingest → TL;DR → telegram run every hour
- Key TL;DR snapshots on **Asia/Ho_Chi_Minh** date (same as digest), refresh ~hourly
- Digest falls back to the UTC snapshot if the local-date row is missing
- Telegram bullets use `item_ids[0]` for permalinks
- TL;DR step no longer fails the whole workflow

## Admin / menu
- Footer **Analytics → System**
- Status shows telegram configured + latest TL;DR + recent notifications
- **Send Telegram digest** (ignores 08:00 gate)
- Audit log table + `/api/admin/audit`

## Test plan
- [x] `cd apps/news && pnpm test` (413)
- [ ] After merge/deploy: apply D1 migration 0015
- [ ] Trigger ingest or wait for cron; check `/system` admin

## Summary by Sourcery

Restore hourly news processing and improve TL;DR and Telegram reliability with operational controls and visibility.

New Features:
- Add hourly automated news ingestion through TL;DR generation and Telegram delivery.
- Add system admin visibility for Telegram configuration, TL;DR state, recent notifications, and audit history.
- Add an admin action to send the Telegram digest immediately.
- Expose admin endpoints for notifications, audit records, and manual digest delivery.

Bug Fixes:
- Align TL;DR snapshots with the Asia/Ho_Chi_Minh digest date and refresh them hourly.
- Fall back to the UTC snapshot when the local-date TL;DR snapshot is unavailable.
- Preserve Telegram story permalinks by deriving bullet item IDs from item_ids.
- Prevent TL;DR errors from aborting the overall ingest workflow.

Enhancements:
- Record administrative ingest, TL;DR regeneration, and notification actions for operational traceability.
- Rename the footer System navigation entry to match the admin area.

Tests:
- Expand coverage for timezone-based snapshot dates, refresh intervals, timestamp formats, and Telegram permalink IDs.

Chores:
- Add the database migration for the admin audit log.