### PR TITLE
fix(home): paint prerendered HTML before hydrating

### DIFF
--- a/apps/home/src/client.tsx
+++ b/apps/home/src/client.tsx
@@ -2,18 +2,37 @@ import { StartClient } from "@tanstack/react-start/client";
 import { StrictMode, startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 
+/**
+ * Mark the entry as executed immediately, then hydrate after first paint.
+ * `__CF_ENTRY_RAN__` means the module ran (not that hydrateRoot finished) so
+ * the 800ms Cloudflare retry does not import a second copy and blank the page.
+ */
+function afterFirstPaint(fn: () => void) {
+  const run = () => {
+    if (typeof requestIdleCallback === "function") {
+      requestIdleCallback(() => fn(), { timeout: 1500 });
+      return;
+    }
+    setTimeout(fn, 0);
+  };
+  if (document.readyState === "complete") run();
+  else window.addEventListener("load", run, { once: true });
+}
+
 const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
 if (w.__CF_ENTRY_RAN__) {
   // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
   // instance). Skip so hydrateRoot does not run twice and blank the page.
 } else {
   w.__CF_ENTRY_RAN__ = true;
-  startTransition(() => {
-    hydrateRoot(
-      document,
-      <StrictMode>
-        <StartClient />
-      </StrictMode>,
-    );
+  afterFirstPaint(() => {
+    startTransition(() => {
+      hydrateRoot(
+        document,
+        <StrictMode>
+          <StartClient />
+        </StrictMode>,
+      );
+    });
   });
 }

--- a/scripts/patch-html-for-cloudflare.test.ts
+++ b/scripts/patch-html-for-cloudflare.test.ts
@@ -8,6 +8,7 @@ import {
   rewriteHydrationRetryHtml,
   SAME_URL_FIRST_RETRY_IMPORT,
 } from "../apps/home/functions/_middleware";
+import { preferStaticFirstPaint } from "./patch-html-for-cloudflare";
 
 const source = readFileSync(
   join(dirname(fileURLToPath(import.meta.url)), "patch-html-for-cloudflare.ts"),
@@ -53,17 +54,38 @@ describe("home Pages Function rewrites the old cache-busting retry", () => {
 });
 
 describe("home TanStack client entry", () => {
+  const client = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../apps/home/src/client.tsx"),
+    "utf8",
+  );
+
   it("sets __CF_ENTRY_RAN__ before hydrateRoot so the CF retry does not run twice", () => {
-    const client = readFileSync(
-      join(
-        dirname(fileURLToPath(import.meta.url)),
-        "../apps/home/src/client.tsx",
-      ),
-      "utf8",
-    );
     const flag = client.indexOf("w.__CF_ENTRY_RAN__ = true");
     const hydrate = client.indexOf("hydrateRoot(");
     expect(flag).toBeGreaterThan(0);
     expect(hydrate).toBeGreaterThan(flag);
+  });
+
+  it("hydrates after first paint so prerendered HTML is the first body", () => {
+    expect(client).toContain("afterFirstPaint");
+    expect(client).toContain("requestIdleCallback");
+    expect(client.indexOf("afterFirstPaint")).toBeLessThan(
+      client.indexOf("hydrateRoot("),
+    );
+  });
+});
+
+describe("preferStaticFirstPaint", () => {
+  it("puts CSS before JS and drops head modulepreloads", () => {
+    const html = `<html><head><link rel="modulepreload" href="/assets/main-abc.js"/><link rel="icon" href="/icon.svg"/><link rel="stylesheet" href="/assets/main-abc.css#" type="text/css"/></head><body><main>Building agent workflows</main><script type="module">import("/assets/main-abc.js")</script></body></html>`;
+    const out = preferStaticFirstPaint(html);
+    expect(out).toContain("Building agent workflows");
+    expect(out).not.toContain("modulepreload");
+    expect(out).toContain('href="/assets/main-abc.css"');
+    expect(out).not.toContain(".css#");
+    expect(out.indexOf('rel="stylesheet"')).toBeLessThan(
+      out.indexOf('rel="icon"'),
+    );
+    expect(out).toContain('import("/assets/main-abc.js")');
   });
 });

--- a/scripts/patch-html-for-cloudflare.ts
+++ b/scripts/patch-html-for-cloudflare.ts
@@ -48,6 +48,27 @@ let files = 0;
 let tags = 0;
 let retries = 0;
 
+/**
+ * Prerendered pages already contain the full body. Head `modulepreload` of the
+ * 600kB+ client graph races the stylesheet, so first paint looks like the body
+ * arrived later. Drop those preloads (the body module script still loads JS)
+ * and put stylesheets first in `<head>`.
+ */
+export function preferStaticFirstPaint(html: string): string {
+  let out = html.replace(/<link\b[^>]*rel="modulepreload"[^>]*>/gi, "");
+  const sheets = [
+    ...out.matchAll(/<link\b[^>]*rel=["']stylesheet["'][^>]*>/gi),
+  ].map((m) => m[0]);
+  if (sheets.length === 0) return out;
+  for (const sheet of sheets) {
+    out = out.replace(sheet, "");
+  }
+  const cleaned = sheets.map((sheet) =>
+    sheet.replace(/(\.css)#(["'\s>])/g, "$1$2"),
+  );
+  return out.replace(/<head([^>]*)>/i, `<head$1>${cleaned.join("")}`);
+}
+
 function patchHtmlFiles(dir: string) {
   for (const entry of readdirSync(dir)) {
     const filePath = join(dir, entry);
@@ -59,7 +80,7 @@ function patchHtmlFiles(dir: string) {
 
     const original = readFileSync(filePath, "utf8");
     let count = 0;
-    let updated = original.replace(SCRIPT_OPEN, () => {
+    let updated = preferStaticFirstPaint(original).replace(SCRIPT_OPEN, () => {
       count += 1;
       return '<script data-cfasync="false"';
     });
@@ -81,7 +102,13 @@ function patchHtmlFiles(dir: string) {
   }
 }
 
-patchHtmlFiles(distDir);
-console.log(
-  `Rocket Loader opt-out: tagged ${tags} <script> tags across ${files} HTML files; hydration retry on ${retries} files.`,
-);
+const launched = process.argv[1]?.replace(/\\/g, "/") ?? "";
+if (
+  launched.endsWith("patch-html-for-cloudflare.ts") ||
+  launched.endsWith("patch-html-for-cloudflare.js")
+) {
+  patchHtmlFiles(distDir);
+  console.log(
+    `Rocket Loader opt-out: tagged ${tags} <script> tags across ${files} HTML files; hydration retry on ${retries} files.`,
+  );
+}


### PR DESCRIPTION
## Why

`https://duyet.net/` already prerenders the full body as static HTML. Head `modulepreload` of the 600kB client graph and immediate `hydrateRoot` made the body look like it arrived with JS.

Does **not** change #1339 marker semantics: `__CF_ENTRY_RAN__` still means the entry executed and is set before `hydrateRoot`.

## What

- Drop head `modulepreload`s and put the stylesheet first so HTML+CSS win first paint
- Hydrate on idle after `load` so nav/theme still work after first paint
- `__CF_ENTRY_RAN__` is still set as soon as the entry runs

## Test

`preferStaticFirstPaint` fixture + client entry still sets the flag before `hydrateRoot(`

## Summary by Sourcery

Prioritize static content for first paint by optimizing generated HTML and deferring client hydration until the page has loaded and the browser is idle.

Bug Fixes:
- Prioritize prerendered HTML and CSS for the initial page paint before client hydration.

Enhancements:
- Defer hydration until after the window load event and browser idle time while preserving the existing Cloudflare entry-execution marker semantics.
- Make the Cloudflare HTML patching utility safe to import for testing without automatically processing the distribution directory.

Tests:
- Add coverage for first-paint HTML rewriting, stylesheet ordering, modulepreload removal, and deferred hydration behavior.