### PR TITLE
feat(homelab): lock dark mode and tune night-ops palette

### DIFF
--- a/apps/homelab/app/globals.css
+++ b/apps/homelab/app/globals.css
@@ -3,47 +3,28 @@
 @config "../tailwind.config.mjs";
 
 @layer base {
-  :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --radius: 0.5rem;
-  }
-
+  :root,
   .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.3 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.72 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 14%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
+    --background: #070708;
+    --foreground: #f3efe6;
+    --card: #101114;
+    --card-foreground: #f3efe6;
+    --popover: #101114;
+    --popover-foreground: #f3efe6;
+    --primary: #f3efe6;
+    --primary-foreground: #070708;
+    --secondary: #16171b;
+    --secondary-foreground: #f3efe6;
+    --muted: #16171b;
+    --muted-foreground: #8b877c;
+    --accent: #1c1712;
+    --accent-foreground: #f0a060;
+    --destructive: #ff6b5a;
+    --destructive-foreground: #fff4f1;
+    --border: rgba(243, 239, 230, 0.09);
+    --input: rgba(243, 239, 230, 0.12);
+    --ring: rgba(240, 160, 96, 0.42);
+    --radius: 8px;
   }
 
   * {
@@ -51,18 +32,29 @@
   }
 
   html {
-    background: var(--background);
-    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    color-scheme: dark;
+    background-color: #070708;
+    font-family: Geist, ui-sans-serif, system-ui, sans-serif;
     font-size: 16px;
     -webkit-text-size-adjust: 100%;
   }
 
   body {
-    background: var(--background);
+    background-color: var(--background);
+    background-image: radial-gradient(
+      980px 440px at 10% -12%,
+      rgba(240, 116, 63, 0.14),
+      transparent 58%
+    );
     color: var(--foreground);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     line-height: 1.6;
+  }
+
+  ::selection {
+    background: rgba(240, 160, 96, 0.28);
+    color: #fff6ee;
   }
 }
 

