### PR TITLE
fix(blog): hydrate from src/client.tsx so posts stay visible

### DIFF
--- a/apps/agent-assistant/src/client.tsx
+++ b/apps/agent-assistant/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/ai-percentage/src/client.tsx
+++ b/apps/ai-percentage/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/blog/src/client.tsx
+++ b/apps/blog/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>
+    );
+  });
+}

--- a/apps/blog/src/entry-client.test.ts
+++ b/apps/blog/src/entry-client.test.ts
@@ -6,20 +6,20 @@ import { describe, expect, it } from "vitest";
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../..");
 const appsDir = join(repoRoot, "apps");
 
-function listEntryClients(): string[] {
+function listClientEntries(): string[] {
   return readdirSync(appsDir)
-    .map((app) => join(appsDir, app, "src/entry-client.tsx"))
+    .map((app) => join(appsDir, app, "src/client.tsx"))
     .filter((path) => existsSync(path));
 }
 
 describe("static app hydrate guard", () => {
-  it("sets __CF_ENTRY_RAN__ before hydrateRoot so CF retry cannot remount", () => {
-    const entries = listEntryClients();
+  it("sets __CF_ENTRY_RAN__ in src/client.tsx so CF retry cannot remount", () => {
+    const entries = listClientEntries();
     expect(entries.length).toBeGreaterThan(8);
     for (const path of entries) {
       const source = readFileSync(path, "utf8");
       expect(source, path).toContain("__CF_ENTRY_RAN__");
-      expect(source, path).toContain("hydrateRoot(document, <StartClient />)");
+      expect(source, path).toContain("hydrateRoot(");
     }
   });
 });

--- a/apps/burns/src/client.tsx
+++ b/apps/burns/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/cv/src/client.tsx
+++ b/apps/cv/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>
+    );
+  });
+}

--- a/apps/homelab/src/client.tsx
+++ b/apps/homelab/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/insights/src/client.tsx
+++ b/apps/insights/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/kb/src/client.tsx
+++ b/apps/kb/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/llm-timeline/src/client.tsx
+++ b/apps/llm-timeline/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/news/src/client.tsx
+++ b/apps/news/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/photos/src/client.tsx
+++ b/apps/photos/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}

--- a/apps/x-algo/src/client.tsx
+++ b/apps/x-algo/src/client.tsx
@@ -1,0 +1,19 @@
+import { StartClient } from "@tanstack/react-start/client";
+import { StrictMode, startTransition } from "react";
+import { hydrateRoot } from "react-dom/client";
+
+const w = window as Window & { __CF_ENTRY_RAN__?: boolean };
+if (w.__CF_ENTRY_RAN__) {
+  // Cloudflare retry may re-import this file with ?cf_retry= (a new ESM
+  // instance). Skip so hydrateRoot does not run twice and blank the page.
+} else {
+  w.__CF_ENTRY_RAN__ = true;
+  startTransition(() => {
+    hydrateRoot(
+      document,
+      <StrictMode>
+        <StartClient />
+      </StrictMode>,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- TanStack Start uses `src/client.tsx`. `entry-client.tsx` was unused.
- Home already guarded `src/client.tsx`; blog and the other static apps did not, so Cloudflare retry remounted `hydrateRoot` and blanked prerendered HTML.
- Copy home's guarded client entry across those apps.

## Test plan
- [x] `src/client.tsx` exists and contains `__CF_ENTRY_RAN__`
- [ ] Live post stays visible after JS load

## Summary by Sourcery

Guard client hydration across static applications so Cloudflare retries cannot remount the app and hide prerendered content.

Bug Fixes:
- Prevent prerendered content from being blanked when Cloudflare retries client loading by ensuring hydration runs only once across the static applications.

Tests:
- Update the static-app hydration guard test to validate guarded src/client.tsx entries across the applications.