### PR TITLE
fix(blog): prerender posts and keep tests off WASM

### DIFF
--- a/apps/ai-percentage/src/router.tsx
+++ b/apps/ai-percentage/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/blog/lib/__tests__/resolve-article-html.test.ts
+++ b/apps/blog/lib/__tests__/resolve-article-html.test.ts
@@ -1,6 +1,12 @@
 import type { Post } from "@duyet/interfaces";
 import { describe, expect, it } from "vitest";
-import { type PostContent, resolveArticleHtml } from "../posts";
+import { resolveArticleHtml } from "../resolve-article-html";
+
+type PostContent = {
+  content: string;
+  isMDX?: boolean;
+  html?: string;
+};
 
 function post(
   overrides: Partial<Post & PostContent> & Pick<PostContent, "content">

--- a/apps/blog/lib/posts.ts
+++ b/apps/blog/lib/posts.ts
@@ -10,7 +10,6 @@
 
 import type { CategoryCount, Post, Series, TagCount } from "@duyet/interfaces";
 import { getSlug } from "@duyet/libs/getSlug";
-import { embedXPosts } from "./x-embed";
 
 const isServer = typeof window === "undefined";
 
@@ -169,38 +168,6 @@ export async function getPostBySlug(
   if (!post) throw new Error(`Post not found: ${slugPath}`);
   const content = await fetchPostContent(post.slug);
   return { ...post, ...content };
-}
-
-/**
- * Static article HTML for prerender and hydrate. Prefer build-time `html`
- * so the page never waits on WASM/MDX compile. Client navigation falls back
- * to marked only when that payload is missing.
- */
-export async function resolveArticleHtml(
-  post: Post & PostContent
-): Promise<{ htmlContent: string; mdxSource?: string }> {
-  const markdownContent = post.content || "";
-  const mdxSource = post.isMDX ? markdownContent : undefined;
-
-  let html = post.html || "";
-  if (!html && markdownContent) {
-    if (typeof window === "undefined") {
-      const { markdownToHtml } = await import("@duyet/libs/markdownToHtml");
-      html = await markdownToHtml(markdownContent);
-    } else {
-      console.warn(
-        "posts-content missing html; using marked client fallback:",
-        post.slug
-      );
-      const { marked } = await import("marked");
-      html = String(await marked.parse(markdownContent));
-    }
-  }
-
-  return {
-    htmlContent: html ? embedXPosts(html) : "",
-    mdxSource,
-  };
 }
 
 export async function getAllCategories(): Promise<CategoryCount> {

--- a/apps/blog/lib/resolve-article-html.ts
+++ b/apps/blog/lib/resolve-article-html.ts
@@ -1,0 +1,40 @@
+import type { Post } from "@duyet/interfaces";
+import { embedXPosts } from "./x-embed";
+
+type ArticleSource = Post & {
+  content?: string;
+  isMDX?: boolean;
+  html?: string;
+};
+
+/**
+ * Static article HTML for prerender and hydrate. Prefer build-time `html`
+ * so the page never waits on WASM/MDX compile. Client navigation falls back
+ * to marked only when that payload is missing.
+ */
+export async function resolveArticleHtml(
+  post: ArticleSource
+): Promise<{ htmlContent: string; mdxSource?: string }> {
+  const markdownContent = post.content || "";
+  const mdxSource = post.isMDX ? markdownContent : undefined;
+
+  let html = post.html || "";
+  if (!html && markdownContent) {
+    if (typeof window === "undefined") {
+      const { markdownToHtml } = await import("@duyet/libs/markdownToHtml");
+      html = await markdownToHtml(markdownContent);
+    } else {
+      console.warn(
+        "posts-content missing html; using marked client fallback:",
+        post.slug
+      );
+      const { marked } = await import("marked");
+      html = String(await marked.parse(markdownContent));
+    }
+  }
+
+  return {
+    htmlContent: html ? embedXPosts(html) : "",
+    mdxSource,
+  };
+}

--- a/apps/blog/src/__tests__/root.hydrate.test.ts
+++ b/apps/blog/src/__tests__/root.hydrate.test.ts
@@ -7,7 +7,7 @@ const dir = dirname(fileURLToPath(import.meta.url));
 
 describe("blog root hydrate", () => {
   it("suppresses theme class mismatches on html/body", () => {
-    const source = readFileSync(join(dir, "__root.tsx"), "utf8");
+    const source = readFileSync(join(dir, "../routes/__root.tsx"), "utf8");
     expect(source).toContain('<html lang="en" suppressHydrationWarning>');
     expect(source).toContain("<body suppressHydrationWarning>");
   });

--- a/apps/blog/src/router.test.ts
+++ b/apps/blog/src/router.test.ts
@@ -32,6 +32,15 @@ describe("static app routers keep prerendered loader data", () => {
     }
   });
 
+  it("shims router.stores.matches so prerender dehydrate does not crash", () => {
+    for (const app of staticApps) {
+      const path = join(appsDir, app, "src/router.tsx");
+      const source = readFileSync(path, "utf8");
+      expect(source, path).toContain("shimMatchesStore");
+      expect(source, path).toContain("activeMatchesSnapshot");
+    }
+  });
+
   it("covers every pages app with a router.tsx", () => {
     const routers = readdirSync(appsDir).filter((app) =>
       existsSync(join(appsDir, app, "src/router.tsx"))

--- a/apps/blog/src/router.tsx
+++ b/apps/blog/src/router.tsx
@@ -1,8 +1,25 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
@@ -11,6 +28,14 @@ export function getRouter() {
     // hydrate (default staleTime is 0) — that pending swap blanks the post.
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/blog/src/routes/$year/$month/$slug/$child.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug/$child.tsx
@@ -9,8 +9,8 @@ import {
   getPostBySlug,
   getRelatedPosts,
   getSeries,
-  resolveArticleHtml,
 } from "@/lib/posts";
+import { resolveArticleHtml } from "@/lib/resolve-article-html";
 import "@/styles/post-reader.css";
 import { ChildBreadcrumb } from "../-breadcrumb";
 import Content from "../-content";

--- a/apps/blog/src/routes/$year/$month/$slug/index.tsx
+++ b/apps/blog/src/routes/$year/$month/$slug/index.tsx
@@ -7,8 +7,8 @@ import {
   getPostBySlug,
   getRelatedPosts,
   getSeries,
-  resolveArticleHtml,
 } from "@/lib/posts";
+import { resolveArticleHtml } from "@/lib/resolve-article-html";
 import { TWITTER_WIDGETS_SRC } from "@/lib/x-embed";
 import "@/styles/post-reader.css";
 import { Chapters } from "../-chapters";

--- a/apps/burns/src/router.tsx
+++ b/apps/burns/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/cv/src/router.tsx
+++ b/apps/cv/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/homelab/src/router.tsx
+++ b/apps/homelab/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/insights/src/router.tsx
+++ b/apps/insights/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/kb/src/router.tsx
+++ b/apps/kb/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/llm-timeline/src/router.tsx
+++ b/apps/llm-timeline/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/photos/src/router.tsx
+++ b/apps/photos/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {

--- a/apps/x-algo/src/router.tsx
+++ b/apps/x-algo/src/router.tsx
@@ -1,13 +1,38 @@
 import { createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
+type LegacyStores = {
+  matches?: { get: () => unknown };
+  activeMatchesSnapshot?: { state?: unknown };
+};
+
+function shimMatchesStore(router: {
+  stores?: LegacyStores;
+  update: (opts: object) => unknown;
+}) {
+  const stores = router.stores;
+  if (stores && !stores.matches && stores.activeMatchesSnapshot) {
+    stores.matches = {
+      get: () => stores.activeMatchesSnapshot?.state ?? [],
+    };
+  }
+}
+
 export function getRouter() {
-  return createRouter({
+  const router = createRouter({
     routeTree,
     defaultPreload: "intent",
     scrollRestoration: true,
     defaultStaleTime: Number.POSITIVE_INFINITY,
   });
+  const originalUpdate = router.update.bind(router);
+  router.update = ((opts: object) => {
+    const result = originalUpdate(opts);
+    shimMatchesStore(router);
+    return result;
+  }) as typeof router.update;
+  shimMatchesStore(router);
+  return router;
 }
 
 declare module "@tanstack/react-router" {


### PR DESCRIPTION
## Summary
- Follow-up to #1341: prerender crashed on `router.stores.matches.get()`, so zero HTML pages were generated.
- Shim matches store like home so dehydrate works.
- Move article HTML helper off `posts.ts` so CI tests do not import WASM.

## Test plan
- [x] `cd apps/blog && pnpm run test` (96 passed)
- [x] Local blog build prerendered HTML (462 files)
- [ ] Live post stays visible after JS load

## Summary by Sourcery

Restore reliable static prerendering and hydration while keeping blog tests independent of WASM dependencies.

Bug Fixes:
- Prevent prerendering from failing when router dehydration accesses the matches store, allowing static HTML pages to be generated and preserved through hydration.

Enhancements:
- Apply the router compatibility shim across static applications.
- Move article HTML resolution into a standalone module so blog tests avoid importing WASM-dependent post code.

Tests:
- Add coverage for router match-store compatibility and update article HTML and hydration test imports.