### PR TITLE
docs(agents): require herdr agent start after worktree create

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,13 @@ For `apps/news` (news.duyet.net: LLM news pipeline on Workers/Workflows/D1), rea
 
 Put durable repository knowledge in `docs/ai/internal-knowledge.md` instead of expanding this file.
 
+## Herdr isolated worktrees (when `HERDR_ENV=1`)
+
+`herdr worktree create` only opens a **shell** pane. Always follow with
+`herdr agent start` + `herdr agent prompt` on `.result.root_pane.pane_id`, or
+the worktree sits idle. Recipe: `docs/ai/internal-knowledge.md` (Herdr section).
+Do not run bare `herdr` (attaches the TUI). Confirm with `herdr --skill`.
+
 ## Code-smell / dead-code automation
 
 For scoped reviews after the last run timestamp:

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -18,6 +18,24 @@ GitHub repo metadata (description + topics) must match the current stack. When m
 - UI primitives come from **latest shadcn/ui** under `packages/components/ui/` (registry style `new-york-v4`). Chat conversations use the official June 2026 set: `MessageScroller`, `Message`, `Bubble`, `Attachment`, `Marker`. Compose them via `ChatTranscript` / `ChatMessageList` in `packages/components/chat/`. Do not invent a parallel chat kit.
 - Ignore generated Next dumps: `.next/`, `out/`, `next-env.d.ts`. Do not commit `apps/agents/` scratch or leftover agent worktrees.
 
+## Herdr (isolated coding agents)
+
+When this session has `HERDR_ENV=1` and the user asks for a Herdr worktree / parallel agent:
+
+1. Do **not** run bare `herdr` (that attaches the TUI). Use `herdr worktree`, `herdr agent`, or `herdr --skill`.
+2. `herdr worktree create` only creates a git worktree + **shell** pane. It does **not** start a coding agent.
+3. Required follow-up — parse `.result.root_pane.pane_id`, then start and prompt:
+
+```bash
+CREATE=$(herdr worktree create --cwd "$PWD" --branch feat/<name> --base origin/master --no-focus)
+PANE=$(printf '%s' "$CREATE" | jq -r '.result.root_pane.pane_id')
+herdr agent start feat-<short> --kind cursor --pane "$PANE"
+herdr agent prompt feat-<short> "<full task spec>" --wait --timeout 600000
+```
+
+4. Agent names: `[a-z][a-z0-9_-]{0,31}`, unique among live agents. Prefer `--kind` matching the user’s agent (Cursor → `cursor`, Grok → `grok`, etc.).
+5. Herdr 0.8 `agent start` works (`agent_started` / `interactive_ready`). Stopping after `worktree create` is the idle-shell failure mode, not a Herdr regression.
+
 ## Static rendering
 
 - `apps/blog`, `apps/home`, `apps/cv`, `apps/insights`, `apps/photos`, `apps/kb`, `apps/llm-timeline`, `apps/ai-percentage`, `apps/burns`, `apps/homelab`, `apps/x-algo` emit static HTML for public pages at build time (Vite/TanStack prerender or Pages output).


### PR DESCRIPTION
## Summary
- Document that `herdr worktree create` only opens a shell pane on Herdr 0.8+
- Require `herdr agent start` + `herdr agent prompt` on `.result.root_pane.pane_id` so isolated agents actually run

## Test plan
- [ ] Confirm `AGENTS.md`/`CLAUDE.md` points at the Herdr section in `docs/ai/internal-knowledge.md`
- [ ] With `HERDR_ENV=1`, run create → start → prompt and see `agent_started` / `interactive_ready`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Document the complete Herdr isolated-agent startup workflow so newly created worktrees do not remain idle.

Enhancements:
- Document the required workflow for launching coding agents in Herdr isolated worktrees after creating them.
- Add guidance to avoid attaching the Herdr TUI directly and to verify successful agent startup and readiness.

Documentation:
- Update repository agent guidance with Herdr worktree and agent-start instructions, including a reference to the durable internal knowledge recipe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for using isolated worktrees with Herdr.
  * Documented the required agent startup and prompting workflow.
  * Clarified pane identification, supported agent types and names, and commands for avoiding TUI attachment.
  * Added guidance for handling idle-shell failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->