### PR TITLE
style(homelab): match blog editorial layout

### DIFF
--- a/apps/homelab/app/globals.css
+++ b/apps/homelab/app/globals.css
@@ -4,48 +4,46 @@
 
 @layer base {
   :root {
-    --background: var(--rd-bg, #ffffff);
-    --foreground: var(--rd-text, #0c0c0c);
-    --card: var(--rd-surface, #ffffff);
-    --card-foreground: var(--rd-text, #0c0c0c);
-    --popover: var(--rd-surface, #ffffff);
-    --popover-foreground: var(--rd-text, #0c0c0c);
-    --primary: var(--rd-text, #0c0c0c);
-    --primary-foreground: var(--rd-bg, #ffffff);
-    --secondary: var(--rd-surface-2, #f6f6f5);
-    --secondary-foreground: var(--rd-text, #0c0c0c);
-    --muted: var(--rd-surface-2, #f6f6f5);
-    --muted-foreground: var(--rd-text-3, #8c8b85);
-    --accent: var(--rd-accent-bg, #fbeee7);
-    --accent-foreground: var(--rd-accent-ink, #b54a1f);
-    --destructive: var(--rd-down, #d23b3b);
-    --destructive-foreground: #ffffff;
-    --border: var(--rd-border, #e8e8e6);
-    --input: var(--rd-border, #e8e8e6);
-    --ring: var(--rd-ring, rgba(216,96,47,.32));
-    --radius: var(--rd-r, 11px);
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.145 0 0);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.145 0 0);
+    --popover: oklch(1 0 0);
+    --popover-foreground: oklch(0.145 0 0);
+    --primary: oklch(0.205 0 0);
+    --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.97 0 0);
+    --secondary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.97 0 0);
+    --muted-foreground: oklch(0.556 0 0);
+    --accent: oklch(0.97 0 0);
+    --accent-foreground: oklch(0.205 0 0);
+    --destructive: oklch(0.577 0.245 27.325);
+    --border: oklch(0.922 0 0);
+    --input: oklch(0.922 0 0);
+    --ring: oklch(0.708 0 0);
+    --radius: 0.5rem;
   }
 
   .dark {
-    --background: var(--rd-bg, #0a0a0a);
-    --foreground: var(--rd-text, #f4f3f1);
-    --card: var(--rd-surface, #111111);
-    --card-foreground: var(--rd-text, #f4f3f1);
-    --popover: var(--rd-surface, #111111);
-    --popover-foreground: var(--rd-text, #f4f3f1);
-    --primary: var(--rd-text, #f4f3f1);
-    --primary-foreground: var(--rd-bg, #0a0a0a);
-    --secondary: var(--rd-surface-2, #161616);
-    --secondary-foreground: var(--rd-text, #f4f3f1);
-    --muted: var(--rd-surface-2, #161616);
-    --muted-foreground: var(--rd-text-3, #74736e);
-    --accent: var(--rd-accent-bg, #2a1810);
-    --accent-foreground: var(--rd-accent-ink, #f59568);
-    --destructive: var(--rd-down, #f06464);
-    --destructive-foreground: #ffffff;
-    --border: var(--rd-border, #242424);
-    --input: var(--rd-border, #242424);
-    --ring: var(--rd-ring, rgba(240,116,63,.4));
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.3 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.72 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 14%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
   }
 
   * {
@@ -53,18 +51,18 @@
   }
 
   html {
-    font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+    background: var(--background);
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
     font-size: 16px;
     -webkit-text-size-adjust: 100%;
   }
 
   body {
-    background-color: var(--background);
+    background: var(--background);
     color: var(--foreground);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    line-height: 1.55;
-    transition: background-color .35s ease, color .35s ease;
+    line-height: 1.6;
   }
 }
 

--- a/apps/homelab/components/dashboard/ClusterOverview.tsx
+++ b/apps/homelab/components/dashboard/ClusterOverview.tsx
@@ -1,34 +1,28 @@
 "use client";
 
-import { Activity, Database, HardDrive, Server, CheckCircle2 } from "lucide-react";
 import { useClusterStats } from "@/hooks/useDashboard";
-import { Card, CardContent } from "@/components/ui/card";
 
 const statCards = [
   {
     key: "nodes",
-    icon: Server,
     label: "Nodes",
     value: (stats: ReturnType<typeof useClusterStats>) => String(stats.totalNodes),
     sub: (stats: ReturnType<typeof useClusterStats>) => `${stats.onlineNodes} online`,
   },
   {
     key: "services",
-    icon: CheckCircle2,
     label: "Services",
     value: (stats: ReturnType<typeof useClusterStats>) => String(stats.totalServices),
     sub: (stats: ReturnType<typeof useClusterStats>) => `${stats.runningServices} running`,
   },
   {
     key: "cpu",
-    icon: Activity,
     label: "Avg CPU",
     value: (stats: ReturnType<typeof useClusterStats>) => `${stats.avgCpu.toFixed(1)}%`,
     sub: () => "all nodes",
   },
   {
     key: "memory",
-    icon: HardDrive,
     label: "Memory",
     value: (stats: ReturnType<typeof useClusterStats>) => `${stats.usedMemory.toFixed(0)} GB`,
     sub: (stats: ReturnType<typeof useClusterStats>) =>
@@ -36,7 +30,6 @@ const statCards = [
   },
   {
     key: "storage",
-    icon: Database,
     label: "Storage",
     value: (stats: ReturnType<typeof useClusterStats>) =>
       `${(stats.totalStorage / 1024).toFixed(1)} TB`,
@@ -48,22 +41,17 @@ export function ClusterOverview() {
   const stats = useClusterStats();
 
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+    <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--rd-border)] bg-[var(--rd-border)] sm:grid-cols-3 lg:grid-cols-5">
       {statCards.map((card) => (
-        <Card key={card.key} className="min-w-0">
-          <CardContent className="p-4">
-            <div className="flex items-center gap-1.5 text-muted-foreground">
-              <card.icon className="size-3.5" />
-              <p className="text-[11px] font-medium">{card.label}</p>
-            </div>
-            <p className="mt-2 font-mono text-2xl font-semibold tracking-tight tabular-nums">
-              {card.value(stats)}
-            </p>
-            <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
-              {card.sub(stats)}
-            </p>
-          </CardContent>
-        </Card>
+        <div key={card.key} className="min-w-0 bg-[var(--rd-surface)] p-5">
+          <p className="text-[12px] text-[var(--rd-text-3)]">{card.label}</p>
+          <p className="mt-2 font-mono text-[28px] font-semibold leading-none tracking-tight tabular-nums text-[var(--rd-text)]">
+            {card.value(stats)}
+          </p>
+          <p className="mt-2 truncate font-mono text-[12px] text-[var(--rd-text-3)]">
+            {card.sub(stats)}
+          </p>
+        </div>
       ))}
     </div>
   );

--- a/apps/homelab/components/dashboard/K8sInfo.tsx
+++ b/apps/homelab/components/dashboard/K8sInfo.tsx
@@ -24,7 +24,8 @@ export function K8sInfo() {
   const { pods, summary } = useK8s();
 
   return (
-    <div className="grid grid-cols-2 gap-3 lg:grid-cols-12">
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--rd-border)] bg-[var(--rd-border)] lg:grid-cols-4">
       <StatCell
         icon={Cuboid}
         label="Namespaces"
@@ -47,8 +48,9 @@ export function K8sInfo() {
         value={String(summary.totalRestarts)}
         sub="total"
       />
+      </div>
 
-      <Card className="col-span-2 min-w-0 lg:col-span-12">
+      <Card className="min-w-0">
         <CardHeader className="flex-row items-center justify-between">
           <CardTitle>Pods</CardTitle>
         </CardHeader>
@@ -128,19 +130,17 @@ function StatCell({
   sub?: string;
 }) {
   return (
-    <Card className="min-w-0 lg:col-span-3">
-      <CardContent className="p-4">
-        <div className="flex items-center gap-1.5 text-muted-foreground">
-          <Icon className="size-3.5" />
-          <p className="text-[11px] font-medium">{label}</p>
-        </div>
-        <p className="mt-2 font-mono text-2xl font-semibold tracking-tight tabular-nums">
-          {value}
-        </p>
-        {sub ? (
-          <p className="mt-0.5 text-[11px] text-muted-foreground">{sub}</p>
-        ) : null}
-      </CardContent>
-    </Card>
+    <div className="min-w-0 bg-[var(--rd-surface)] p-5">
+      <div className="flex items-center gap-1.5 text-[var(--rd-text-3)]">
+        <Icon className="size-3.5" />
+        <p className="text-[12px]">{label}</p>
+      </div>
+      <p className="mt-2 font-mono text-[28px] font-semibold leading-none tracking-tight tabular-nums text-[var(--rd-text)]">
+        {value}
+      </p>
+      {sub ? (
+        <p className="mt-2 font-mono text-[12px] text-[var(--rd-text-3)]">{sub}</p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/homelab/components/dashboard/ServicesStatus.tsx
+++ b/apps/homelab/components/dashboard/ServicesStatus.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Badge } from "@duyet/components/ui/badge";
-import { Button } from "@duyet/components/ui/button";
 import { Input } from "@duyet/components/ui/input";
 import {
   Table,
@@ -61,12 +60,17 @@ export function ServicesStatus() {
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="flex flex-wrap gap-1.5" role="tablist" aria-label="Namespace">
+        <div
+          className="flex gap-5 overflow-x-auto whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          role="tablist"
+          aria-label="Namespace"
+        >
           <FilterChip
             active={selectedNamespace === null}
             onClick={() => setSelectedNamespace(null)}
           >
-            All ({allServices.length})
+            All
+            <span className="ml-[3px] text-[var(--rd-text-4)]">{allServices.length}</span>
           </FilterChip>
           {namespaces.map((namespace) => (
             <FilterChip
@@ -74,7 +78,10 @@ export function ServicesStatus() {
               active={selectedNamespace === namespace}
               onClick={() => setSelectedNamespace(namespace)}
             >
-              {namespace} ({servicesByNamespace[namespace]?.length || 0})
+              {namespace}
+              <span className="ml-[3px] text-[var(--rd-text-4)]">
+                {servicesByNamespace[namespace]?.length || 0}
+              </span>
             </FilterChip>
           ))}
         </div>
@@ -154,16 +161,18 @@ function FilterChip({
   children: ReactNode;
 }) {
   return (
-    <Button
+    <button
       type="button"
-      size="xs"
-      variant={active ? "default" : "outline"}
       onClick={onClick}
       role="tab"
       aria-selected={active}
-      className="h-6 px-2 text-[11px]"
+      className={`shrink-0 cursor-pointer bg-transparent px-0 text-[16px] tracking-tight transition-colors ${
+        active
+          ? "font-semibold text-[var(--rd-text)]"
+          : "font-normal text-[var(--rd-text-3)] hover:text-[var(--rd-text)]"
+      }`}
     >
       {children}
-    </Button>
+    </button>
   );
 }

--- a/apps/homelab/components/tiles/NodesTile.tsx
+++ b/apps/homelab/components/tiles/NodesTile.tsx
@@ -18,11 +18,14 @@ function NodesTile() {
 
   return (
     <Card className="min-w-0">
-      <CardHeader className="flex-row items-center justify-between">
-        <CardTitle>Nodes</CardTitle>
-        <Badge variant="secondary" className="font-mono text-[11px] font-normal">
-          {onlineCount}/{totalNodes} online
-        </Badge>
+      <CardHeader className="flex-row items-baseline justify-between">
+        <CardTitle className="text-base font-semibold">Nodes</CardTitle>
+        <span className="font-mono text-[12px] text-[var(--rd-text-3)]">
+          <strong className="font-semibold text-[var(--rd-accent)]">
+            {onlineCount}/{totalNodes}
+          </strong>{" "}
+          online
+        </span>
       </CardHeader>
       <CardContent>
         <Table>

--- a/apps/homelab/components/ui/card.tsx
+++ b/apps/homelab/components/ui/card.tsx
@@ -15,7 +15,10 @@ const Card = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SharedCard
     ref={ref}
-    className={cn("rounded-lg border bg-card text-card-foreground shadow-none", className)}
+    className={cn(
+      "rounded-[8px] border border-black/10 bg-background text-foreground shadow-none dark:border-white/12",
+      className,
+    )}
     {...props}
   />
 ));
@@ -39,7 +42,7 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SharedCardTitle
     ref={ref}
-    className={cn("text-sm font-medium tracking-tight", className)}
+    className={cn("text-sm font-semibold tracking-tight", className)}
     {...props}
   />
 ));

--- a/apps/homelab/src/routes/__root.tsx
+++ b/apps/homelab/src/routes/__root.tsx
@@ -10,7 +10,6 @@ import {
   HeadContent,
   Outlet,
   Scripts,
-  useRouterState,
 } from "@tanstack/react-router";
 import ErrorPage from "@/app/error";
 import NotFoundPage from "@/app/not-found";
@@ -26,6 +25,16 @@ export const Route = createRootRoute({
       { name: "description", content: homelabConfig.metadata.description },
     ],
     links: [
+      { rel: "preconnect", href: "https://fonts.googleapis.com" },
+      {
+        rel: "preconnect",
+        href: "https://fonts.gstatic.com",
+        crossOrigin: "anonymous",
+      },
+      {
+        rel: "stylesheet",
+        href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap",
+      },
       { rel: "icon", href: "/favicon.svg", sizes: "any" },
     ],
   }),
@@ -37,8 +46,6 @@ export const Route = createRootRoute({
 });
 
 function RootComponent() {
-  const pathname = useRouterState({ select: (s) => s.location.pathname });
-
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -46,10 +53,14 @@ function RootComponent() {
       </head>
       <body>
         <ThemeProvider>
-          <SiteHeader currentApp="homelab" />
-          <Outlet />
-          <ExploreApps currentApp="homelab" />
-          <SiteFooter />
+          <div className="relative flex min-h-screen flex-col justify-between overflow-x-hidden bg-background text-foreground subpixel-antialiased">
+            <SiteHeader currentApp="homelab" />
+            <main className="relative z-10 flex-grow">
+              <Outlet />
+            </main>
+            <ExploreApps currentApp="homelab" />
+            <SiteFooter />
+          </div>
         </ThemeProvider>
         <Scripts />
       </body>

--- a/apps/homelab/src/routes/index.tsx
+++ b/apps/homelab/src/routes/index.tsx
@@ -1,13 +1,6 @@
-import { Badge } from "@duyet/components/ui/badge";
-import { Button } from "@duyet/components/ui/button";
-import { Box, Server, Smartphone, Zap } from "lucide-react";
-import {
-  AgentActionsTile,
-  ClusterStatsTile,
-  NodesTile,
-  SmartDevicesTile,
-  StatusDot,
-} from "@/components/tiles";
+import { SecHead } from "@duyet/components";
+import { createFileRoute } from "@tanstack/react-router";
+import { AgentActionsTile, NodesTile, SmartDevicesTile, StatusDot } from "@/components/tiles";
 import { ClusterOverview } from "@/components/dashboard/ClusterOverview";
 import { K8sInfo } from "@/components/dashboard/K8sInfo";
 import { NetworkStats } from "@/components/dashboard/NetworkStats";
@@ -16,15 +9,17 @@ import { ServiceDowntime } from "@/components/dashboard/ServiceDowntime";
 import { ServicesStatus } from "@/components/dashboard/ServicesStatus";
 import { SmartDevicesOverview } from "@/components/smart-devices/SmartDevicesOverview";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { useClusterInfo, useNodes } from "@/hooks/useDashboard";
-import { createFileRoute } from "@tanstack/react-router";
+import { useClusterInfo, useClusterStats, useNodes } from "@/hooks/useDashboard";
 
 const sections = [
-  { id: "overview", label: "Overview", icon: Zap },
-  { id: "infrastructure", label: "Infrastructure", icon: Server },
-  { id: "k8s", label: "Kubernetes", icon: Box },
-  { id: "smart-devices", label: "Smart Devices", icon: Smartphone },
+  { id: "overview", label: "Overview" },
+  { id: "infrastructure", label: "Infrastructure" },
+  { id: "k8s", label: "Kubernetes" },
+  { id: "smart-devices", label: "Smart devices" },
 ] as const;
+
+const INTRO =
+  "A small k3s lab on mini PCs, a Raspberry Pi, and a few home devices. Metrics here are mock data that refresh on each build.";
 
 export const Route = createFileRoute("/")({
   component: HomelabPage,
@@ -33,112 +28,76 @@ export const Route = createFileRoute("/")({
 function HomelabPage() {
   const { onlineCount, totalNodes } = useNodes();
   const clusterInfo = useClusterInfo();
+  const stats = useClusterStats();
 
   return (
-    <div className="bg-background text-foreground">
-      <section className="mx-auto max-w-6xl px-4 pb-4 pt-6 sm:px-6">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div className="min-w-0">
-            <p className="mb-1 inline-flex items-center gap-2 text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
-              <StatusDot status={onlineCount === totalNodes ? "online" : "degraded"} />
-              Infrastructure · homelab.duyet.net
-            </p>
-            <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
-              Homelab
-            </h1>
-          </div>
-          <div className="flex items-center gap-3">
-            <div className="text-left sm:text-right">
-              <p className="text-sm font-medium">
-                Kubernetes {clusterInfo.version}
-              </p>
-              <p className="text-[11px] text-muted-foreground">
-                {clusterInfo.platform} · {clusterInfo.cni} CNI · {clusterInfo.csi} CSI
-              </p>
-            </div>
-            <Badge variant="secondary" className="gap-1.5 font-mono text-[11px] font-normal">
-              <span className="size-1.5 rounded-full bg-[var(--rd-ok)]" />
-              k3s
-            </Badge>
-          </div>
+    <div>
+      <section className="mx-auto max-w-[var(--rd-maxw)] px-[var(--rd-pad)] pt-[clamp(32px,4.5vw,56px)] pb-[clamp(22px,3vw,36px)]">
+        <h1 className="rd-display text-[clamp(2.4rem,5.5vw,4rem)]">
+          Homelab, a{" "}
+          <span className="text-[var(--rd-accent)]">k3s cluster</span>.
+        </h1>
+        <p className="rd-lead mt-[16px] max-w-[64ch] text-[clamp(1.02rem,1.4vw,1.18rem)]">
+          {INTRO}
+        </p>
+        <div className="mt-[16px] flex flex-wrap items-center gap-5 font-[var(--font-mono)] text-[13px] text-[var(--rd-text-3)]">
+          <span className="inline-flex items-center gap-2">
+            <StatusDot status={onlineCount === totalNodes ? "online" : "degraded"} />
+            <strong className="text-[var(--rd-accent)]">
+              {onlineCount}/{totalNodes}
+            </strong>{" "}
+            nodes
+          </span>
+          <span>
+            <strong className="text-[var(--rd-accent)]">
+              {stats.runningServices}/{stats.totalServices}
+            </strong>{" "}
+            services
+          </span>
+          <span>
+            {clusterInfo.platform} {clusterInfo.version}
+          </span>
+          <span>
+            {clusterInfo.cni} · {clusterInfo.csi}
+          </span>
         </div>
+
+        <nav className="mt-6 flex gap-5 overflow-x-auto whitespace-nowrap [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {sections.map((s) => (
+            <a
+              key={s.id}
+              href={`#${s.id}`}
+              className="shrink-0 text-[16px] tracking-tight text-[var(--rd-text-3)] no-underline transition-colors hover:text-[var(--rd-text)]"
+            >
+              {s.label}
+            </a>
+          ))}
+        </nav>
       </section>
 
-      <nav className="sticky top-[3.5rem] z-20 border-y bg-background/85 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl gap-1 overflow-x-auto px-4 sm:px-6">
-          {sections.map((s) => {
-            const Icon = s.icon;
-            return (
-              <Button
-                key={s.id}
-                variant="ghost"
-                size="sm"
-                asChild
-                className="h-9 shrink-0 text-[13px] text-muted-foreground hover:text-foreground"
-              >
-                <a href={`#${s.id}`}>
-                  <Icon className="size-3.5" />
-                  {s.label}
-                </a>
-              </Button>
-            );
-          })}
-        </div>
-      </nav>
-
-      <main className="mx-auto max-w-6xl space-y-8 px-4 py-6 sm:px-6">
-        <OverviewSection />
-        <InfrastructureSection />
-        <K8sSection />
-        <SmartDevicesSection />
-      </main>
-    </div>
-  );
-}
-
-function SectionLabel({
-  id,
-  kicker,
-  title,
-}: {
-  id: string;
-  kicker: string;
-  title: string;
-}) {
-  return (
-    <div id={id} className="scroll-mt-28 mb-3">
-      <p className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground">
-        {kicker}
-      </p>
-      <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+      <OverviewSection />
+      <InfrastructureSection />
+      <K8sSection />
+      <SmartDevicesSection />
     </div>
   );
 }
 
 function OverviewSection() {
   return (
-    <section>
-      <SectionLabel id="overview" kicker="At a glance" title="Overview" />
-      <div className="space-y-3">
+    <section
+      id="overview"
+      className="scroll-mt-24 mx-auto max-w-[var(--rd-maxw)] px-[var(--rd-pad)] py-[clamp(28px,3.5vw,44px)] border-t border-[var(--rd-border)]"
+    >
+      <SecHead eyebrow="At a glance" title="Overview" />
+      <div className="space-y-8">
         <ErrorBoundary>
           <ClusterOverview />
         </ErrorBoundary>
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-12">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
           <div className="min-w-0 lg:col-span-8">
             <ErrorBoundary>
               <NodesTile />
-            </ErrorBoundary>
-          </div>
-          <div className="min-w-0 lg:col-span-4">
-            <ErrorBoundary>
-              <ClusterStatsTile />
-            </ErrorBoundary>
-          </div>
-        </div>
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-12">
-          <div className="min-w-0 lg:col-span-8">
-            <ErrorBoundary>
-              <AgentActionsTile />
             </ErrorBoundary>
           </div>
           <div className="min-w-0 lg:col-span-4">
@@ -147,6 +106,9 @@ function OverviewSection() {
             </ErrorBoundary>
           </div>
         </div>
+        <ErrorBoundary>
+          <AgentActionsTile />
+        </ErrorBoundary>
       </div>
     </section>
   );
@@ -154,9 +116,12 @@ function OverviewSection() {
 
 function InfrastructureSection() {
   return (
-    <section>
-      <SectionLabel id="infrastructure" kicker="Cluster" title="Infrastructure" />
-      <div className="space-y-3">
+    <section
+      id="infrastructure"
+      className="scroll-mt-24 mx-auto max-w-[var(--rd-maxw)] px-[var(--rd-pad)] py-[clamp(28px,3.5vw,44px)] border-t border-[var(--rd-border)]"
+    >
+      <SecHead eyebrow="Cluster" title="Infrastructure" />
+      <div className="space-y-10">
         <ErrorBoundary>
           <ResourceMetrics />
         </ErrorBoundary>
@@ -176,8 +141,11 @@ function InfrastructureSection() {
 
 function K8sSection() {
   return (
-    <section>
-      <SectionLabel id="k8s" kicker="Kubernetes" title="Cluster" />
+    <section
+      id="k8s"
+      className="scroll-mt-24 mx-auto max-w-[var(--rd-maxw)] px-[var(--rd-pad)] py-[clamp(28px,3.5vw,44px)] border-t border-[var(--rd-border)]"
+    >
+      <SecHead eyebrow="Kubernetes" title="Cluster" />
       <ErrorBoundary>
         <K8sInfo />
       </ErrorBoundary>
@@ -187,8 +155,11 @@ function K8sSection() {
 
 function SmartDevicesSection() {
   return (
-    <section>
-      <SectionLabel id="smart-devices" kicker="Home" title="Smart devices" />
+    <section
+      id="smart-devices"
+      className="scroll-mt-24 mx-auto max-w-[var(--rd-maxw)] px-[var(--rd-pad)] py-[clamp(28px,3.5vw,44px)] pb-[clamp(44px,6vw,72px)] border-t border-[var(--rd-border)]"
+    >
+      <SecHead eyebrow="Home" title="Smart devices" />
       <ErrorBoundary>
         <SmartDevicesOverview />
       </ErrorBoundary>


### PR DESCRIPTION
## Summary
Restyle [homelab.duyet.net](https://homelab.duyet.net/) to match the blog editorial layout.

## Changes
- Inter + white oklch tokens, same as blog
- Display hero, lead, and mono cluster stats
- Hairline 1px stat grids (cluster + Kubernetes)
- Text namespace filters instead of filled chips
- 8px hairline tiles, no beige card chrome
- Shared `--rd-maxw` / `--rd-pad` measure and `SecHead` sections

## Verify
- `pnpm --filter homelab run check-types`
- `pnpm --filter homelab run test`
- `pnpm exec biome lint` on touched files

## Summary by Sourcery

Align the homelab dashboard with the blog’s editorial layout and visual design system.

Enhancements:
- Restyle the homelab dashboard with the blog’s editorial typography, spacing, navigation, section structure, and visual language.
- Present cluster and Kubernetes metrics as compact hairline stat grids with streamlined cards and namespace filters.
- Align global theme tokens, font loading, layout framing, and shared content measurements with the editorial design system.