--- a/apps/homelab/components/dashboard/ClusterOverview.tsx
+++ b/apps/homelab/components/dashboard/ClusterOverview.tsx
@@ -41,14 +41,14 @@ export function ClusterOverview() {
   const stats = useClusterStats();
 
   return (
-    <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--rd-border)] bg-[var(--rd-border)] sm:grid-cols-3 lg:grid-cols-5">
+    <div className="grid grid-cols-2 gap-px overflow-hidden border border-white/10 bg-white/10 sm:grid-cols-3 lg:grid-cols-5">
       {statCards.map((card) => (
-        <div key={card.key} className="min-w-0 bg-[var(--rd-surface)] p-5">
-          <p className="text-[12px] text-[var(--rd-text-3)]">{card.label}</p>
-          <p className="mt-2 font-mono text-[28px] font-semibold leading-none tracking-tight tabular-nums text-[var(--rd-text)]">
+        <div key={card.key} className="min-w-0 bg-[#101114] p-5">
+          <p className="text-[12px] text-muted-foreground">{card.label}</p>
+          <p className="mt-2 font-mono text-[28px] font-semibold leading-none tracking-tight tabular-nums text-foreground">
             {card.value(stats)}
           </p>
-          <p className="mt-2 truncate font-mono text-[12px] text-[var(--rd-text-3)]">
+          <p className="mt-2 truncate font-mono text-[12px] text-muted-foreground">
             {card.sub(stats)}
           </p>
         </div>

--- a/apps/homelab/components/dashboard/K8sInfo.tsx
+++ b/apps/homelab/components/dashboard/K8sInfo.tsx
@@ -25,7 +25,7 @@ export function K8sInfo() {
 
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-2 gap-px overflow-hidden border border-[var(--rd-border)] bg-[var(--rd-border)] lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-px overflow-hidden border border-white/10 bg-white/10 lg:grid-cols-4">
       <StatCell
         icon={Cuboid}
         label="Namespaces"
@@ -130,7 +130,7 @@ function StatCell({
   sub?: string;
 }) {
   return (
-    <div className="min-w-0 bg-[var(--rd-surface)] p-5">
+    <div className="min-w-0 bg-[#101114] p-5">
       <div className="flex items-center gap-1.5 text-[var(--rd-text-3)]">
         <Icon className="size-3.5" />
         <p className="text-[12px]">{label}</p>

--- a/apps/homelab/components/smart-devices/BoschWashingMachine.tsx
+++ b/apps/homelab/components/smart-devices/BoschWashingMachine.tsx
@@ -54,13 +54,13 @@ function ViewModeToggle({
   onChange: (mode: ViewMode) => void;
 }) {
   return (
-    <div className="flex rounded-full bg-neutral-100 p-0.5 dark:bg-neutral-800">
+    <div className="flex rounded-full bg-white/8 p-0.5">
       <button
         onClick={() => onChange("day")}
         className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
           mode === "day"
-            ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900"
-            : "text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+            ? "bg-[#f3efe6] text-[#070708]"
+            : "text-[#8b877c] hover:text-[#f3efe6]"
         }`}
       >
         Day
@@ -69,8 +69,8 @@ function ViewModeToggle({
         onClick={() => onChange("month")}
         className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
           mode === "month"
-            ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900"
-            : "text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+            ? "bg-[#f3efe6] text-[#070708]"
+            : "text-[#8b877c] hover:text-[#f3efe6]"
         }`}
       >
         Month
@@ -142,7 +142,7 @@ function ConsumptionChart({
     <div className={`${BENTO_CELL} ${className ?? ""}`}>
       <div className="mb-4 space-y-2">
         <div className="flex items-center justify-between">
-          <h4 className="flex items-center gap-2 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+          <h4 className="flex items-center gap-2 text-sm font-semibold text-foreground">
             {icon}
             {title}
           </h4>
@@ -159,7 +159,7 @@ function ConsumptionChart({
         {selectedEntry && (
           <p className="text-sm text-neutral-500 dark:text-neutral-400">
             {selectedEntry.label}:{" "}
-            <span className="font-semibold text-neutral-900 dark:text-neutral-100">
+            <span className="font-semibold text-foreground">
               {selectedEntry.value} {unit}
             </span>
           </p>
@@ -210,7 +210,7 @@ const STATUS_CONFIG = {
   offline: {
     label: "Offline",
     badgeClass:
-      "bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-400",
+      "bg-white/10 text-muted-foreground",
     dotClass: "bg-neutral-400",
   },
 } as const;
@@ -227,7 +227,7 @@ export function BoschWashingMachine() {
           <RefreshCw className="h-5 w-5 text-claude-lavender" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+          <h3 className="text-lg font-semibold text-foreground">
             {data.model}
           </h3>
           <p className="text-xs text-neutral-500 dark:text-neutral-400">

--- a/apps/homelab/components/smart-devices/DysonAirPurifier.tsx
+++ b/apps/homelab/components/smart-devices/DysonAirPurifier.tsx
@@ -68,7 +68,7 @@ const STATUS_CONFIG = {
   offline: {
     label: "Offline",
     badgeClass:
-      "bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-400",
+      "bg-white/10 text-muted-foreground",
     dotClass: "bg-neutral-400",
   },
 } as const;
@@ -145,7 +145,7 @@ function AirQualityRing({
             <Thermometer className="h-4 w-4 text-claude-orange" />
           </div>
           <div>
-            <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
+            <p className="text-2xl font-bold text-foreground">
               {Math.round(temperature)}°
             </p>
             <p className="text-[10px] text-neutral-500 dark:text-neutral-400">
@@ -158,7 +158,7 @@ function AirQualityRing({
             <Droplets className="h-4 w-4 text-claude-sky" />
           </div>
           <div>
-            <p className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
+            <p className="text-2xl font-bold text-foreground">
               {Math.round(humidity)}%
             </p>
             <p className="text-[10px] text-neutral-500 dark:text-neutral-400">
@@ -210,7 +210,7 @@ function AirQualityChart() {
     <div className={`${BENTO_CELL} md:col-span-2 lg:col-span-2`}>
       <div className="mb-4 space-y-2">
         <div className="flex items-center justify-between">
-          <h4 className="flex items-center gap-2 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+          <h4 className="flex items-center gap-2 text-sm font-semibold text-foreground">
             <Gauge className="h-4 w-4 text-claude-lavender" />
             Air Quality History
           </h4>
@@ -226,8 +226,8 @@ function AirQualityChart() {
               onClick={() => setActiveMetric(key)}
               className={`rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors ${
                 activeMetric === key
-                  ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900"
-                  : "bg-neutral-100 text-neutral-500 hover:text-neutral-700 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
+                  ? "bg-[#f3efe6] text-[#070708]"
+                  : "bg-white/8 text-[#8b877c] hover:text-[#f3efe6]"
               }`}
             >
               {METRIC_CONFIG[key].label}
@@ -266,7 +266,7 @@ function TemperatureHumidityChart() {
     <div className={`${BENTO_CELL} md:col-span-2 lg:col-span-2`}>
       <div className="mb-4">
         <div className="flex items-center justify-between">
-          <h4 className="flex items-center gap-2 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+          <h4 className="flex items-center gap-2 text-sm font-semibold text-foreground">
             <Thermometer className="h-4 w-4 text-claude-orange" />
             Temperature & Humidity
           </h4>
@@ -309,7 +309,7 @@ function FilterStatus() {
 
   return (
     <div className={BENTO_CELL}>
-      <h4 className="mb-4 flex items-center gap-2 text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+      <h4 className="mb-4 flex items-center gap-2 text-sm font-semibold text-foreground">
         <Wind className="h-4 w-4 text-claude-lavender" />
         Filter Life
       </h4>
@@ -327,13 +327,13 @@ function FilterStatus() {
                   className={`text-sm font-bold ${
                     isLow
                       ? "text-claude-coral"
-                      : "text-neutral-900 dark:text-neutral-100"
+                      : "text-foreground"
                   }`}
                 >
                   {filter.remainingPercent}%
                 </span>
               </div>
-              <div className="h-3 w-full overflow-hidden rounded-full bg-claude-tan/50 dark:bg-neutral-700">
+              <div className="h-3 w-full overflow-hidden rounded-full bg-white/10">
                 <div
                   className={`h-full rounded-full transition-all ${
                     isLow ? "bg-claude-coral" : "bg-claude-lavender"
@@ -436,7 +436,7 @@ export function DysonAirPurifier() {
           <Wind className="h-5 w-5 text-claude-lavender" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+          <h3 className="text-lg font-semibold text-foreground">
             {data.model}
           </h3>
           <p className="text-xs text-neutral-500 dark:text-neutral-400">

--- a/apps/homelab/components/ui/card.tsx
+++ b/apps/homelab/components/ui/card.tsx
@@ -16,7 +16,7 @@ const Card = React.forwardRef<
   <SharedCard
     ref={ref}
     className={cn(
-      "rounded-[8px] border border-black/10 bg-background text-foreground shadow-none dark:border-white/12",
+      "rounded-[8px] border border-white/10 bg-card text-card-foreground shadow-none",
       className,
     )}
     {...props}

--- a/apps/homelab/src/routes/__root.tsx
+++ b/apps/homelab/src/routes/__root.tsx
@@ -25,16 +25,6 @@ export const Route = createRootRoute({
       { name: "description", content: homelabConfig.metadata.description },
     ],
     links: [
-      { rel: "preconnect", href: "https://fonts.googleapis.com" },
-      {
-        rel: "preconnect",
-        href: "https://fonts.gstatic.com",
-        crossOrigin: "anonymous",
-      },
-      {
-        rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap",
-      },
       { rel: "icon", href: "/favicon.svg", sizes: "any" },
     ],
   }),
@@ -47,14 +37,14 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>
       <body>
-        <ThemeProvider>
+        <ThemeProvider forcedTheme="dark" defaultTheme="dark" enableSystem={false}>
           <div className="relative flex min-h-screen flex-col justify-between overflow-x-hidden bg-background text-foreground subpixel-antialiased">
-            <SiteHeader currentApp="homelab" />
+            <SiteHeader currentApp="homelab" hideThemeToggle />
             <main className="relative z-10 flex-grow">
               <Outlet />
             </main>

--- a/apps/homelab/src/routes/index.tsx
+++ b/apps/homelab/src/routes/index.tsx
@@ -33,23 +33,23 @@ function HomelabPage() {
   return (
     <div>
       <section className="mx-auto max-w-[var(--rd-maxw)] px-[var(--rd-pad)] pt-[clamp(32px,4.5vw,56px)] pb-[clamp(22px,3vw,36px)]">
-        <h1 className="rd-display text-[clamp(2.4rem,5.5vw,4rem)]">
+        <h1 className="rd-display text-[clamp(2.4rem,5.5vw,4rem)] text-[#f3efe6]">
           Homelab, a{" "}
-          <span className="text-[var(--rd-accent)]">k3s cluster</span>.
+          <span className="text-[#f0a060]">k3s cluster</span>.
         </h1>
-        <p className="rd-lead mt-[16px] max-w-[64ch] text-[clamp(1.02rem,1.4vw,1.18rem)]">
+        <p className="rd-lead mt-[16px] max-w-[64ch] text-[clamp(1.02rem,1.4vw,1.18rem)] text-[#8b877c]">
           {INTRO}
         </p>
-        <div className="mt-[16px] flex flex-wrap items-center gap-5 font-[var(--font-mono)] text-[13px] text-[var(--rd-text-3)]">
+        <div className="mt-[16px] flex flex-wrap items-center gap-5 font-[var(--font-mono)] text-[13px] text-[#8b877c]">
           <span className="inline-flex items-center gap-2">
             <StatusDot status={onlineCount === totalNodes ? "online" : "degraded"} />
-            <strong className="text-[var(--rd-accent)]">
+            <strong className="text-[#f0a060]">
               {onlineCount}/{totalNodes}
             </strong>{" "}
             nodes
           </span>
           <span>
-            <strong className="text-[var(--rd-accent)]">
+            <strong className="text-[#f0a060]">
               {stats.runningServices}/{stats.totalServices}
             </strong>{" "}
             services
@@ -67,7 +67,7 @@ function HomelabPage() {
             <a
               key={s.id}
               href={`#${s.id}`}
-              className="shrink-0 text-[16px] tracking-tight text-[var(--rd-text-3)] no-underline transition-colors hover:text-[var(--rd-text)]"
+              className="shrink-0 text-[16px] tracking-tight text-[#8b877c] no-underline transition-colors hover:text-[#f3efe6]"
             >
               {s.label}
             </a>

--- a/packages/components/ThemeProvider.tsx
+++ b/packages/components/ThemeProvider.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { ThemeProvider } from "next-themes";
+import { ThemeProvider, type ThemeProviderProps } from "next-themes";
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+export default function Providers({
+  children,
+  ...props
+}: ThemeProviderProps) {
   return (
     <ThemeProvider
       defaultTheme="system"
       attribute="class"
       enableSystem={true}
       disableTransitionOnChange
+      {...props}
     >
       {children}
     </ThemeProvider>

--- a/packages/components/site-header/SiteHeader.tsx
+++ b/packages/components/site-header/SiteHeader.tsx
@@ -16,6 +16,7 @@ export function SiteHeader({
   localNav,
   activeHref,
   className,
+  hideThemeToggle = false,
 }: SiteHeaderProps) {
   return (
     <header
@@ -32,11 +33,15 @@ export function SiteHeader({
         <div className="ml-auto flex shrink-0 items-center gap-1">
           <MobileNav currentApp={currentApp} localNav={localNav} />
           <GlobalNav currentApp={currentApp} localNav={localNav} />
-          <Separator
-            orientation="vertical"
-            className="mx-1 hidden h-6 md:block"
-          />
-          <ThemeButton />
+          {!hideThemeToggle && (
+            <>
+              <Separator
+                orientation="vertical"
+                className="mx-1 hidden h-6 md:block"
+              />
+              <ThemeButton />
+            </>
+          )}
         </div>
       </div>
     </header>

--- a/packages/components/site-header/types.ts
+++ b/packages/components/site-header/types.ts
@@ -69,4 +69,5 @@ export interface SiteHeaderProps {
   localNav?: LocalNavItem[];
   activeHref?: string;
   className?: string;
+  hideThemeToggle?: boolean;
 }


### PR DESCRIPTION
## Summary
Lock [homelab.duyet.net](https://homelab.duyet.net/) to dark mode and restyle it as a night-ops console.

## Changes
- Force `dark` on html and ThemeProvider; hide the theme toggle
- Warm charcoal canvas, paper text, phosphor amber stats
- Hairline white/10 tiles and a faint amber hero wash
- Dark-first device toggles (no inverted light chips)

## Verify
- `pnpm --filter homelab run check-types`
- `pnpm --filter homelab run test`

## Summary by Sourcery

Lock the homelab dashboard to dark mode and apply a cohesive night-operations visual treatment across its interface.

New Features:
- Allow site headers to hide the theme toggle when an application requires a fixed color scheme.

Enhancements:
- Adopt a cohesive dark night-ops visual theme for the homelab dashboard, including warm charcoal surfaces, paper-colored text, amber highlights, and subtle translucent borders.
- Align dashboard cards, statistics, charts, device statuses, and controls with the dark-first visual system.
- Use the local Geist font instead of loading Inter from Google Fonts.