### PR TITLE
fix(blog): keep prerendered pages visible after hydrate

### DIFF
--- a/apps/agent-assistant/src/entry-client.tsx
+++ b/apps/agent-assistant/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/ai-percentage/src/entry-client.tsx
+++ b/apps/ai-percentage/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/ai-percentage/src/router.tsx
+++ b/apps/ai-percentage/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/blog/lib/__tests__/resolve-article-html.test.ts
+++ b/apps/blog/lib/__tests__/resolve-article-html.test.ts
@@ -1,0 +1,43 @@
+import type { Post } from "@duyet/interfaces";
+import { describe, expect, it } from "vitest";
+import { type PostContent, resolveArticleHtml } from "../posts";
+
+function post(
+  overrides: Partial<Post & PostContent> & Pick<PostContent, "content">
+): Post & PostContent {
+  return {
+    slug: "/2026/08/grok-bot",
+    title: "Grok Bot",
+    date: new Date("2026-08-19"),
+    category: "AI",
+    category_slug: "ai",
+    tags: [],
+    tags_slug: [],
+    featured: false,
+    isMDX: false,
+    ...overrides,
+  };
+}
+
+describe("resolveArticleHtml", () => {
+  it("uses prebuilt html so hydrate does not wait on markdown", async () => {
+    const result = await resolveArticleHtml(
+      post({ content: "# unused", html: "<p>Hello from prerender</p>" })
+    );
+    expect(result.htmlContent).toContain("Hello from prerender");
+    expect(result.mdxSource).toBeUndefined();
+  });
+
+  it("returns mdxSource plus static html for MDX posts", async () => {
+    const result = await resolveArticleHtml(
+      post({
+        isMDX: true,
+        content: "hello **world**",
+        html: "<p>hello <strong>world</strong></p>",
+      })
+    );
+    expect(result.mdxSource).toBe("hello **world**");
+    expect(result.htmlContent).toContain("hello");
+    expect(result.htmlContent).toContain("strong");
+  });
+});

--- a/apps/blog/lib/posts.ts
+++ b/apps/blog/lib/posts.ts
@@ -10,6 +10,7 @@
 
 import type { CategoryCount, Post, Series, TagCount } from "@duyet/interfaces";
 import { getSlug } from "@duyet/libs/getSlug";
+import { embedXPosts } from "./x-embed";
 
 const isServer = typeof window === "undefined";
 
