### PR TITLE
feat(news): AI;DR rebrand, word-boundary highlights, ox-alpha fallback

### DIFF
--- a/apps/news/src/components/PrefsPanel.tsx
+++ b/apps/news/src/components/PrefsPanel.tsx
@@ -131,7 +131,7 @@ function SettingsTab({ t }: { t: (en: string, vi: string) => string }) {
   const sectionToggles: { key: keyof typeof prefs.sections; label: string }[] =
     [
       { key: "trending", label: t("Trending", "Xu hướng") },
-      { key: "tldr", label: "TL;DR" },
+      { key: "tldr", label: "AI;DR" },
       { key: "days", label: t("Daily feed", "Bảng tin theo ngày") },
       { key: "categories", label: t("Category nav", "Danh mục") },
     ];
@@ -140,7 +140,7 @@ function SettingsTab({ t }: { t: (en: string, vi: string) => string }) {
     <div className="space-y-4">
       <div>
         <span className="mb-1.5 block text-xs text-muted-foreground">
-          {t("TL;DR items", "Số mục TL;DR")}
+          {t("AI;DR items", "Số mục AI;DR")}
         </span>
         <div className="flex gap-1.5">
           {TLDR_COUNTS.map((n) => (

--- a/apps/news/src/components/TldrSection.tsx
+++ b/apps/news/src/components/TldrSection.tsx
@@ -65,7 +65,7 @@ export function TldrSection({
     <section className="border-y-2 border-brand py-4">
       <div className="mb-2.5 flex items-baseline justify-between gap-3">
         <div className="flex items-baseline gap-3">
-          <h2 className="text-lg font-bold tracking-widest">TL;DR</h2>
+          <h2 className="text-lg font-bold tracking-widest">AI;DR</h2>
           <span className="text-xs text-muted-foreground">
             {snapshotDate
               ? snapshotDate

--- a/apps/news/src/components/system/AdminPanel.tsx
+++ b/apps/news/src/components/system/AdminPanel.tsx
@@ -411,7 +411,7 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
           disabled={tldrBusy}
           className="rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-muted disabled:opacity-50"
         >
-          {tldrBusy ? "Regenerating…" : "Regenerate TL;DR"}
+          {tldrBusy ? "Regenerating…" : "Regenerate AI;DR"}
         </button>
         {tldrResult && (
           <span className="text-xs text-muted-foreground">{tldrResult}</span>
@@ -440,7 +440,7 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
 
       <div className="mt-4">
         <p className="text-xs font-medium text-muted-foreground">
-          Telegram / TL;DR
+          Telegram / AI;DR
         </p>
         <pre className="mt-1 max-h-32 overflow-auto rounded border border-border p-2 text-xs text-muted-foreground">
           {status

--- a/apps/news/src/components/system/RunsList.tsx
+++ b/apps/news/src/components/system/RunsList.tsx
@@ -54,7 +54,7 @@ function extraBadges(stats: WorkflowRunStats, lang: "en" | "vi"): ExtraBadge[] {
     }
   }
   if (stats.tldrGenerated) {
-    badges.push({ label: lang === "vi" ? "TL;DR" : "TL;DR", value: 1 });
+    badges.push({ label: lang === "vi" ? "AI;DR" : "AI;DR", value: 1 });
   }
   return badges;
 }

--- a/apps/news/src/components/system/RunsList.tsx
+++ b/apps/news/src/components/system/RunsList.tsx
@@ -54,7 +54,7 @@ function extraBadges(stats: WorkflowRunStats, lang: "en" | "vi"): ExtraBadge[] {
     }
   }
   if (stats.tldrGenerated) {
-    badges.push({ label: lang === "vi" ? "AI;DR" : "AI;DR", value: 1 });
+    badges.push({ label: "AI;DR", value: 1 });
   }
   return badges;
 }

--- a/apps/news/src/lib/highlight.test.ts
+++ b/apps/news/src/lib/highlight.test.ts
@@ -53,6 +53,28 @@ describe("highlightTitle", () => {
     expect(highlighted[0].text.toLowerCase()).toBe("open source");
   });
 
+  it("does not highlight a needle embedded in a larger word", () => {
+    // "SpaceXAI" is a single brand: neither "SpaceX" nor "xAI" may color
+    // a fragment of it — only the standalone "Grok" gets highlighted.
+    const segments = highlightTitle("SpaceXAI Opens Grok Build to All", [
+      "SpaceX",
+      "xAI",
+      "Grok",
+    ]);
+    const highlighted = segments.filter((s) => s.highlighted).map((s) => s.text);
+    expect(highlighted).toEqual(["Grok"]);
+  });
+
+  it("still matches when bordered by digits or punctuation", () => {
+    const gpt = highlightTitle("New GPT-5.6 model announced", ["GPT"]);
+    expect(gpt.filter((s) => s.highlighted).map((s) => s.text)).toEqual(["GPT"]);
+
+    const qwen = highlightTitle("Qwen3 tops the charts", ["qwen"]);
+    expect(qwen.filter((s) => s.highlighted).map((s) => s.text)).toEqual([
+      "Qwen",
+    ]);
+  });
+
   it("caps highlights at 3 distinct tags", () => {
     const title = "Alpha Beta Gamma Delta all launch today";
     const segments = highlightTitle(title, ["alpha", "beta", "gamma", "delta"]);

--- a/apps/news/src/lib/highlight.ts
+++ b/apps/news/src/lib/highlight.ts
@@ -10,6 +10,10 @@ export interface TitleSegment {
 
 const MAX_HIGHLIGHTS = 3;
 
+/** Unicode letters count as "inside a word"; digits and punctuation are
+ * boundaries, so "GPT" still matches in "GPT-5" but not in "OpenAI". */
+const isLetter = (ch: string) => /\p{L}/u.test(ch);
+
 /**
  * Entity / product names that almost always deserve a highlight even
  * when the scoring step left `items.tags` empty (today's ingest often
@@ -108,8 +112,14 @@ export function highlightTitle(title: string, tags: string[]): TitleSegment[] {
       const idx = lowerTitle.indexOf(lowerNeedle, searchFrom);
       if (idx === -1) break;
       const end = idx + lowerNeedle.length;
+      // Whole-word match only: a needle bordered by letters is a fragment
+      // of a larger word ("SpaceX" inside "SpaceXAI") and must not color
+      // half a brand name. Digits/punctuation borders are fine ("GPT-5").
+      const borderedByLetter =
+        (idx > 0 && isLetter(title[idx - 1])) ||
+        (end < title.length && isLetter(title[end]));
       const overlaps = ranges.some((r) => idx < r.end && end > r.start);
-      if (!overlaps) {
+      if (!borderedByLetter && !overlaps) {
         const originalTag = needleTag.get(needle) ?? needle;
         ranges.push({ start: idx, end, tag: originalTag });
         matchedTags.add(lowerNeedle);

--- a/apps/news/src/lib/highlight.ts
+++ b/apps/news/src/lib/highlight.ts
@@ -12,7 +12,7 @@ const MAX_HIGHLIGHTS = 3;
 
 /** Unicode letters count as "inside a word"; digits and punctuation are
  * boundaries, so "GPT" still matches in "GPT-5" but not in "OpenAI". */
-const isLetter = (ch: string) => /\p{L}/u.test(ch);
+const isLetter = (ch: string): boolean => /\p{L}/u.test(ch);
 
 /**
  * Entity / product names that almost always deserve a highlight even
@@ -115,9 +115,10 @@ export function highlightTitle(title: string, tags: string[]): TitleSegment[] {
       // Whole-word match only: a needle bordered by letters is a fragment
       // of a larger word ("SpaceX" inside "SpaceXAI") and must not color
       // half a brand name. Digits/punctuation borders are fine ("GPT-5").
+      // Checked against lowerTitle so the offsets match the indexOf above.
       const borderedByLetter =
-        (idx > 0 && isLetter(title[idx - 1])) ||
-        (end < title.length && isLetter(title[end]));
+        (idx > 0 && isLetter(lowerTitle[idx - 1])) ||
+        (end < lowerTitle.length && isLetter(lowerTitle[end]));
       const overlaps = ranges.some((r) => idx < r.end && end > r.start);
       if (!borderedByLetter && !overlaps) {
         const originalTag = needleTag.get(needle) ?? needle;

--- a/apps/news/src/routes/about.tsx
+++ b/apps/news/src/routes/about.tsx
@@ -56,8 +56,8 @@ const STEPS: Step[] = [
     subVi: "tầm quan trọng × chất lượng, mới hơn thắng",
   },
   {
-    en: "TL;DR + Email",
-    vi: "TL;DR + Email",
+    en: "AI;DR + Email",
+    vi: "AI;DR + Email",
     subEn: "daily digest",
     subVi: "bản tin hằng ngày",
   },

--- a/apps/news/src/routes/changelog.tsx
+++ b/apps/news/src/routes/changelog.tsx
@@ -25,8 +25,8 @@ const ENTRIES: ChangelogEntry[] = [
   },
   {
     date: "2026-05",
-    en: "Initial launch: an hourly ingestion pipeline, a daily TL;DR summary, and English/Vietnamese translations for every story.",
-    vi: "Ra mắt lần đầu: pipeline thu thập tin theo giờ, tóm tắt TL;DR hằng ngày, và bản dịch song ngữ Anh/Việt cho từng tin.",
+    en: "Initial launch: an hourly ingestion pipeline, a daily AI;DR summary, and English/Vietnamese translations for every story.",
+    vi: "Ra mắt lần đầu: pipeline thu thập tin theo giờ, tóm tắt AI;DR hằng ngày, và bản dịch song ngữ Anh/Việt cho từng tin.",
   },
 ];
 

--- a/apps/news/src/routes/system.tsx
+++ b/apps/news/src/routes/system.tsx
@@ -285,7 +285,7 @@ function SystemPage() {
             </li>
             <li className="flex justify-between">
               <span className="text-muted-foreground">
-                {t("TL;DR digests", "Bản tóm tắt")}
+                {t("AI;DR digests", "Bản tóm tắt")}
               </span>
               <span className="font-mono tabular-nums text-foreground">
                 {stats.totals.tldrSnapshots}

--- a/apps/news/worker/__tests__/notify.test.ts
+++ b/apps/news/worker/__tests__/notify.test.ts
@@ -153,7 +153,7 @@ describe("trending story message", () => {
     expect(caption).toContain("…");
   });
 
-  it("builds Read + TL;DR buttons with UTM tracking", () => {
+  it("builds Read + AI;DR buttons with UTM tracking", () => {
     const markup = buildStoryReplyMarkup(story()) as {
       inline_keyboard: { text: string; url: string }[][];
     };

--- a/apps/news/worker/notify/telegram.ts
+++ b/apps/news/worker/notify/telegram.ts
@@ -93,7 +93,7 @@ export function buildStoryReplyMarkup(story: StoryPayload): object {
     inline_keyboard: [
       [
         { text: "Đọc bài →", url: withUtm(story.url) },
-        { text: "TL;DR", url: withUtm(storyUrl(story)) },
+        { text: "AI;DR", url: withUtm(storyUrl(story)) },
       ],
     ],
   };

--- a/apps/news/worker/subscribe/send.ts
+++ b/apps/news/worker/subscribe/send.ts
@@ -135,7 +135,7 @@ export function buildDigestEmail(
   unsubscribeToken: string
 ): { subject: string; html: string; text: string } {
   const unsubscribeUrl = `${SITE_URL}/subscribe?unsubscribe=${unsubscribeToken}`;
-  const title = `AI News TL;DR — ${date}`;
+  const title = `AI News AI;DR — ${date}`;
   const footerText =
     lang === "vi"
       ? `Hủy đăng ký: ${unsubscribeUrl}`

--- a/apps/news/wrangler.toml
+++ b/apps/news/wrangler.toml
@@ -37,11 +37,13 @@ ANYROUTER_BASE_URL = "https://anyrouter.dev/api/v1"
 # and never reached a model that can write title_vi. Translate leads
 # with Gemma 4 (completes a 3-item JSON batch); score/TL;DR lead with
 # Flash-Lite. Paid native Gemini after; no BYOK-only ids.
-ANYROUTER_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash"
-ANYROUTER_TRANSLATE_MODEL = "google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,anyrouter/auto,google/gemma-4-31b,google/gemini-2.5-flash-lite,google/gemini-2.5-flash,google/gemini-3.5-flash"
+# stealth/ox-alpha sits last on each chain as a final fallback: only reached
+# when every native id above fails, so an unproven id cannot eat budget.
+ANYROUTER_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
+ANYROUTER_TRANSLATE_MODEL = "google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,anyrouter/auto,google/gemma-4-31b,google/gemini-2.5-flash-lite,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
 # Bilingual TL;DR used to fall through to ANYROUTER_MODEL (reasoning-first)
 # and time out both attempts, leaving English bullets on the VI homepage.
-ANYROUTER_TLDR_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash"
+ANYROUTER_TLDR_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
 # Derived from VITE_CLERK_PUBLISHABLE_KEY's base64 domain suffix (see
 # apps/news/.env.production): pk_live_Y2xlcmsuZHV5ZXQubmV0JA -> clerk.duyet.net
 CLERK_ISSUER = "https://clerk.duyet.net"


### PR DESCRIPTION
## Changes

1. **fix(news): match title highlights on word boundaries only** — "SpaceX" no longer colors half of the compound brand "SpaceXAI" (f84a… story) while blocking "xAI" via overlap. Needles bordered by unicode letters are skipped; digits/punctuation still count as boundaries so GPT matches in GPT-5 and qwen in Qwen3.
2. **feat(news): rebrand TL;DR → AI;DR** — homepage heading, prefs panel, admin panel, system stats, about/changelog copy, Telegram digest button, email subject. Internal `tldr` identifiers unchanged.
3. **chore(news): add stealth/ox-alpha as last-resort LLM fallback** — appended after all native ids on score/translate/TL;DR chains so an unproven id cannot consume fallback budget.

## Verification

- 581 vitest tests pass (17 in highlight.test.ts incl. new boundary cases)
- biome lint clean on all touched files
- Pre-existing unrelated tsc errors in packages/components/ui confirmed via stash
- Deployed prod from this tree: version 24dc7951, smoke 17/17 PASS
- Live SSR shows SpaceXAI plain + Grok highlighted; AI;DR heading live
- /api/system shows stealth/ox-alpha last on scoring, translation, tldr chains
- Workflow runs green (last 10 error:null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve news title highlighting, rebrand the digest experience as AI;DR, and add a last-resort language-model fallback.

Bug Fixes:
- Restrict title highlighting to matches bounded by non-letter characters, preventing partial matches inside compound brand names while preserving matches next to digits and punctuation.

Enhancements:
- Rebrand user-facing TL;DR terminology to AI;DR across the news interface, administration, system views, about and changelog content, Telegram digests, and email subjects.
- Add stealth/ox-alpha as the final fallback for scoring, translation, and AI;DR generation model chains.

Tests:
- Add coverage for word-boundary highlighting and matches adjacent to digits or punctuation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed TL;DR labels to “AI;DR” across settings, digests, admin tools, notifications, email, and informational pages.
  * Added an additional fallback option to improve digest generation, translation, and bilingual content reliability.

* **Bug Fixes**
  * Improved title highlighting to avoid matching brand fragments within larger words while preserving matches next to numbers and punctuation.

* **Tests**
  * Added coverage for word-boundary highlighting and common punctuation and numeric formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->