@@ -168,6 +169,38 @@ export async function getPostBySlug(
   if (!post) throw new Error(`Post not found: ${slugPath}`);
   const content = await fetchPostContent(post.slug);
   return { ...post, ...content };
+}
+
+/**
+ * Static article HTML for prerender and hydrate. Prefer build-time `html`
+ * so the page never waits on WASM/MDX compile. Client navigation falls back
+ * to marked only when that payload is missing.
+ */
+export async function resolveArticleHtml(
+  post: Post & PostContent
+): Promise<{ htmlContent: string; mdxSource?: string }> {
+  const markdownContent = post.content || "";
+  const mdxSource = post.isMDX ? markdownContent : undefined;
+
+  let html = post.html || "";
+  if (!html && markdownContent) {
+    if (typeof window === "undefined") {
+      const { markdownToHtml } = await import("@duyet/libs/markdownToHtml");
+      html = await markdownToHtml(markdownContent);
+    } else {
+      console.warn(
+        "posts-content missing html; using marked client fallback:",
+        post.slug
+      );
+      const { marked } = await import("marked");
+      html = String(await marked.parse(markdownContent));
+    }
+  }
+
+  return {
+    htmlContent: html ? embedXPosts(html) : "",
+    mdxSource,
+  };
 }
 
 export async function getAllCategories(): Promise<CategoryCount> {
@@ -383,7 +416,6 @@ export async function getChildNavigation(
 
   return {
     prev: index > 0 ? toNavItem(siblings[index - 1]) : null,
-    next:
-      index < siblings.length - 1 ? toNavItem(siblings[index + 1]) : null,
+    next: index < siblings.length - 1 ? toNavItem(siblings[index + 1]) : null,
   };
 }

--- a/apps/blog/scripts/generate-posts-data.ts
+++ b/apps/blog/scripts/generate-posts-data.ts
@@ -223,21 +223,26 @@ for (const post of allPostsWithContent) {
     payload.widgets = resolvedWidgets;
   }
 
-  // Pre-convert .md content to HTML so the route loader can skip
-  // markdownToHtml (WASM) during prerender/build. Missing html on the
-  // client leaves the body as "No content" — fail the build instead.
-  if (!payload.isMDX && processedMarkdown) {
+  // Pre-convert markdown/MDX to HTML so prerendered pages ship a full
+  // article body. MDX still compiles on the client for Mermaid/JSX, but
+  // the static HTML is the hydrate fallback so the post cannot go blank.
+  if (processedMarkdown) {
     try {
       payload.html = embedXPosts(await markdownToHtml(processedMarkdown));
       if (!payload.html?.trim()) {
-        conversionFailures.push(`${key}: empty HTML output`);
+        if (!payload.isMDX)
+          conversionFailures.push(`${key}: empty HTML output`);
       } else {
         htmlConverted++;
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      conversionFailures.push(`${key}: ${msg}`);
-      console.error(`  ✗ Failed to convert ${key}: ${msg}`);
+      if (payload.isMDX) {
+        console.warn(`  ⚠ MDX static HTML fallback failed for ${key}: ${msg}`);
+      } else {
+        conversionFailures.push(`${key}: ${msg}`);
+        console.error(`  ✗ Failed to convert ${key}: ${msg}`);
+      }
     }
   }
 

--- a/apps/blog/src/entry-client.test.ts
+++ b/apps/blog/src/entry-client.test.ts
@@ -1,0 +1,25 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const appsDir = join(repoRoot, "apps");
+
+function listEntryClients(): string[] {
+  return readdirSync(appsDir)
+    .map((app) => join(appsDir, app, "src/entry-client.tsx"))
+    .filter((path) => existsSync(path));
+}
+
+describe("static app hydrate guard", () => {
+  it("sets __CF_ENTRY_RAN__ before hydrateRoot so CF retry cannot remount", () => {
+    const entries = listEntryClients();
+    expect(entries.length).toBeGreaterThan(8);
+    for (const path of entries) {
+      const source = readFileSync(path, "utf8");
+      expect(source, path).toContain("__CF_ENTRY_RAN__");
+      expect(source, path).toContain("hydrateRoot(document, <StartClient />)");
+    }
+  });
+});

--- a/apps/blog/src/entry-client.tsx
+++ b/apps/blog/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/blog/src/router.test.ts
+++ b/apps/blog/src/router.test.ts
@@ -1,0 +1,43 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+const appsDir = join(repoRoot, "apps");
+
+const staticApps = [
+  "blog",
+  "home",
+  "cv",
+  "kb",
+  "insights",
+  "photos",
+  "homelab",
+  "llm-timeline",
+  "burns",
+  "ai-percentage",
+  "x-algo",
+];
+
+describe("static app routers keep prerendered loader data", () => {
+  it("sets defaultStaleTime to Infinity so hydrate does not refetch", () => {
+    for (const app of staticApps) {
+      const path = join(appsDir, app, "src/router.tsx");
+      expect(existsSync(path), path).toBe(true);
+      const source = readFileSync(path, "utf8");
+      expect(source, path).toContain(
+        "defaultStaleTime: Number.POSITIVE_INFINITY"
+      );
+    }
+  });
+
+  it("covers every pages app with a router.tsx", () => {
+    const routers = readdirSync(appsDir).filter((app) =>
+      existsSync(join(appsDir, app, "src/router.tsx"))
+    );
+    for (const app of staticApps) {
+      expect(routers).toContain(app);
+    }
+  });
+});

--- a/apps/blog/src/router.tsx
+++ b/apps/blog/src/router.tsx
@@ -7,6 +7,9 @@ export function getRouter() {
     defaultPreload: "intent",
     scrollRestoration: true,
     trailingSlash: "always",
+    // Prerendered HTML is the source of truth. Do not refetch loaders on
+    // hydrate (default staleTime is 0) — that pending swap blanks the post.
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/blog/src/routes/$year/$month/$slug/$child.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug/$child.tsx
@@ -6,9 +6,10 @@ import {
   type ChildNavItem,
   fetchAllPosts,
   getChildren,
-  getRelatedPosts,
   getPostBySlug,
+  getRelatedPosts,
   getSeries,
+  resolveArticleHtml,
 } from "@/lib/posts";
 import "@/styles/post-reader.css";
 import { ChildBreadcrumb } from "../-breadcrumb";
@@ -80,26 +81,8 @@ export const Route = createFileRoute("/$year/$month/$slug/$child")({
     const file = `${year}/${month}/${slug}/${child}.${sourceExt}`;
     const edit_url = `${repoUrl}/edit/master/apps/blog/_posts/${file}`;
 
-    let htmlContent = "";
-    let mdxSource: string | undefined;
-
-    if (postWithContent.isMDX) {
-      mdxSource = markdownContent;
-    } else if (postWithContent.html) {
-      htmlContent = postWithContent.html;
-    } else if (markdownContent) {
-      if (typeof window === "undefined") {
-        const { markdownToHtml } = await import("@duyet/libs/markdownToHtml");
-        htmlContent = await markdownToHtml(markdownContent);
-      } else {
-        console.warn(
-          "posts-content missing html; using marked client fallback:",
-          slugPath
-        );
-        const { marked } = await import("marked");
-        htmlContent = await marked.parse(markdownContent);
-      }
-    }
+    const { htmlContent, mdxSource } =
+      await resolveArticleHtml(postWithContent);
 
     const related = await getRelatedPosts(postWithContent, 3);
 
@@ -141,7 +124,13 @@ export const Route = createFileRoute("/$year/$month/$slug/$child")({
       edit_url,
     };
 
-    return { post, parentTitle, siblings: siblings.map(toNavItem), series, related };
+    return {
+      post,
+      parentTitle,
+      siblings: siblings.map(toNavItem),
+      series,
+      related,
+    };
   },
   component: ChildPostPage,
 });

--- a/apps/blog/src/routes/$year/$month/$slug/index.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug/index.tsx
@@ -2,13 +2,14 @@ import type { Post, Series } from "@duyet/interfaces";
 import { extractHeadings } from "@duyet/libs/extractHeadings";
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { ReadingProgress } from "@/components/post/ReadingProgress";
-import { embedXPosts, TWITTER_WIDGETS_SRC } from "@/lib/x-embed";
 import {
   getChildren,
   getPostBySlug,
   getRelatedPosts,
   getSeries,
+  resolveArticleHtml,
 } from "@/lib/posts";
+import { TWITTER_WIDGETS_SRC } from "@/lib/x-embed";
 import "@/styles/post-reader.css";
 import { Chapters } from "../-chapters";
 import Content from "../-content";
@@ -88,29 +89,8 @@ export const Route = createFileRoute("/$year/$month/$slug/")({
     const file = `${year}/${month}/${slug}.md`;
     const edit_url = `${repoUrl}/edit/master/apps/blog/_posts/${file}`;
 
-    let htmlContent = "";
-    let mdxSource: string | undefined;
-
-    if (postWithContent.isMDX) {
-      mdxSource = markdownContent;
-    } else if (postWithContent.html) {
-      htmlContent = embedXPosts(postWithContent.html);
-    } else if (markdownContent) {
-      // Prefer prebuilt html from posts-content/*.json. Fallback:
-      // - server/prerender: full WASM pipeline (KaTeX, highlight)
-      // - client: marked so SPA navigations never paint "No content"
-      if (typeof window === "undefined") {
-        const { markdownToHtml } = await import("@duyet/libs/markdownToHtml");
-        htmlContent = embedXPosts(await markdownToHtml(markdownContent));
-      } else {
-        console.warn(
-          "posts-content missing html; using marked client fallback:",
-          slugPath
-        );
-        const { marked } = await import("marked");
-        htmlContent = embedXPosts(String(await marked.parse(markdownContent)));
-      }
-    }
+    const { htmlContent, mdxSource } =
+      await resolveArticleHtml(postWithContent);
 
     const series = postWithContent.series
       ? await getSeries({ name: postWithContent.series as string })

--- a/apps/blog/src/routes/$year/$month/-content.test.ts
+++ b/apps/blog/src/routes/$year/$month/-content.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "-content.tsx"),
+  "utf8"
+);
+
+describe("post content static HTML", () => {
+  it("keeps prerendered HTML while MDX compiles", () => {
+    expect(source).toContain("Suspense");
+    expect(source).toContain("fallback={staticArticle}");
+    expect(source).toContain("dangerouslySetInnerHTML");
+  });
+});

--- a/apps/blog/src/routes/$year/$month/-content.tsx
+++ b/apps/blog/src/routes/$year/$month/-content.tsx
@@ -3,7 +3,7 @@ import type { TOCItem } from "@duyet/libs/extractHeadings";
 import { cn } from "@duyet/libs/utils";
 import { compile, run } from "@mdx-js/mdx";
 import { common } from "lowlight";
-import { Fragment, use, useEffect, useRef } from "react";
+import { Fragment, Suspense, use, useEffect, useRef } from "react";
 import * as runtime from "react/jsx-runtime";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
@@ -185,6 +185,15 @@ function MDXRenderer({ source }: { source: string }) {
 export default function Content({ post }: { post: ContentPost }) {
   const copyRef = useCodeCopyButtons();
   useTwitterWidgets();
+  const html = embedXPosts(post.content || "");
+  const staticArticle = (
+    <article
+      className={typesetClassName}
+      dangerouslySetInnerHTML={{
+        __html: html || (post.isMDX ? "" : "No content"),
+      }}
+    />
+  );
 
   return (
     <>
@@ -192,14 +201,11 @@ export default function Content({ post }: { post: ContentPost }) {
 
       <div ref={copyRef} className="contents">
         {post.isMDX && post.mdxSource ? (
-          <MDXRenderer source={post.mdxSource} />
+          <Suspense fallback={staticArticle}>
+            <MDXRenderer source={post.mdxSource} />
+          </Suspense>
         ) : (
-          <article
-            className={typesetClassName}
-            dangerouslySetInnerHTML={{
-              __html: embedXPosts(post.content || "No content"),
-            }}
-          />
+          staticArticle
         )}
       </div>
 

--- a/apps/blog/src/routes/__root.hydrate.test.ts
+++ b/apps/blog/src/routes/__root.hydrate.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+describe("blog root hydrate", () => {
+  it("suppresses theme class mismatches on html/body", () => {
+    const source = readFileSync(join(dir, "__root.tsx"), "utf8");
+    expect(source).toContain('<html lang="en" suppressHydrationWarning>');
+    expect(source).toContain("<body suppressHydrationWarning>");
+  });
+});

--- a/apps/blog/src/routes/__root.tsx
+++ b/apps/blog/src/routes/__root.tsx
@@ -1,18 +1,17 @@
-import '@duyet/components/styles.css'
-import '../../app/globals.css'
-import '../../styles/blog-design.css'
+import "@duyet/components/styles.css";
+import "../../app/globals.css";
+import "../../styles/blog-design.css";
 
-import { SiteFooter, SiteHeader } from '@duyet/components'
-import Analytics from '@duyet/components/Analytics'
-import ThemeProvider from '@duyet/components/ThemeProvider'
+import { SiteFooter, SiteHeader } from "@duyet/components";
+import Analytics from "@duyet/components/Analytics";
+import ThemeProvider from "@duyet/components/ThemeProvider";
 import {
   createRootRoute,
   HeadContent,
   Outlet,
   Scripts,
-  useRouterState,
-} from '@tanstack/react-router'
-import { ServiceWorkerRegister } from '@/components/ServiceWorkerRegister'
+} from "@tanstack/react-router";
+import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 
 function NotFoundComponent() {
   return (
@@ -48,55 +47,60 @@ function NotFoundComponent() {
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 const siteFooterLinks = [
-  { label: 'Home', href: 'https://duyet.net' },
-  { label: 'Blog', href: 'https://blog.duyet.net' },
-  { label: 'CV', href: 'https://cv.duyet.net' },
-  { label: 'Insights', href: 'https://insights.duyet.net' },
-]
+  { label: "Home", href: "https://duyet.net" },
+  { label: "Blog", href: "https://blog.duyet.net" },
+  { label: "CV", href: "https://cv.duyet.net" },
+  { label: "Insights", href: "https://insights.duyet.net" },
+];
 
 export const Route = createRootRoute({
   head: () => ({
     meta: [
-      { charSet: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1.0' },
-      { name: 'robots', content: 'follow, index' },
-      { title: 'Tôi là Duyệt | blog.duyet.net' },
+      { charSet: "utf-8" },
+      { name: "viewport", content: "width=device-width, initial-scale=1.0" },
+      { name: "robots", content: "follow, index" },
+      { title: "Tôi là Duyệt | blog.duyet.net" },
       {
-        name: 'description',
+        name: "description",
         content:
-          'Sr. Data Engineer. Rustacean at night. Technical blog on data engineering, distributed systems, and open source.',
+          "Sr. Data Engineer. Rustacean at night. Technical blog on data engineering, distributed systems, and open source.",
       },
     ],
     links: [
-      { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-      { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' },
-      { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap' },
-      { rel: 'icon', href: '/favicon.ico' },
+      { rel: "preconnect", href: "https://fonts.googleapis.com" },
       {
-        rel: 'alternate',
-        type: 'application/rss+xml',
-        href: '/rss.xml',
-        title: 'Tôi là Duyệt - RSS Feed',
+        rel: "preconnect",
+        href: "https://fonts.gstatic.com",
+        crossOrigin: "anonymous",
+      },
+      {
+        rel: "stylesheet",
+        href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap",
+      },
+      { rel: "icon", href: "/favicon.ico" },
+      {
+        rel: "alternate",
+        type: "application/rss+xml",
+        href: "/rss.xml",
+        title: "Tôi là Duyệt - RSS Feed",
       },
     ],
   }),
   notFoundComponent: NotFoundComponent,
   component: RootComponent,
-})
+});
 
 function RootComponent() {
-  const pathname = useRouterState({ select: (s) => s.location.pathname })
-
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>
-      <body>
+      <body suppressHydrationWarning>
         <ThemeProvider>
           <div className="blog-editorial-shell min-h-screen relative bg-background text-foreground overflow-x-hidden flex flex-col justify-between subpixel-antialiased">
             <SiteHeader currentApp="blog" />
@@ -113,5 +117,5 @@ function RootComponent() {
         <Scripts />
       </body>
     </html>
-  )
+  );
 }

--- a/apps/burns/src/entry-client.tsx
+++ b/apps/burns/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/burns/src/router.tsx
+++ b/apps/burns/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/cv/src/entry-client.tsx
+++ b/apps/cv/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/cv/src/router.tsx
+++ b/apps/cv/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/cv/src/routes/__root.tsx
+++ b/apps/cv/src/routes/__root.tsx
@@ -101,11 +101,11 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>
-      <body>
+      <body suppressHydrationWarning>
         <ThemeProvider>
           <main>
             <Container className="mb-20 mt-10 min-h-screen max-w-3xl md:mt-20">

--- a/apps/home/src/router.tsx
+++ b/apps/home/src/router.tsx
@@ -20,6 +20,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
   const originalUpdate = router.update.bind(router);
   router.update = ((opts: object) => {

--- a/apps/homelab/src/entry-client.tsx
+++ b/apps/homelab/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/homelab/src/router.tsx
+++ b/apps/homelab/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/insights/src/entry-client.tsx
+++ b/apps/insights/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/insights/src/router.tsx
+++ b/apps/insights/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/kb/src/entry-client.tsx
+++ b/apps/kb/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/kb/src/router.tsx
+++ b/apps/kb/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/llm-timeline/src/entry-client.tsx
+++ b/apps/llm-timeline/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/llm-timeline/src/router.tsx
+++ b/apps/llm-timeline/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/news/src/entry-client.tsx
+++ b/apps/news/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/photos/src/entry-client.tsx
+++ b/apps/photos/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/photos/src/router.tsx
+++ b/apps/photos/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 

--- a/apps/x-algo/src/entry-client.tsx
+++ b/apps/x-algo/src/entry-client.tsx
@@ -1,4 +1,10 @@
 import { StartClient } from "@tanstack/react-start/client";
 import { hydrateRoot } from "react-dom/client";
 
-hydrateRoot(document, <StartClient />);
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry script may re-import this module; do not hydrate twice.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  hydrateRoot(document, <StartClient />);
+}

--- a/apps/x-algo/src/router.tsx
+++ b/apps/x-algo/src/router.tsx
@@ -6,6 +6,7 @@ export function getRouter() {
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
+    defaultStaleTime: Number.POSITIVE_INFINITY,
   });
 }
 


### PR DESCRIPTION
## Summary
- Blog posts were complete static HTML, then went blank after JS loaded.
- Cloudflare retry remounted `hydrateRoot` because `__CF_ENTRY_RAN__` was unset (same bug home already fixed).
- Loader `staleTime` defaulted to 0, so hydrate could swap the prerendered post for an empty pending state.
- Applied the hydrate-once guard and `defaultStaleTime: Infinity` across static apps. MDX now falls back to build-time HTML.

## Test plan
- [x] `cd apps/blog && pnpm run test`
- [ ] Open https://blog.duyet.net/2026/08/grok-bot/ and confirm the article stays after load
- [ ] Check homepage, archives, a note, and an MDX post
- [ ] Spot-check kb/cv/home after their deploys

## Summary by Sourcery

Keep prerendered content stable after hydration across the blog and other static applications.

Bug Fixes:
- Keep prerendered blog articles visible through hydration and client-side loading.
- Prevent Cloudflare retries from mounting static applications more than once.
- Preserve static HTML while MDX content compiles and provide build-time HTML fallbacks.

Enhancements:
- Configure static applications to treat prerendered loader data as indefinitely fresh during hydration.
- Centralize article HTML resolution for consistent prerender and navigation behavior.
- Suppress expected root-level hydration warnings from theme-related markup differences.

Tests:
- Add coverage for article HTML resolution, static content fallbacks, hydration guards, router freshness settings, and root hydration behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate page hydration during client-side retries or reloading.
  * Reduced unnecessary data refetching while restoring prerendered pages.
  * Improved hydration stability by handling expected server/client markup differences.

* **Improvements**
  * Blog posts now use pre-rendered HTML more consistently, with improved Markdown and MDX rendering and embedded content support.
  * Added reliable fallback content while dynamic article content loads.

* **Tests**
  * Expanded coverage for hydration, routing, article rendering, and static content behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->