### PR TITLE
feat(home,api): agent-readiness fixes from Is Agentic audit

### DIFF
--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -6,7 +6,10 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import app from "./index";
-import { resetRateLimits } from "./lib/rate-limit.js";
+import {
+  GLOBAL_RATE_LIMIT,
+  resetRateLimits,
+} from "./lib/rate-limit.js";
 
 interface ApiInfoResponse {
   name: string;
@@ -80,6 +83,84 @@ describe("API Endpoints", () => {
       const json = (await res.json()) as HealthResponse;
       expect(json.status).toBe("ok");
       expect(json.timestamp).toBeDefined();
+    });
+  });
+
+  describe("GET /openapi.json", () => {
+    it("should serve an OpenAPI 3.1 document with unique operationIds and oauth2 scopes", async () => {
+      const res = await app.request("/openapi.json");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+
+      const doc = (await res.json()) as Record<string, any>;
+      expect(String(doc.openapi)).toMatch(/^3\.1\./);
+      expect(doc.info?.title).toBe("duyet.net API");
+
+      // Every operation: unique operationId + non-empty description + 200 response
+      const operationIds = new Set<string>();
+      for (const [path, pathItem] of Object.entries<any>(doc.paths)) {
+        for (const [method, operation] of Object.entries<any>(pathItem)) {
+          expect(operation.operationId, `${method} ${path}`).toBeTruthy();
+          expect(
+            operationIds.has(operation.operationId),
+            `duplicate operationId ${operation.operationId}`
+          ).toBe(false);
+          operationIds.add(operation.operationId);
+          expect(operation.description, `${method} ${path}`).toBeTruthy();
+          expect(operation.responses?.["200"], `${method} ${path}`).toBeDefined();
+        }
+      }
+
+      // Security schemes declare the canonical scopes
+      const flows = doc.components?.securitySchemes?.oauth2?.flows ?? {};
+      const scopes = Object.values<any>(flows).flatMap((f) => Object.keys(f.scopes ?? {}));
+      expect(scopes).toContain("read:profile");
+      expect(scopes).toContain("chat");
+
+      // The secured operation requires the chat scope (or bearer fallback)
+      const generateSecurity = doc.paths?.["/api/llm/generate"]?.post?.security;
+      expect(generateSecurity).toEqual([{ oauth2: ["chat"] }, { bearerAuth: [] }]);
+    });
+  });
+
+  describe("Rate-limit headers", () => {
+    function expectRateLimitHeaders(res: Response): void {
+      expect(res.headers.get("RateLimit-Limit")).toBe(
+        String(GLOBAL_RATE_LIMIT.max)
+      );
+      expect(Number(res.headers.get("RateLimit-Remaining"))).not.toBeNaN();
+      expect(Number(res.headers.get("RateLimit-Reset"))).not.toBeNaN();
+    }
+
+    it("sets RateLimit-* headers on success responses", async () => {
+      for (const path of ["/", "/health", "/api/insights/overview"]) {
+        const res = await app.request(path, {
+          headers: { "CF-Connecting-IP": "203.0.113.50" },
+        });
+        expect(res.status, path).toBe(200);
+        expectRateLimitHeaders(res);
+        await res.json().catch(() => null);
+      }
+    });
+
+    it("returns 429 with Retry-After when the global bucket is exhausted", async () => {
+      const ip = "203.0.113.60";
+      let lastRes: Response | undefined;
+
+      for (let i = 0; i <= GLOBAL_RATE_LIMIT.max; i += 1) {
+        lastRes = await app.request("/health", {
+          headers: { "CF-Connecting-IP": ip },
+        });
+        if (i < GLOBAL_RATE_LIMIT.max) {
+          expect(lastRes.status).toBe(200);
+        }
+      }
+
+      expect(lastRes?.status).toBe(429);
+      expectRateLimitHeaders(lastRes as Response);
+      expect(Number(lastRes?.headers.get("Retry-After"))).toBeGreaterThan(0);
+      const json = (await lastRes?.json()) as ErrorResponse;
+      expect(json.error).toBe("rate limited");
     });
   });
 
@@ -172,7 +253,7 @@ describe("API Endpoints", () => {
 
     it("should return 429 after 10 requests from the same IP", async () => {
       const ip = "198.51.100.9";
-      let lastStatus = 0;
+      let lastRes: Response | undefined;
 
       for (let i = 0; i < 11; i += 1) {
         const res = await app.request(
@@ -180,13 +261,16 @@ describe("API Endpoints", () => {
           generateInit({}, ip),
           AUTH_ENV
         );
-        lastStatus = res.status;
+        lastRes = res;
         if (i < 10) {
           expect(res.status).toBe(400);
         }
       }
 
-      expect(lastStatus).toBe(429);
+      expect(lastRes?.status).toBe(429);
+      // 429s carry Retry-After (seconds until the window resets)
+      const retryAfter = Number(lastRes?.headers.get("Retry-After"));
+      expect(retryAfter).toBeGreaterThan(0);
     });
 
     it("should accept blog card prompt", async () => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,8 @@
 
 import { Hono } from "hono";
 import type { Env } from "./env.js";
+import { openApiDocument } from "./lib/openapi.js";
+import { consumeRateLimit, GLOBAL_RATE_LIMIT, secondsUntil } from "./lib/rate-limit.js";
 import aiPercentageRouter from "./routes/ai-percentage.js";
 import cardDescriptionStreamingRouter from "./routes/card-description-streaming.js";
 import insightsRouter from "./routes/insights.js";
@@ -34,6 +36,35 @@ app.use("*", async (c, next) => {
 });
 
 /**
+ * Global per-IP rate-limit middleware.
+ * Sets RateLimit-* headers (IETF draft
+ * https-draft-ietf-httpapi-ratelimit-headers) on every response and
+ * returns 429 with Retry-After once the bucket is exhausted.
+ * Separate bucket namespace ("global:") from the stricter generate limiter.
+ */
+app.use("*", async (c, next) => {
+  const ip = c.req.header("CF-Connecting-IP") || "anonymous";
+  const now = Date.now();
+  const limit = consumeRateLimit(
+    `global:${ip}`,
+    now,
+    GLOBAL_RATE_LIMIT.max,
+    GLOBAL_RATE_LIMIT.windowMs
+  );
+
+  c.header("RateLimit-Limit", String(GLOBAL_RATE_LIMIT.max));
+  c.header("RateLimit-Remaining", String(limit.remaining));
+  c.header("RateLimit-Reset", String(secondsUntil(limit.resetAt, now)));
+
+  if (!limit.allowed) {
+    c.header("Retry-After", String(secondsUntil(limit.resetAt, now)));
+    return c.json({ error: "rate limited" }, 429);
+  }
+
+  await next();
+});
+
+/**
  * Health check endpoint
  */
 app.get("/", (c) => {
@@ -55,6 +86,14 @@ app.get("/", (c) => {
  */
 app.get("/health", (c) => {
   return c.json({ status: "ok", timestamp: new Date().toISOString() });
+});
+
+/**
+ * Published OpenAPI document (mirrored at https://duyet.net/openapi.json)
+ */
+app.get("/openapi.json", (c) => {
+  c.header("Cache-Control", "public, max-age=300");
+  return c.json(openApiDocument);
 });
 
 /**

--- a/apps/api/src/lib/openapi.ts
+++ b/apps/api/src/lib/openapi.ts
@@ -1,0 +1,605 @@
+/**
+ * Hand-written OpenAPI 3.1 document describing the public API surface.
+ *
+ * Dependency-free by design: keep this file in sync with src/index.ts and the
+ * route handlers, then re-generate the static mirror at
+ * apps/home/public/openapi.json (identical JSON, pretty-printed).
+ */
+
+type Schema = Record<string, unknown>;
+
+interface Operation {
+  content?: Record<string, unknown>;
+  description: string;
+  headers?: Record<string, unknown>;
+}
+
+function jsonResponse(description: string, schema: Schema): Operation {
+  return {
+    content: { "application/json": { schema } },
+    description,
+  };
+}
+
+function errorSchema(): Schema {
+  return {
+    additionalProperties: false,
+    properties: { error: { type: "string" } },
+    required: ["error"],
+    type: "object",
+  };
+}
+
+function rateLimitHeaders(): Record<string, unknown> {
+  return {
+    "RateLimit-Limit": { $ref: "#/components/headers/RateLimit-Limit" },
+    "RateLimit-Remaining": { $ref: "#/components/headers/RateLimit-Remaining" },
+    "RateLimit-Reset": { $ref: "#/components/headers/RateLimit-Reset" },
+  };
+}
+
+function okResponse(description: string, schema: Schema): Operation {
+  return { ...jsonResponse(description, schema), headers: rateLimitHeaders() };
+}
+
+function tooManyRequestsResponse(): Operation {
+  return {
+    ...okResponse(
+      "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+      errorSchema()
+    ),
+    headers: {
+      ...rateLimitHeaders(),
+      "Retry-After": { $ref: "#/components/headers/Retry-After" },
+    },
+  };
+}
+
+const unauthorizedResponse = jsonResponse(
+  "Missing or invalid bearer token.",
+  errorSchema()
+);
+
+const serviceInfoSchema: Schema = {
+  additionalProperties: false,
+  properties: {
+    endpoints: {
+      additionalProperties: false,
+      properties: {
+        aiPercentage: { type: "string" },
+        cardDescription: { type: "string" },
+        health: { type: "string" },
+        insights: { type: "string" },
+      },
+      required: ["health", "cardDescription", "aiPercentage", "insights"],
+      type: "object",
+    },
+    name: { type: "string" },
+    status: { type: "string" },
+    version: { type: "string" },
+  },
+  required: ["name", "version", "status", "endpoints"],
+  type: "object",
+};
+
+const healthSchema: Schema = {
+  additionalProperties: false,
+  properties: {
+    status: { type: "string" },
+    timestamp: { format: "date-time", type: "string" },
+  },
+  required: ["status", "timestamp"],
+  type: "object",
+};
+
+const aiPercentageCurrentSchema: Schema = {
+  additionalProperties: false,
+  properties: {
+    ai_percentage: { type: "number" },
+    ai_lines_added: { type: "integer" },
+    human_lines_added: { type: "integer" },
+    total_lines_added: { type: "integer" },
+  },
+  required: [
+    "ai_percentage",
+    "total_lines_added",
+    "human_lines_added",
+    "ai_lines_added",
+  ],
+  type: "object",
+};
+
+const aiPercentageHistoryPointSchema: Schema = {
+  additionalProperties: false,
+  properties: {
+    ai_commits: { type: "integer" },
+    ai_percentage: { type: "number" },
+    ai_lines_added: { type: "integer" },
+    date: { type: "string" },
+    human_commits: { type: "integer" },
+    human_lines_added: { type: "integer" },
+    total_commits: { type: "integer" },
+    total_lines_added: { type: "integer" },
+  },
+  required: [
+    "date",
+    "ai_percentage",
+    "total_lines_added",
+    "human_lines_added",
+    "ai_lines_added",
+    "total_commits",
+    "human_commits",
+    "ai_commits",
+  ],
+  type: "object",
+};
+
+const insightsOverviewSchema: Schema = {
+  additionalProperties: true,
+  properties: {
+    aiActivity: {
+      items: {
+        additionalProperties: false,
+        properties: {
+          "Total Cost": { type: "number" },
+          "Total Tokens": { type: "integer" },
+          date: { type: "string" },
+        },
+        required: ["date", "Total Tokens", "Total Cost"],
+        type: "object",
+      },
+      type: "array",
+    },
+    aiMetrics: {
+      additionalProperties: false,
+      properties: {
+        activeDays: { type: "integer" },
+        cacheTokens: { type: "integer" },
+        dailyAverage: { type: "integer" },
+        topModel: { type: "string" },
+        totalCost: { type: "number" },
+        totalTokens: { type: "integer" },
+      },
+      required: [
+        "totalTokens",
+        "cacheTokens",
+        "totalCost",
+        "activeDays",
+        "dailyAverage",
+        "topModel",
+      ],
+      type: "object",
+    },
+    aiModels: {
+      items: {
+        additionalProperties: false,
+        properties: {
+          cost: { type: "number" },
+          name: { type: "string" },
+          percent: { type: "integer" },
+          tokens: { type: "integer" },
+          usageCount: { type: "integer" },
+        },
+        required: ["name", "tokens", "cost", "percent", "usageCount"],
+        type: "object",
+      },
+      type: "array",
+    },
+    cloudflare: {
+      additionalProperties: false,
+      properties: {
+        data: {
+          additionalProperties: true,
+          properties: {
+            viewer: {
+              additionalProperties: true,
+              properties: {
+                zones: {
+                  items: {
+                    additionalProperties: true,
+                    properties: {
+                      httpRequests1dGroups: {
+                        items: {
+                          additionalProperties: true,
+                          properties: {
+                            date: {
+                              properties: { date: { type: "string" } },
+                              required: ["date"],
+                              type: "object",
+                            },
+                            sum: {
+                              properties: {
+                                bytes: { type: "integer" },
+                                cachedBytes: { type: "integer" },
+                                pageViews: { type: "integer" },
+                                requests: { type: "integer" },
+                              },
+                              required: ["requests", "pageViews"],
+                              type: "object",
+                            },
+                            uniq: {
+                              properties: { uniques: { type: "integer" } },
+                              required: ["uniques"],
+                              type: "object",
+                            },
+                          },
+                          required: ["date", "sum", "uniq"],
+                          type: "object",
+                        },
+                        type: "array",
+                      },
+                    },
+                    required: ["httpRequests1dGroups"],
+                    type: "object",
+                  },
+                  type: "array",
+                },
+              },
+              required: ["zones"],
+              type: "object",
+            },
+          },
+          required: ["viewer"],
+          type: "object",
+        },
+        days: { type: "integer" },
+        generatedAt: { format: "date-time", type: "string" },
+        totalPageviews: { type: "integer" },
+        totalRequests: { type: "integer" },
+      },
+      required: [
+        "data",
+        "days",
+        "generatedAt",
+        "totalPageviews",
+        "totalRequests",
+      ],
+      type: "object",
+    },
+    posthog: {
+      additionalProperties: false,
+      properties: {
+        avgVisitorsPerPage: { type: "number" },
+        blogUrl: { type: "string" },
+        paths: {
+          items: {
+            additionalProperties: false,
+            properties: {
+              path: { type: "string" },
+              views: { type: "integer" },
+              visitors: { type: "integer" },
+            },
+            required: ["path", "views", "visitors"],
+            type: "object",
+          },
+          type: "array",
+        },
+        totalViews: { type: "integer" },
+        totalVisitors: { type: "integer" },
+      },
+      required: [
+        "totalVisitors",
+        "totalViews",
+        "avgVisitorsPerPage",
+        "paths",
+        "blogUrl",
+      ],
+      type: "object",
+    },
+    wakaLanguages: {
+      items: {
+        additionalProperties: true,
+        properties: {
+          name: { type: "string" },
+          percent: { type: "number" },
+          total_seconds: { type: "number" },
+        },
+        required: ["name", "percent", "total_seconds"],
+        type: "object",
+      },
+      type: "array",
+    },
+    wakaMetrics: {
+      additionalProperties: false,
+      properties: {
+        avgDailyHours: { type: "number" },
+        daysActive: { type: "integer" },
+        topLanguage: { type: "string" },
+        totalHours: { type: "number" },
+      },
+      required: ["totalHours", "avgDailyHours", "daysActive", "topLanguage"],
+      type: "object",
+    },
+    wakaTrend: {
+      items: {
+        additionalProperties: false,
+        properties: {
+          displayDate: { type: "string" },
+          hours: { type: "number" },
+          yearMonth: { type: "string" },
+        },
+        required: ["yearMonth", "displayDate", "hours"],
+        type: "object",
+      },
+      type: "array",
+    },
+  },
+  required: [
+    "aiActivity",
+    "aiMetrics",
+    "aiModels",
+    "cloudflare",
+    "posthog",
+    "wakaLanguages",
+    "wakaMetrics",
+    "wakaTrend",
+  ],
+  type: "object",
+};
+
+export const openApiDocument = {
+  components: {
+    headers: {
+      "RateLimit-Limit": {
+        description:
+          "Maximum number of requests allowed in the current window (per IP).",
+        schema: { type: "integer" },
+      },
+      "RateLimit-Remaining": {
+        description: "Requests remaining in the current window.",
+        schema: { type: "integer" },
+      },
+      "RateLimit-Reset": {
+        description: "Seconds until the current window resets.",
+        schema: { type: "integer" },
+      },
+      "Retry-After": {
+        description:
+          "Seconds to wait before retrying the request (sent with 429 responses).",
+        schema: { type: "integer" },
+      },
+    },
+    schemas: {
+      AiPercentageAvailable: {
+        additionalProperties: false,
+        properties: { available: { type: "boolean" } },
+        required: ["available"],
+        type: "object",
+      },
+      AiPercentageCurrent: aiPercentageCurrentSchema,
+      AiPercentageHistoryPoint: aiPercentageHistoryPointSchema,
+      AiPercentageHistoryResponse: {
+        additionalProperties: false,
+        properties: {
+          data: { items: { $ref: "#/components/schemas/AiPercentageHistoryPoint" }, type: "array" },
+        },
+        required: ["data"],
+        type: "object",
+      },
+      Error: errorSchema(),
+      GenerateRequest: {
+        additionalProperties: false,
+        properties: {
+          prompt: {
+            description:
+              'Prompt describing the card to describe, e.g. "generate description for blog card". Must mention a supported card type.',
+            type: "string",
+          },
+        },
+        required: ["prompt"],
+        type: "object",
+      },
+      GenerateResponse: {
+        additionalProperties: false,
+        properties: { description: { type: "string" } },
+        required: ["description"],
+        type: "object",
+      },
+      Health: healthSchema,
+      InsightsOverview: insightsOverviewSchema,
+      ServiceInfo: serviceInfoSchema,
+    },
+    securitySchemes: {
+      bearerAuth: {
+        description:
+          "Static API token issued for agents (API_TOKEN / AGENT_API_TOKEN), passed as `Authorization: Bearer <token>`.",
+        scheme: "bearer",
+        type: "http",
+      },
+      oauth2: {
+        description:
+          "OAuth 2.0 against the authorization server at https://duyet.net (see /.well-known/oauth-protected-resource and /.well-known/oauth-authorization-server).",
+        flows: {
+          clientCredentials: {
+            scopes: {
+              "read:profile":
+                "Read the authenticated agent's public profile information.",
+              chat: "Send prompts to LLM-backed endpoints such as POST /api/llm/generate.",
+            },
+            tokenUrl: "https://duyet.net/oauth/token",
+          },
+        },
+        type: "oauth2",
+      },
+    },
+  },
+  info: {
+    description:
+      "Public API for duyet.net: AI-generated card descriptions, AI code-usage metrics, and site analytics. All endpoints are rate limited per IP and return RateLimit-Limit, RateLimit-Remaining, and RateLimit-Reset headers on every response; exhausted quotas produce a 429 response with a Retry-After header (seconds until reset). Authentication uses either a static bearer token or OAuth 2.0 scopes published in /.well-known/oauth-protected-resource.",
+    title: "duyet.net API",
+    version: "0.1.0",
+  },
+  openapi: "3.1.0",
+  paths: {
+    "/": {
+      get: {
+        description:
+          "Returns the service name, version, health status, and a map of available endpoints.",
+        operationId: "getServiceInfo",
+        responses: {
+          "200": okResponse("Service information.", serviceInfoSchema),
+          "429": tooManyRequestsResponse(),
+        },
+        security: [],
+        summary: "Get service info",
+        tags: ["Meta"],
+      },
+    },
+    "/api/ai/percentage/available": {
+      get: {
+        description:
+          "Reports whether AI code-percentage data exists in the backing ClickHouse table.",
+        operationId: "getAiPercentageAvailability",
+        responses: {
+          "200": okResponse("Data availability.", {
+            $ref: "#/components/schemas/AiPercentageAvailable",
+          }),
+          "429": tooManyRequestsResponse(),
+        },
+        security: [],
+        summary: "Check AI percentage availability",
+        tags: ["AI Percentage"],
+      },
+    },
+    "/api/ai/percentage/current": {
+      get: {
+        description:
+          "Returns the most recent AI code percentage with line counts (total, human, AI) from ClickHouse.",
+        operationId: "getCurrentAiPercentage",
+        responses: {
+          "200": okResponse(
+            "Latest AI code percentage snapshot.",
+            aiPercentageCurrentSchema
+          ),
+          "404": jsonResponse("No data available.", errorSchema()),
+          "500": jsonResponse("ClickHouse not configured or query failed.", errorSchema()),
+          "429": tooManyRequestsResponse(),
+        },
+        security: [],
+        summary: "Get current AI percentage",
+        tags: ["AI Percentage"],
+      },
+    },
+    "/api/ai/percentage/history": {
+      get: {
+        description:
+          "Returns daily AI code-percentage history ordered ascending, including line and commit splits.",
+        operationId: "getAiPercentageHistory",
+        parameters: [
+          {
+            description: "Number of days to look back.",
+            in: "query",
+            name: "days",
+            required: false,
+            schema: { default: 365, minimum: 1, type: "integer" },
+          },
+        ],
+        responses: {
+          "200": okResponse("Historical AI code percentages.", {
+            $ref: "#/components/schemas/AiPercentageHistoryResponse",
+          }),
+          "500": jsonResponse("ClickHouse not configured or query failed.", errorSchema()),
+          "429": tooManyRequestsResponse(),
+        },
+        security: [],
+        summary: "Get AI percentage history",
+        tags: ["AI Percentage"],
+      },
+    },
+    "/api/insights/overview": {
+      get: {
+        description:
+          "Aggregated dashboard overview combining AI usage metrics, WakaTime coding stats, Cloudflare traffic, and PostHog page analytics. Individual source failures degrade to zeroed defaults instead of erroring.",
+        operationId: "getInsightsOverview",
+        responses: {
+          "200": okResponse("Aggregated overview payload.", {
+            $ref: "#/components/schemas/InsightsOverview",
+          }),
+          "429": tooManyRequestsResponse(),
+        },
+        security: [],
+        summary: "Get insights overview",
+        tags: ["Insights"],
+      },
+    },
+    "/api/llm/generate": {
+      post: {
+        description:
+          "Generates a short card description with an LLM. Requires authentication and is limited to 10 requests/min/IP on top of the global limit. The prompt must mention a supported card type (\"blog card\" or \"featured posts card\").",
+        operationId: "generateLlmCardDescription",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/GenerateRequest" },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          "200": okResponse("Generated card description.", {
+            $ref: "#/components/schemas/GenerateResponse",
+          }),
+          "400": jsonResponse(
+            "Missing/invalid prompt or unsupported card type. May include supportedTypes listing accepted card types.",
+            {
+              properties: {
+                error: { type: "string" },
+                supportedTypes: { items: { type: "string" }, type: "array" },
+              },
+              required: ["error"],
+              type: "object",
+            }
+          ),
+          "401": unauthorizedResponse,
+          "429": tooManyRequestsResponse(),
+          "500": jsonResponse(
+            "Upstream generation failed. May include a fallback description.",
+            {
+              properties: {
+                error: { type: "string" },
+                fallback: { type: "string" },
+              },
+              required: ["error"],
+              type: "object",
+            }
+          ),
+        },
+        security: [{ oauth2: ["chat"] }, { bearerAuth: [] }],
+        summary: "Generate LLM card description",
+        tags: ["LLM"],
+      },
+    },
+    "/health": {
+      get: {
+        description:
+          "Liveness probe returning an ok status and the current server time. Used by uptime checks and listed in /.well-known/api-catalog.",
+        operationId: "getHealth",
+        responses: {
+          "200": okResponse("Service is healthy.", healthSchema),
+          "429": tooManyRequestsResponse(),
+        },
+        security: [],
+        summary: "Health check",
+        tags: ["Meta"],
+      },
+    },
+    "/openapi.json": {
+      get: {
+        description:
+          "Returns this OpenAPI document. Mirrored statically at https://duyet.net/openapi.json.",
+        operationId: "getOpenApiDocument",
+        responses: {
+          "200": okResponse("OpenAPI 3.1 document.", { type: "object" }),
+          "429": tooManyRequestsResponse(),
+        },
+        security: [],
+        summary: "Get OpenAPI document",
+        tags: ["Meta"],
+      },
+    },
+  },
+  servers: [
+    { url: "https://api.duyet.net" },
+    { url: "https://duyet.net/api", description: "Same-origin mirror" },
+  ],
+};

--- a/apps/api/src/lib/rate-limit.test.ts
+++ b/apps/api/src/lib/rate-limit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  consumeRateLimit,
+  resetRateLimits,
+  secondsUntil,
+} from "./rate-limit.js";
+
+describe("consumeRateLimit", () => {
+  it("returns allowed=true with remaining decrements inside the window", () => {
+    resetRateLimits();
+    const now = 1_000_000;
+
+    const first = consumeRateLimit("test:a", now, 3, 60_000);
+    expect(first).toEqual({
+      allowed: true,
+      remaining: 2,
+      resetAt: now + 60_000,
+    });
+
+    const second = consumeRateLimit("test:a", now + 1, 3, 60_000);
+    expect(second.allowed).toBe(true);
+    expect(second.remaining).toBe(1);
+    expect(second.resetAt).toBe(now + 60_000);
+  });
+
+  it("returns allowed=false with remaining=0 once the bucket is exhausted", () => {
+    resetRateLimits();
+    const now = 2_000_000;
+
+    for (let i = 0; i < 2; i += 1) {
+      expect(consumeRateLimit("test:b", now, 2, 60_000).allowed).toBe(true);
+    }
+
+    const rejected = consumeRateLimit("test:b", now + 1, 2, 60_000);
+    expect(rejected.allowed).toBe(false);
+    expect(rejected.remaining).toBe(0);
+    expect(rejected.resetAt).toBe(now + 60_000);
+  });
+
+  it("starts a fresh window once resetAt has passed", () => {
+    resetRateLimits();
+    const now = 3_000_000;
+
+    consumeRateLimit("test:c", now, 1, 60_000);
+    expect(consumeRateLimit("test:c", now + 1, 1, 60_000).allowed).toBe(false);
+
+    const afterWindow = consumeRateLimit("test:c", now + 60_000, 1, 60_000);
+    expect(afterWindow.allowed).toBe(true);
+    expect(afterWindow.remaining).toBe(0);
+    expect(afterWindow.resetAt).toBe(now + 120_000);
+  });
+
+  it("keeps separate buckets per key namespace", () => {
+    resetRateLimits();
+    const now = 4_000_000;
+
+    consumeRateLimit("global:1.2.3.4", now, 1, 60_000);
+    expect(consumeRateLimit("global:1.2.3.4", now, 1, 60_000).allowed).toBe(
+      false
+    );
+    expect(consumeRateLimit("llm-generate:1.2.3.4", now, 1, 60_000).allowed).toBe(
+      true
+    );
+  });
+});
+
+describe("secondsUntil", () => {
+  it("rounds up to whole seconds and clamps at zero", () => {
+    const now = 10_000_000;
+    expect(secondsUntil(now + 60_000, now)).toBe(60);
+    expect(secondsUntil(now + 500, now)).toBe(1);
+    expect(secondsUntil(now - 5_000, now)).toBe(0);
+  });
+});

--- a/apps/api/src/lib/rate-limit.ts
+++ b/apps/api/src/lib/rate-limit.ts
@@ -1,5 +1,6 @@
 const WINDOW_MS = 60_000;
 const MAX_REQUESTS = 10;
+const GLOBAL_MAX_REQUESTS = 600;
 const MAX_BUCKETS = 10_000;
 
 interface Bucket {
@@ -13,6 +14,21 @@ export const GENERATE_RATE_LIMIT = {
   max: MAX_REQUESTS,
   windowMs: WINDOW_MS,
 };
+
+export const GLOBAL_RATE_LIMIT = {
+  max: GLOBAL_MAX_REQUESTS,
+  windowMs: WINDOW_MS,
+};
+
+/**
+ * Result of consuming one request from a rate-limit bucket.
+ * `resetAt` is the epoch ms at which the window resets.
+ */
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+}
 
 function pruneExpired(now: number): void {
   if (buckets.size <= MAX_BUCKETS) return;
@@ -29,21 +45,32 @@ export function consumeRateLimit(
   now = Date.now(),
   max = MAX_REQUESTS,
   windowMs = WINDOW_MS
-): boolean {
+): RateLimitResult {
   pruneExpired(now);
 
   const existing = buckets.get(key);
   if (!existing || now >= existing.resetAt) {
     buckets.set(key, { count: 1, resetAt: now + windowMs });
-    return true;
+    return { allowed: true, remaining: max - 1, resetAt: now + windowMs };
   }
 
   if (existing.count >= max) {
-    return false;
+    return { allowed: false, remaining: 0, resetAt: existing.resetAt };
   }
 
   existing.count += 1;
-  return true;
+  return {
+    allowed: true,
+    remaining: max - existing.count,
+    resetAt: existing.resetAt,
+  };
+}
+
+/**
+ * Seconds until the given resetAt (epoch ms), for RateLimit-Reset / Retry-After.
+ */
+export function secondsUntil(resetAt: number, now = Date.now()): number {
+  return Math.max(0, Math.ceil((resetAt - now) / 1000));
 }
 
 export function resetRateLimits(): void {

--- a/apps/api/src/routes/card-description-streaming.ts
+++ b/apps/api/src/routes/card-description-streaming.ts
@@ -7,7 +7,11 @@
 import { Hono } from "hono";
 import type { Env } from "../env.js";
 import { isAuthorizedApiRequest } from "../lib/auth.js";
-import { consumeRateLimit } from "../lib/rate-limit.js";
+import {
+  consumeRateLimit,
+  GENERATE_RATE_LIMIT,
+  secondsUntil,
+} from "../lib/rate-limit.js";
 
 const cardDescriptionRouter = new Hono<{ Bindings: Env }>();
 
@@ -25,7 +29,14 @@ cardDescriptionRouter.use("*", async (c, next) => {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
-  if (!consumeRateLimit(`llm-generate:${clientIp(c.req.raw)}`)) {
+  const limit = consumeRateLimit(
+    `llm-generate:${clientIp(c.req.raw)}`,
+    Date.now(),
+    GENERATE_RATE_LIMIT.max,
+    GENERATE_RATE_LIMIT.windowMs
+  );
+  if (!limit.allowed) {
+    c.header("Retry-After", String(secondsUntil(limit.resetAt)));
     return c.json({ error: "Too Many Requests" }, 429);
   }
 

--- a/apps/home/__tests__/api-proxy.test.ts
+++ b/apps/home/__tests__/api-proxy.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { onRequest } from "../functions/api/[[route]]";
+
+function call(path: string, init?: RequestInit): Promise<Response> {
+  return onRequest({ request: new Request(`https://duyet.net${path}`, init) });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("home /api suffix proxy", () => {
+  it("proxies an allowlisted GET to the upstream root with query preserved", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ ok: true }, { status: 200 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await call("/api/api/ai/percentage/history?months=12");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.duyet.net/api/ai/percentage/history?months=12",
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("maps bare health check to the upstream root", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await call("/api/health");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.duyet.net/health",
+      expect.anything()
+    );
+  });
+
+  it("forwards Authorization header and JSON body on llm/generate POST", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ id: "gen_1" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await call("/api/api/llm/generate", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer sk-test",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ prompt: "hello" }),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    const headers = init.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer sk-test");
+    expect(init.body).toBe(JSON.stringify({ prompt: "hello" }));
+    expect(init.method).toBe("POST");
+    expect(res.status).toBe(200);
+  });
+
+  it("does not forward other inbound headers upstream", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await call("/api/health", {
+      headers: { Cookie: "secret=1", "X-Bad": "1" },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    const headers = init.headers as Headers;
+    expect(headers.has("Cookie")).toBe(false);
+    expect(headers.has("X-Bad")).toBe(false);
+  });
+
+  it("rejects non-allowlisted paths with 404 JSON", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    for (const path of ["/api/api/admin/secret", "/api/../../evil"]) {
+      const res = await call(path);
+      expect(res.status).toBe(404);
+      await expect(res.json()).resolves.toEqual({ error: "not found" });
+    }
+    // GET is not allowlisted on the generate endpoint.
+    const res = await call("/api/api/llm/generate");
+    expect(res.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("answers OPTIONS preflight with 204 and CORS headers", async () => {
+    const res = await call("/api/api/llm/generate", { method: "OPTIONS" });
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+    expect(res.headers.get("Access-Control-Allow-Headers")).toContain(
+      "Authorization"
+    );
+  });
+
+  it("returns 502 when the upstream fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("boom");
+      })
+    );
+
+    const res = await call("/api/health");
+
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({
+      error: "upstream unavailable",
+    });
+  });
+});

--- a/apps/home/__tests__/jsonld.test.ts
+++ b/apps/home/__tests__/jsonld.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  organizationJsonLd,
+  personJsonLd,
+  websiteJsonLd,
+} from "../src/lib/jsonld";
+
+describe("homepage JSON-LD builders", () => {
+  it("tags every object with the schema.org context", () => {
+    for (const obj of [websiteJsonLd(), personJsonLd(), organizationJsonLd()]) {
+      // Structured data without a context is dropped by search engines.
+      expect(obj["@context"]).toBe("https://schema.org");
+    }
+  });
+
+  it("describes the website with name, url, and language", () => {
+    const website = websiteJsonLd();
+    expect(website["@type"]).toBe("WebSite");
+    expect(website.name).toBe("duyet.net");
+    expect(website.url).toBe("https://duyet.net");
+    expect(website.inLanguage).toBe("en");
+  });
+
+  it("gives the person a sameAs profile list", () => {
+    const person = personJsonLd();
+    expect(person["@type"]).toBe("Person");
+    expect(person.name).toBe("Duyet");
+    expect(Array.isArray(person.sameAs)).toBe(true);
+    // Identity disambiguation depends on sameAs pointing at real profiles.
+    for (const url of person.sameAs) {
+      expect(url).toMatch(/^https:\/\//);
+    }
+  });
+
+  it("makes the organization reachable via contactPoint and address", () => {
+    const org = organizationJsonLd();
+    expect(org["@type"]).toBe("Organization");
+    expect(Array.isArray(org.contactPoint)).toBe(true);
+    expect(
+      org.contactPoint.some((point) => point.email === "me@duyet.net")
+    ).toBe(true);
+    expect(org.address.addressCountry).toBe("VN");
+  });
+});

--- a/apps/home/__tests__/llms-txt.test.ts
+++ b/apps/home/__tests__/llms-txt.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const llmsTxt = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "../public/llms.txt"),
+  "utf8"
+);
+
+describe("llms.txt agent guidance", () => {
+  it("tells agents when the site is a good source", () => {
+    expect(llmsTxt).toContain("When to use");
+  });
+
+  it("points at the developer portal and MCP server", () => {
+    // The developer portal is the entry point for machine access.
+    expect(llmsTxt).toContain("/developers");
+    expect(llmsTxt).toContain("https://mcp.duyet.net/mcp");
+  });
+
+  it("exposes contact and legal pages", () => {
+    expect(llmsTxt).toContain("/contact");
+  });
+});

--- a/apps/home/__tests__/middleware.test.ts
+++ b/apps/home/__tests__/middleware.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { onRequest } from "../functions/_middleware";
+
+const html = `<!doctype html><html><head></head><body><main>hi</main></body></html>`;
+
+function htmlResponse(): Response {
+  return new Response(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("home _middleware", () => {
+  it("adds Vary to the HTML response so caches vary on Accept", async () => {
+    const res = await onRequest({
+      request: new Request("https://duyet.net/"),
+      next: async () => htmlResponse(),
+    });
+    expect(res.headers.get("Vary")).toContain("Accept");
+  });
+
+  it("preserves existing Vary values on the HTML response", async () => {
+    const res = await onRequest({
+      request: new Request("https://duyet.net/"),
+      next: async () =>
+        new Response(html, {
+          status: 200,
+          headers: { "Content-Type": "text/html", Vary: "User-Agent" },
+        }),
+    });
+    expect(res.headers.get("Vary")).toBe("User-Agent, Accept, Accept-Encoding");
+  });
+
+  it("serves llms.txt as text/markdown with Vary: Accept, Accept-Encoding", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response("# Site index\n- /projects", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await onRequest({
+      request: new Request("https://duyet.net/", {
+        headers: { Accept: "text/markdown" },
+      }),
+      next: async () => htmlResponse(),
+    });
+
+    // The middleware fetches /llms.txt from its own origin.
+    expect(fetchMock).toHaveBeenCalledWith("https://duyet.net/llms.txt");
+    expect(res.headers.get("Content-Type")).toContain("text/markdown");
+    expect(res.headers.get("Vary")).toBe("Accept, Accept-Encoding");
+    expect(res.headers.get("Link")).toContain("api-catalog");
+  });
+
+  it("falls back to HTML when llms.txt is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 404 }))
+    );
+
+    const res = await onRequest({
+      request: new Request("https://duyet.net/", {
+        headers: { Accept: "text/markdown" },
+      }),
+      next: async () => htmlResponse(),
+    });
+
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+});

--- a/apps/home/__tests__/pages-config.test.ts
+++ b/apps/home/__tests__/pages-config.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const publicDir = join(dirname(fileURLToPath(import.meta.url)), "../public");
+
+describe("Cloudflare Pages _redirects", () => {
+  const redirects = readFileSync(join(publicDir, "_redirects"), "utf8");
+
+  it("no longer serves the SPA fallback (unknown URLs must 404)", () => {
+    expect(redirects).not.toContain("/* /index.html 200");
+  });
+
+  it("retargets /mcp to the JSON-RPC endpoint with a method-preserving 308", () => {
+    expect(redirects).toMatch(/^\/mcp https:\/\/mcp\.duyet\.net\/mcp 308$/m);
+  });
+});
+
+describe("Cloudflare Pages 404 page", () => {
+  const notFound = readFileSync(join(publicDir, "404.html"), "utf8");
+
+  it("points agents at the machine-readable index", () => {
+    expect(notFound).toContain("/llms.txt");
+    expect(notFound).toContain("sitemap.xml");
+    expect(notFound).toContain("/.well-known/api-catalog");
+    expect(notFound).toContain("/developers");
+    expect(notFound).not.toMatch(/<script/i);
+  });
+});
+
+describe("Cloudflare Pages _routes.json", () => {
+  const routes = JSON.parse(readFileSync(join(publicDir, "_routes.json"), "utf8")) as {
+    version: number;
+    include: string[];
+    exclude: string[];
+  };
+
+  it("invokes functions for /, /index.html and /api/* only", () => {
+    expect(routes.version).toBe(1);
+    for (const route of ["/", "/index.html", "/api/*"]) {
+      expect(routes.include).toContain(route);
+    }
+  });
+});
+
+describe("Cloudflare Pages _headers additions", () => {
+  const headers = readFileSync(join(publicDir, "_headers"), "utf8");
+
+  it("keeps existing rules intact and adds openapi + well-known CORS rules", () => {
+    // Pre-existing rules that must survive.
+    expect(headers).toMatch(/\/assets\/\*\n {2}Cache-Control: public, max-age=31536000/);
+    expect(headers).toMatch(/\/llms\.txt\n {2}Content-Type: text\/plain/);
+
+    // New rules.
+    expect(headers).toMatch(/\/openapi\.json\n {2}Access-Control-Allow-Origin: \*\n {2}Cache-Control: public, max-age=300\n/);
+    expect(headers).toMatch(/\/\.well-known\/\*\n {2}Access-Control-Allow-Origin: \*/);
+  });
+
+  it("does not duplicate Content-Type on /llms.txt (Pages joins duplicates)", () => {
+    // Count rule lines (start of line), not prose mentions in comments.
+    expect(headers.match(/^\/llms\.txt$/gm)).toHaveLength(1);
+  });
+});

--- a/apps/home/__tests__/sitemap.test.ts
+++ b/apps/home/__tests__/sitemap.test.ts
@@ -23,10 +23,37 @@ describe("home sitemap.xml", () => {
     expect(paths).toContain("/projects");
     expect(paths).toContain("/cartrack");
     expect(paths).toContain("/about-duyetbot");
+    expect(paths).toContain("/developers");
+    expect(paths).toContain("/contact");
+    expect(paths).toContain("/privacy");
 
     for (const path of paths) {
       const loc = `https://duyet.net${path === "/" ? "/" : path}`;
       expect(sitemap, `missing ${loc}`).toContain(`<loc>${loc}</loc>`);
+    }
+  });
+
+  it("lists product pages and stamps new entries with a lastmod date", () => {
+    for (const slug of ["anyrouter", "chm", "stamp"]) {
+      expect(sitemap, `missing /p/${slug}`).toContain(
+        `<loc>https://duyet.net/p/${slug}</loc>`
+      );
+    }
+
+    const newPaths = [
+      "/developers",
+      "/contact",
+      "/privacy",
+      "/p/anyrouter",
+      "/p/chm",
+      "/p/stamp",
+    ];
+    for (const path of newPaths) {
+      const entry = sitemap.split("<url>").find((block) =>
+        block.includes(`<loc>https://duyet.net${path}</loc>`)
+      );
+      expect(entry, `no <url> block for ${path}`).toBeTruthy();
+      expect(entry).toContain("<lastmod>2026-08-22</lastmod>");
     }
   });
 });

--- a/apps/home/functions/_middleware.ts
+++ b/apps/home/functions/_middleware.ts
@@ -15,11 +15,11 @@ export function rewriteHydrationRetryHtml(html: string): string {
   return html
     .replace(
       'if(window.__CF_ENTRY_RAN__)return;if(document.querySelector("main,header"))return;boot(1)',
-      "if(window.__CF_ENTRY_RAN__)return;boot(1)",
+      "if(window.__CF_ENTRY_RAN__)return;boot(1)"
     )
     .replace(
       'if(!document.querySelector("main"))boot(1)',
-      "if(window.__CF_ENTRY_RAN__)return;boot(1)",
+      "if(window.__CF_ENTRY_RAN__)return;boot(1)"
     )
     .replace(LEGACY_CACHE_BUST_IMPORT, SAME_URL_FIRST_RETRY_IMPORT);
 }
@@ -48,13 +48,19 @@ export async function onRequest(context: PagesContext): Promise<Response> {
             headers: {
               "Content-Type": "text/markdown; charset=utf-8",
               "x-markdown-tokens": tokenCount.toString(),
-              "Link": '</.well-known/api-catalog>; rel="api-catalog", </auth.md>; rel="describedby"',
+              Link: '</.well-known/api-catalog>; rel="api-catalog", </auth.md>; rel="describedby"',
               "Access-Control-Allow-Origin": "*",
+              // Same URL returns markdown or HTML depending on Accept, so
+              // shared caches must not reuse one representation for the other.
+              Vary: "Accept, Accept-Encoding",
             },
           });
         }
       } catch (error) {
-        console.error("Failed to fetch llms.txt for markdown negotiation:", error);
+        console.error(
+          "Failed to fetch llms.txt for markdown negotiation:",
+          error
+        );
       }
     }
   }
@@ -63,11 +69,23 @@ export async function onRequest(context: PagesContext): Promise<Response> {
   const contentType = res.headers.get("content-type") || "";
   if (!contentType.includes("text/html")) return res;
 
+  // Same URL returns HTML or markdown depending on Accept, so shared caches
+  // must not reuse one representation for the other.
+  const headers = new Headers(res.headers);
+  const existingVary = headers.get("Vary");
+  headers.set(
+    "Vary",
+    existingVary
+      ? `${existingVary}, Accept, Accept-Encoding`
+      : "Accept, Accept-Encoding"
+  );
+
   const text = await res.text();
   const patched = rewriteHydrationRetryHtml(text);
-  if (patched === text) return new Response(text, res);
+  if (patched === text) {
+    return new Response(text, { status: res.status, headers });
+  }
 
-  const headers = new Headers(res.headers);
   headers.delete("content-length");
   return new Response(patched, { status: res.status, headers });
 }

--- a/apps/home/functions/api/[[route]].ts
+++ b/apps/home/functions/api/[[route]].ts
@@ -1,0 +1,78 @@
+interface PagesContext {
+  request: Request;
+}
+
+const UPSTREAM = "https://api.duyet.net";
+
+/**
+ * Allowlisted incoming path + method pairs. The key is the path after the
+ * leading `/api/`; the upstream URL is `${UPSTREAM}/<key>`.
+ */
+const ALLOWLIST: Record<string, string[]> = {
+  health: ["GET"],
+  "api/ai/percentage/current": ["GET"],
+  "api/ai/percentage/history": ["GET"],
+  "api/ai/percentage/available": ["GET"],
+  "api/insights/overview": ["GET"],
+  "api/llm/generate": ["POST"],
+};
+
+function json(
+  body: unknown,
+  status: number,
+  extraHeaders?: HeadersInit
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...extraHeaders },
+  });
+}
+
+export const onRequest = async ({
+  request,
+}: PagesContext): Promise<Response> => {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Authorization, Content-Type",
+      },
+    });
+  }
+
+  const url = new URL(request.url);
+  // Strip the leading "/api/" and use the remainder as the upstream suffix.
+  const suffix = url.pathname.replace(/^\/api\//, "");
+  const allowedMethods = ALLOWLIST[suffix];
+  if (!allowedMethods?.includes(request.method)) {
+    return json({ error: "not found" }, 404, {
+      "Access-Control-Allow-Origin": "*",
+    });
+  }
+
+  const headers = new Headers();
+  const auth = request.headers.get("Authorization");
+  if (auth) headers.set("Authorization", auth);
+
+  try {
+    const upstream = await fetch(`${UPSTREAM}/${suffix}${url.search}`, {
+      method: request.method,
+      headers,
+      body: request.method === "POST" ? await request.text() : undefined,
+    });
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: new Headers({
+        "Content-Type":
+          upstream.headers.get("Content-Type") ?? "application/json",
+        "Access-Control-Allow-Origin": "*",
+      }),
+    });
+  } catch {
+    return json({ error: "upstream unavailable" }, 502, {
+      "Access-Control-Allow-Origin": "*",
+    });
+  }
+};

--- a/apps/home/public/.well-known/mcp/server-card.json
+++ b/apps/home/public/.well-known/mcp/server-card.json
@@ -1,12 +1,17 @@
 {
   "serverInfo": {
     "name": "duyet-mcp-server",
-    "version": "0.1.0"
+    "version": "0.2.1"
   },
-  "endpoint": "https://api.duyet.net/mcp",
+  "endpoint": "https://mcp.duyet.net/mcp",
+  "transport": "streamable-http",
   "capabilities": {
     "tools": {},
     "resources": {},
     "prompts": {}
+  },
+  "metadata": {
+    "resourceMetadata": "https://mcp.duyet.net/.well-known/oauth-protected-resource",
+    "documentation": "https://duyet.net/developers"
   }
 }

--- a/apps/home/public/404.html
+++ b/apps/home/public/404.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>404 – Page not found – duyet.net</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #fafafa;
+        color: #18181b;
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+      main {
+        max-width: 32rem;
+        padding: 2rem;
+      }
+      h1 {
+        font-size: 2rem;
+        margin: 0 0 0.5rem;
+      }
+      p {
+        color: #3f3f46;
+        line-height: 1.6;
+      }
+      ul {
+        padding-left: 1.25rem;
+        line-height: 1.8;
+      }
+      a {
+        color: #2563eb;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>404 — Not found</h1>
+      <p>This URL does not exist on duyet.net.</p>
+      <p>Machine-readable index:</p>
+      <ul>
+        <li><a href="/llms.txt">/llms.txt</a> — LLM-friendly site index</li>
+        <li><a href="/sitemap.xml">/sitemap.xml</a></li>
+        <li><a href="/.well-known/api-catalog">/.well-known/api-catalog</a></li>
+        <li><a href="/developers">/developers</a> — developer resources</li>
+        <li><a href="/">/</a> — homepage</li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/apps/home/public/_headers
+++ b/apps/home/public/_headers
@@ -55,6 +55,18 @@
   Content-Type: text/markdown; charset=utf-8
   Access-Control-Allow-Origin: *
 
+# OpenAPI schema — fetchable by agents, short cache
+/openapi.json
+  Access-Control-Allow-Origin: *
+  Cache-Control: public, max-age=300
+
+# Well-known discovery files (catches files beyond the explicit rules above).
+# NOTE: /llms.txt intentionally NOT re-declared here — the existing /llms.txt
+# rule above pins Content-Type: text/plain, and Pages joins duplicate headers
+# from matching rules with commas, which would corrupt the Content-Type.
+/.well-known/*
+  Access-Control-Allow-Origin: *
+
 # Security headers
 /*
   X-Frame-Options: DENY

--- a/apps/home/public/_redirects
+++ b/apps/home/public/_redirects
@@ -10,7 +10,8 @@
 /insights https://insights.duyet.net 302
 
 # Tools & Projects
-/mcp https://mcp.duyet.net 302
+# 308 keeps the method: agents POSTing JSON-RPC to /mcp reach the endpoint intact.
+/mcp https://mcp.duyet.net/mcp 308
 /okie https://okie.one 302
 /pageview https://pageview.duyet.net 302
 /rs https://rust-tieng-viet.github.io 302
@@ -59,6 +60,3 @@
 
 # Burns
 /burn https://burns.duyet.net 302
-
-# SPA fallback — must be last
-/* /index.html 200

--- a/apps/home/public/_routes.json
+++ b/apps/home/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/", "/index.html"],
+  "include": ["/", "/index.html", "/api/*"],
   "exclude": []
 }

--- a/apps/home/public/llms.txt
+++ b/apps/home/public/llms.txt
@@ -108,3 +108,26 @@ Each platform provides structured information for AI systems:
 - **LLM Timeline**: https://llm-timeline.duyet.net/llms.txt - LLM timeline and history data
 - **Knowledge Base**: https://kb.duyet.net/llms.txt - Knowledge base articles and agent memory notes (full text: https://kb.duyet.net/llms-full.txt)
 - **AI Agents API**: https://agents.duyet.net/llms.txt - API-only agent endpoint information
+
+## When to use this site
+
+Use duyet.net when you need to:
+- Research Duyet for hiring or collaboration — experience, focus, and current work are summarized on /about and https://cv.duyet.net
+- Read data-engineering technical writing (ClickHouse, Spark, Airflow, DuckDB) on the blog
+- Explore Duyet's open-source projects and products (full list on /projects)
+- Query public stats about this site via the API (see Developer resources below)
+- Connect an AI assistant to Duyet's tools via MCP (https://mcp.duyet.net/mcp)
+
+## Developer resources
+
+- **Developer portal**: https://duyet.net/developers - one page covering the public API, authentication, rate limits, MCP, and machine-readable files
+- **OpenAPI spec**: https://duyet.net/openapi.json - OpenAPI 3.1 spec for the public API
+- **API catalog**: https://duyet.net/.well-known/api-catalog - link-set catalog of available APIs
+- **MCP endpoint**: https://mcp.duyet.net/mcp - Streamable HTTP MCP server for AI assistants
+- **OAuth metadata**: https://duyet.net/.well-known/oauth-protected-resource - protected-resource metadata with declared scopes
+
+## Contact & legal
+
+- **Contact page**: https://duyet.net/contact - all contact channels in one place; AI agents can use the MCP `send_message` tool instead
+- **Email**: me@duyet.net
+- **Privacy policy**: https://duyet.net/privacy - what the site collects and how to request deletion

--- a/apps/home/public/openapi.json
+++ b/apps/home/public/openapi.json
@@ -1,0 +1,1358 @@
+{
+  "components": {
+    "headers": {
+      "RateLimit-Limit": {
+        "description": "Maximum number of requests allowed in the current window (per IP).",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "RateLimit-Remaining": {
+        "description": "Requests remaining in the current window.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "RateLimit-Reset": {
+        "description": "Seconds until the current window resets.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "Retry-After": {
+        "description": "Seconds to wait before retrying the request (sent with 429 responses).",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    },
+    "schemas": {
+      "AiPercentageAvailable": {
+        "additionalProperties": false,
+        "properties": {
+          "available": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "available"
+        ],
+        "type": "object"
+      },
+      "AiPercentageCurrent": {
+        "additionalProperties": false,
+        "properties": {
+          "ai_percentage": {
+            "type": "number"
+          },
+          "ai_lines_added": {
+            "type": "integer"
+          },
+          "human_lines_added": {
+            "type": "integer"
+          },
+          "total_lines_added": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "ai_percentage",
+          "total_lines_added",
+          "human_lines_added",
+          "ai_lines_added"
+        ],
+        "type": "object"
+      },
+      "AiPercentageHistoryPoint": {
+        "additionalProperties": false,
+        "properties": {
+          "ai_commits": {
+            "type": "integer"
+          },
+          "ai_percentage": {
+            "type": "number"
+          },
+          "ai_lines_added": {
+            "type": "integer"
+          },
+          "date": {
+            "type": "string"
+          },
+          "human_commits": {
+            "type": "integer"
+          },
+          "human_lines_added": {
+            "type": "integer"
+          },
+          "total_commits": {
+            "type": "integer"
+          },
+          "total_lines_added": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "date",
+          "ai_percentage",
+          "total_lines_added",
+          "human_lines_added",
+          "ai_lines_added",
+          "total_commits",
+          "human_commits",
+          "ai_commits"
+        ],
+        "type": "object"
+      },
+      "AiPercentageHistoryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/AiPercentageHistoryPoint"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
+      "Error": {
+        "additionalProperties": false,
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "GenerateRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "prompt": {
+            "description": "Prompt describing the card to describe, e.g. \"generate description for blog card\". Must mention a supported card type.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt"
+        ],
+        "type": "object"
+      },
+      "GenerateResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "type": "object"
+      },
+      "Health": {
+        "additionalProperties": false,
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "timestamp"
+        ],
+        "type": "object"
+      },
+      "InsightsOverview": {
+        "additionalProperties": true,
+        "properties": {
+          "aiActivity": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "Total Cost": {
+                  "type": "number"
+                },
+                "Total Tokens": {
+                  "type": "integer"
+                },
+                "date": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "date",
+                "Total Tokens",
+                "Total Cost"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "aiMetrics": {
+            "additionalProperties": false,
+            "properties": {
+              "activeDays": {
+                "type": "integer"
+              },
+              "cacheTokens": {
+                "type": "integer"
+              },
+              "dailyAverage": {
+                "type": "integer"
+              },
+              "topModel": {
+                "type": "string"
+              },
+              "totalCost": {
+                "type": "number"
+              },
+              "totalTokens": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "totalTokens",
+              "cacheTokens",
+              "totalCost",
+              "activeDays",
+              "dailyAverage",
+              "topModel"
+            ],
+            "type": "object"
+          },
+          "aiModels": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "cost": {
+                  "type": "number"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "percent": {
+                  "type": "integer"
+                },
+                "tokens": {
+                  "type": "integer"
+                },
+                "usageCount": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name",
+                "tokens",
+                "cost",
+                "percent",
+                "usageCount"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "cloudflare": {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "additionalProperties": true,
+                "properties": {
+                  "viewer": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "zones": {
+                        "items": {
+                          "additionalProperties": true,
+                          "properties": {
+                            "httpRequests1dGroups": {
+                              "items": {
+                                "additionalProperties": true,
+                                "properties": {
+                                  "date": {
+                                    "properties": {
+                                      "date": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "date"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "sum": {
+                                    "properties": {
+                                      "bytes": {
+                                        "type": "integer"
+                                      },
+                                      "cachedBytes": {
+                                        "type": "integer"
+                                      },
+                                      "pageViews": {
+                                        "type": "integer"
+                                      },
+                                      "requests": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "requests",
+                                      "pageViews"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "uniq": {
+                                    "properties": {
+                                      "uniques": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "uniques"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "date",
+                                  "sum",
+                                  "uniq"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "httpRequests1dGroups"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "zones"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "viewer"
+                ],
+                "type": "object"
+              },
+              "days": {
+                "type": "integer"
+              },
+              "generatedAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "totalPageviews": {
+                "type": "integer"
+              },
+              "totalRequests": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "data",
+              "days",
+              "generatedAt",
+              "totalPageviews",
+              "totalRequests"
+            ],
+            "type": "object"
+          },
+          "posthog": {
+            "additionalProperties": false,
+            "properties": {
+              "avgVisitorsPerPage": {
+                "type": "number"
+              },
+              "blogUrl": {
+                "type": "string"
+              },
+              "paths": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "views": {
+                      "type": "integer"
+                    },
+                    "visitors": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "path",
+                    "views",
+                    "visitors"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "totalViews": {
+                "type": "integer"
+              },
+              "totalVisitors": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "totalVisitors",
+              "totalViews",
+              "avgVisitorsPerPage",
+              "paths",
+              "blogUrl"
+            ],
+            "type": "object"
+          },
+          "wakaLanguages": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "percent": {
+                  "type": "number"
+                },
+                "total_seconds": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "name",
+                "percent",
+                "total_seconds"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "wakaMetrics": {
+            "additionalProperties": false,
+            "properties": {
+              "avgDailyHours": {
+                "type": "number"
+              },
+              "daysActive": {
+                "type": "integer"
+              },
+              "topLanguage": {
+                "type": "string"
+              },
+              "totalHours": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "totalHours",
+              "avgDailyHours",
+              "daysActive",
+              "topLanguage"
+            ],
+            "type": "object"
+          },
+          "wakaTrend": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "displayDate": {
+                  "type": "string"
+                },
+                "hours": {
+                  "type": "number"
+                },
+                "yearMonth": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "yearMonth",
+                "displayDate",
+                "hours"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "aiActivity",
+          "aiMetrics",
+          "aiModels",
+          "cloudflare",
+          "posthog",
+          "wakaLanguages",
+          "wakaMetrics",
+          "wakaTrend"
+        ],
+        "type": "object"
+      },
+      "ServiceInfo": {
+        "additionalProperties": false,
+        "properties": {
+          "endpoints": {
+            "additionalProperties": false,
+            "properties": {
+              "aiPercentage": {
+                "type": "string"
+              },
+              "cardDescription": {
+                "type": "string"
+              },
+              "health": {
+                "type": "string"
+              },
+              "insights": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "health",
+              "cardDescription",
+              "aiPercentage",
+              "insights"
+            ],
+            "type": "object"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "version",
+          "status",
+          "endpoints"
+        ],
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "description": "Static API token issued for agents (API_TOKEN / AGENT_API_TOKEN), passed as `Authorization: Bearer <token>`.",
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "oauth2": {
+        "description": "OAuth 2.0 against the authorization server at https://duyet.net (see /.well-known/oauth-protected-resource and /.well-known/oauth-authorization-server).",
+        "flows": {
+          "clientCredentials": {
+            "scopes": {
+              "read:profile": "Read the authenticated agent's public profile information.",
+              "chat": "Send prompts to LLM-backed endpoints such as POST /api/llm/generate."
+            },
+            "tokenUrl": "https://duyet.net/oauth/token"
+          }
+        },
+        "type": "oauth2"
+      }
+    }
+  },
+  "info": {
+    "description": "Public API for duyet.net: AI-generated card descriptions, AI code-usage metrics, and site analytics. All endpoints are rate limited per IP and return RateLimit-Limit, RateLimit-Remaining, and RateLimit-Reset headers on every response; exhausted quotas produce a 429 response with a Retry-After header (seconds until reset). Authentication uses either a static bearer token or OAuth 2.0 scopes published in /.well-known/oauth-protected-resource.",
+    "title": "duyet.net API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/": {
+      "get": {
+        "description": "Returns the service name, version, health status, and a map of available endpoints.",
+        "operationId": "getServiceInfo",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "endpoints": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "aiPercentage": {
+                          "type": "string"
+                        },
+                        "cardDescription": {
+                          "type": "string"
+                        },
+                        "health": {
+                          "type": "string"
+                        },
+                        "insights": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "health",
+                        "cardDescription",
+                        "aiPercentage",
+                        "insights"
+                      ],
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "version",
+                    "status",
+                    "endpoints"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Service information.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              },
+              "Retry-After": {
+                "$ref": "#/components/headers/Retry-After"
+              }
+            }
+          }
+        },
+        "security": [],
+        "summary": "Get service info",
+        "tags": [
+          "Meta"
+        ]
+      }
+    },
+    "/api/ai/percentage/available": {
+      "get": {
+        "description": "Reports whether AI code-percentage data exists in the backing ClickHouse table.",
+        "operationId": "getAiPercentageAvailability",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiPercentageAvailable"
+                }
+              }
+            },
+            "description": "Data availability.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              },
+              "Retry-After": {
+                "$ref": "#/components/headers/Retry-After"
+              }
+            }
+          }
+        },
+        "security": [],
+        "summary": "Check AI percentage availability",
+        "tags": [
+          "AI Percentage"
+        ]
+      }
+    },
+    "/api/ai/percentage/current": {
+      "get": {
+        "description": "Returns the most recent AI code percentage with line counts (total, human, AI) from ClickHouse.",
+        "operationId": "getCurrentAiPercentage",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "ai_percentage": {
+                      "type": "number"
+                    },
+                    "ai_lines_added": {
+                      "type": "integer"
+                    },
+                    "human_lines_added": {
+                      "type": "integer"
+                    },
+                    "total_lines_added": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "ai_percentage",
+                    "total_lines_added",
+                    "human_lines_added",
+                    "ai_lines_added"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Latest AI code percentage snapshot.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "No data available."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              },
+              "Retry-After": {
+                "$ref": "#/components/headers/Retry-After"
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "ClickHouse not configured or query failed."
+          }
+        },
+        "security": [],
+        "summary": "Get current AI percentage",
+        "tags": [
+          "AI Percentage"
+        ]
+      }
+    },
+    "/api/ai/percentage/history": {
+      "get": {
+        "description": "Returns daily AI code-percentage history ordered ascending, including line and commit splits.",
+        "operationId": "getAiPercentageHistory",
+        "parameters": [
+          {
+            "description": "Number of days to look back.",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "default": 365,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiPercentageHistoryResponse"
+                }
+              }
+            },
+            "description": "Historical AI code percentages.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              },
+              "Retry-After": {
+                "$ref": "#/components/headers/Retry-After"
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "ClickHouse not configured or query failed."
+          }
+        },
+        "security": [],
+        "summary": "Get AI percentage history",
+        "tags": [
+          "AI Percentage"
+        ]
+      }
+    },
+    "/api/insights/overview": {
+      "get": {
+        "description": "Aggregated dashboard overview combining AI usage metrics, WakaTime coding stats, Cloudflare traffic, and PostHog page analytics. Individual source failures degrade to zeroed defaults instead of erroring.",
+        "operationId": "getInsightsOverview",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsightsOverview"
+                }
+              }
+            },
+            "description": "Aggregated overview payload.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              },
+              "Retry-After": {
+                "$ref": "#/components/headers/Retry-After"
+              }
+            }
+          }
+        },
+        "security": [],
+        "summary": "Get insights overview",
+        "tags": [
+          "Insights"
+        ]
+      }
+    },
+    "/api/llm/generate": {
+      "post": {
+        "description": "Generates a short card description with an LLM. Requires authentication and is limited to 10 requests/min/IP on top of the global limit. The prompt must mention a supported card type (\"blog card\" or \"featured posts card\").",
+        "operationId": "generateLlmCardDescription",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenerateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateResponse"
+                }
+              }
+            },
+            "description": "Generated card description.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "supportedTypes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Missing/invalid prompt or unsupported card type. May include supportedTypes listing accepted card types."
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Missing or invalid bearer token."
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              },
+              "Retry-After": {
+                "$ref": "#/components/headers/Retry-After"
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "fallback": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Upstream generation failed. May include a fallback description."
+          }
+        },
+        "security": [
+          {
+            "oauth2": [
+              "chat"
+            ]
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Generate LLM card description",
+        "tags": [
+          "LLM"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Liveness probe returning an ok status and the current server time. Used by uptime checks and listed in /.well-known/api-catalog.",
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "timestamp": {
+                      "format": "date-time",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "timestamp"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Service is healthy.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              },
+              "Retry-After": {
+                "$ref": "#/components/headers/Retry-After"
+              }
+            }
+          }
+        },
+        "security": [],
+        "summary": "Health check",
+        "tags": [
+          "Meta"
+        ]
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "description": "Returns this OpenAPI document. Mirrored statically at https://duyet.net/openapi.json.",
+        "operationId": "getOpenApiDocument",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OpenAPI 3.1 document.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Rate limit exceeded. The response includes a Retry-After header with the number of seconds until the quota resets.",
+            "headers": {
+              "RateLimit-Limit": {
+                "$ref": "#/components/headers/RateLimit-Limit"
+              },
+              "RateLimit-Remaining": {
+                "$ref": "#/components/headers/RateLimit-Remaining"
+              },
+              "RateLimit-Reset": {
+                "$ref": "#/components/headers/RateLimit-Reset"
+              },
+              "Retry-After": {
+                "$ref": "#/components/headers/Retry-After"
+              }
+            }
+          }
+        },
+        "security": [],
+        "summary": "Get OpenAPI document",
+        "tags": [
+          "Meta"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.duyet.net"
+    },
+    {
+      "url": "https://duyet.net/api",
+      "description": "Same-origin mirror"
+    }
+  ]
+}

--- a/apps/home/public/sitemap.xml
+++ b/apps/home/public/sitemap.xml
@@ -35,4 +35,40 @@
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
+  <url>
+    <loc>https://duyet.net/developers</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <lastmod>2026-08-22</lastmod>
+  </url>
+  <url>
+    <loc>https://duyet.net/contact</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
+    <lastmod>2026-08-22</lastmod>
+  </url>
+  <url>
+    <loc>https://duyet.net/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+    <lastmod>2026-08-22</lastmod>
+  </url>
+  <url>
+    <loc>https://duyet.net/p/anyrouter</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <lastmod>2026-08-22</lastmod>
+  </url>
+  <url>
+    <loc>https://duyet.net/p/chm</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <lastmod>2026-08-22</lastmod>
+  </url>
+  <url>
+    <loc>https://duyet.net/p/stamp</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <lastmod>2026-08-22</lastmod>
+  </url>
 </urlset>

--- a/apps/home/src/components/NotFound.tsx
+++ b/apps/home/src/components/NotFound.tsx
@@ -17,6 +17,31 @@ export function NotFound() {
         >
           Go back home
         </Link>
+        <div className="mt-10 border-t pt-6 text-xs text-muted-foreground">
+          <p className="mb-2 font-mono uppercase tracking-widest">
+            For agents &amp; crawlers
+          </p>
+          <ul className="flex flex-wrap justify-center gap-x-4 gap-y-1">
+            {[
+              { href: "/llms.txt", label: "/llms.txt" },
+              { href: "/sitemap.xml", label: "/sitemap.xml" },
+              {
+                href: "/.well-known/api-catalog",
+                label: "/.well-known/api-catalog",
+              },
+              { href: "/developers", label: "/developers" },
+            ].map((item) => (
+              <li key={item.href}>
+                <a
+                  href={item.href}
+                  className="underline underline-offset-2 hover:text-foreground"
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/apps/home/src/lib/jsonld.ts
+++ b/apps/home/src/lib/jsonld.ts
@@ -1,0 +1,47 @@
+/** JSON-LD builders for schema.org structured data on the homepage. */
+
+export function websiteJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "duyet.net",
+    url: "https://duyet.net",
+    inLanguage: "en",
+  };
+}
+
+export function personJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Duyet",
+    url: "https://duyet.net/",
+    jobTitle: "Senior Data Engineer",
+    sameAs: [
+      "https://github.com/duyet",
+      "https://linkedin.com/in/duyet",
+      "https://x.com/_duyet",
+    ],
+  };
+}
+
+export function organizationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "duyet.net",
+    url: "https://duyet.net",
+    contactPoint: [
+      {
+        "@type": "ContactPoint",
+        contactType: "customer support",
+        email: "me@duyet.net",
+        url: "https://duyet.net/contact",
+      },
+    ],
+    address: {
+      "@type": "PostalAddress",
+      addressCountry: "VN",
+    },
+  };
+}

--- a/apps/home/src/routeTree.gen.ts
+++ b/apps/home/src/routeTree.gen.ts
@@ -9,38 +9,21 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ProjectsRouteImport } from './routes/projects'
-import { Route as LsRouteImport } from './routes/ls'
-import { Route as FossilRouteImport } from './routes/fossil'
-import { Route as CartrackRouteImport } from './routes/cartrack'
-import { Route as AboutDuyetbotRouteImport } from './routes/about-duyetbot'
-import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AboutRouteImport } from './routes/about'
+import { Route as AboutDuyetbotRouteImport } from './routes/about-duyetbot'
+import { Route as CartrackRouteImport } from './routes/cartrack'
+import { Route as ContactRouteImport } from './routes/contact'
+import { Route as DevelopersRouteImport } from './routes/developers'
+import { Route as FossilRouteImport } from './routes/fossil'
+import { Route as LsRouteImport } from './routes/ls'
+import { Route as PrivacyRouteImport } from './routes/privacy'
+import { Route as ProjectsRouteImport } from './routes/projects'
 import { Route as PProjectRouteImport } from './routes/p/$project'
 
-const ProjectsRoute = ProjectsRouteImport.update({
-  id: '/projects',
-  path: '/projects',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LsRoute = LsRouteImport.update({
-  id: '/ls',
-  path: '/ls',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const FossilRoute = FossilRouteImport.update({
-  id: '/fossil',
-  path: '/fossil',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const CartrackRoute = CartrackRouteImport.update({
-  id: '/cartrack',
-  path: '/cartrack',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AboutDuyetbotRoute = AboutDuyetbotRouteImport.update({
-  id: '/about-duyetbot',
-  path: '/about-duyetbot',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AboutRoute = AboutRouteImport.update({
@@ -48,9 +31,44 @@ const AboutRoute = AboutRouteImport.update({
   path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const AboutDuyetbotRoute = AboutDuyetbotRouteImport.update({
+  id: '/about-duyetbot',
+  path: '/about-duyetbot',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CartrackRoute = CartrackRouteImport.update({
+  id: '/cartrack',
+  path: '/cartrack',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DevelopersRoute = DevelopersRouteImport.update({
+  id: '/developers',
+  path: '/developers',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FossilRoute = FossilRouteImport.update({
+  id: '/fossil',
+  path: '/fossil',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LsRoute = LsRouteImport.update({
+  id: '/ls',
+  path: '/ls',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProjectsRoute = ProjectsRouteImport.update({
+  id: '/projects',
+  path: '/projects',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PProjectRoute = PProjectRouteImport.update({
@@ -64,8 +82,11 @@ export interface FileRoutesByFullPath {
   '/about': typeof AboutRoute
   '/about-duyetbot': typeof AboutDuyetbotRoute
   '/cartrack': typeof CartrackRoute
+  '/contact': typeof ContactRoute
+  '/developers': typeof DevelopersRoute
   '/fossil': typeof FossilRoute
   '/ls': typeof LsRoute
+  '/privacy': typeof PrivacyRoute
   '/projects': typeof ProjectsRoute
   '/p/$project': typeof PProjectRoute
 }
@@ -74,8 +95,11 @@ export interface FileRoutesByTo {
   '/about': typeof AboutRoute
   '/about-duyetbot': typeof AboutDuyetbotRoute
   '/cartrack': typeof CartrackRoute
+  '/contact': typeof ContactRoute
+  '/developers': typeof DevelopersRoute
   '/fossil': typeof FossilRoute
   '/ls': typeof LsRoute
+  '/privacy': typeof PrivacyRoute
   '/projects': typeof ProjectsRoute
   '/p/$project': typeof PProjectRoute
 }
@@ -85,8 +109,11 @@ export interface FileRoutesById {
   '/about': typeof AboutRoute
   '/about-duyetbot': typeof AboutDuyetbotRoute
   '/cartrack': typeof CartrackRoute
+  '/contact': typeof ContactRoute
+  '/developers': typeof DevelopersRoute
   '/fossil': typeof FossilRoute
   '/ls': typeof LsRoute
+  '/privacy': typeof PrivacyRoute
   '/projects': typeof ProjectsRoute
   '/p/$project': typeof PProjectRoute
 }
@@ -97,8 +124,11 @@ export interface FileRouteTypes {
     | '/about'
     | '/about-duyetbot'
     | '/cartrack'
+    | '/contact'
+    | '/developers'
     | '/fossil'
     | '/ls'
+    | '/privacy'
     | '/projects'
     | '/p/$project'
   fileRoutesByTo: FileRoutesByTo
@@ -107,8 +137,11 @@ export interface FileRouteTypes {
     | '/about'
     | '/about-duyetbot'
     | '/cartrack'
+    | '/contact'
+    | '/developers'
     | '/fossil'
     | '/ls'
+    | '/privacy'
     | '/projects'
     | '/p/$project'
   id:
@@ -117,8 +150,11 @@ export interface FileRouteTypes {
     | '/about'
     | '/about-duyetbot'
     | '/cartrack'
+    | '/contact'
+    | '/developers'
     | '/fossil'
     | '/ls'
+    | '/privacy'
     | '/projects'
     | '/p/$project'
   fileRoutesById: FileRoutesById
@@ -128,47 +164,22 @@ export interface RootRouteChildren {
   AboutRoute: typeof AboutRoute
   AboutDuyetbotRoute: typeof AboutDuyetbotRoute
   CartrackRoute: typeof CartrackRoute
+  ContactRoute: typeof ContactRoute
+  DevelopersRoute: typeof DevelopersRoute
   FossilRoute: typeof FossilRoute
   LsRoute: typeof LsRoute
+  PrivacyRoute: typeof PrivacyRoute
   ProjectsRoute: typeof ProjectsRoute
   PProjectRoute: typeof PProjectRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/projects': {
-      id: '/projects'
-      path: '/projects'
-      fullPath: '/projects'
-      preLoaderRoute: typeof ProjectsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/ls': {
-      id: '/ls'
-      path: '/ls'
-      fullPath: '/ls'
-      preLoaderRoute: typeof LsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/fossil': {
-      id: '/fossil'
-      path: '/fossil'
-      fullPath: '/fossil'
-      preLoaderRoute: typeof FossilRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/cartrack': {
-      id: '/cartrack'
-      path: '/cartrack'
-      fullPath: '/cartrack'
-      preLoaderRoute: typeof CartrackRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/about-duyetbot': {
-      id: '/about-duyetbot'
-      path: '/about-duyetbot'
-      fullPath: '/about-duyetbot'
-      preLoaderRoute: typeof AboutDuyetbotRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {
@@ -178,11 +189,60 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AboutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/about-duyetbot': {
+      id: '/about-duyetbot'
+      path: '/about-duyetbot'
+      fullPath: '/about-duyetbot'
+      preLoaderRoute: typeof AboutDuyetbotRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cartrack': {
+      id: '/cartrack'
+      path: '/cartrack'
+      fullPath: '/cartrack'
+      preLoaderRoute: typeof CartrackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/developers': {
+      id: '/developers'
+      path: '/developers'
+      fullPath: '/developers'
+      preLoaderRoute: typeof DevelopersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fossil': {
+      id: '/fossil'
+      path: '/fossil'
+      fullPath: '/fossil'
+      preLoaderRoute: typeof FossilRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/ls': {
+      id: '/ls'
+      path: '/ls'
+      fullPath: '/ls'
+      preLoaderRoute: typeof LsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/projects': {
+      id: '/projects'
+      path: '/projects'
+      fullPath: '/projects'
+      preLoaderRoute: typeof ProjectsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/p/$project': {
@@ -200,8 +260,11 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   AboutDuyetbotRoute: AboutDuyetbotRoute,
   CartrackRoute: CartrackRoute,
+  ContactRoute: ContactRoute,
+  DevelopersRoute: DevelopersRoute,
   FossilRoute: FossilRoute,
   LsRoute: LsRoute,
+  PrivacyRoute: PrivacyRoute,
   ProjectsRoute: ProjectsRoute,
   PProjectRoute: PProjectRoute,
 }

--- a/apps/home/src/routes/about-duyetbot.tsx
+++ b/apps/home/src/routes/about-duyetbot.tsx
@@ -14,6 +14,7 @@ export const Route = createFileRoute("/about-duyetbot")({
           "duyetbot is an autonomous agent that maintains, redesigns, and ships duyet.net. A bundle of self-built AI agent skills running on top of the Hermes agent runtime.",
       },
     ],
+    links: [{ rel: "canonical", href: "https://duyet.net/about-duyetbot" }],
   }),
 });
 

--- a/apps/home/src/routes/contact.tsx
+++ b/apps/home/src/routes/contact.tsx
@@ -1,0 +1,133 @@
+import { Eyebrow, Reveal, SecHead } from "@duyet/components";
+import { createFileRoute } from "@tanstack/react-router";
+
+const CHANNELS: Array<{ label: string; href: string; desc: string }> = [
+  {
+    label: "Email",
+    href: "mailto:me@duyet.net",
+    desc: "me@duyet.net — the fastest way to reach me, and the best one for anything that needs a considered reply.",
+  },
+  {
+    label: "GitHub",
+    href: "https://github.com/duyet",
+    desc: "github.com/duyet — issues and pull requests on any of my repositories get read.",
+  },
+  {
+    label: "X (Twitter)",
+    href: "https://x.com/_duyet",
+    desc: "x.com/_duyet — quick questions and public threads.",
+  },
+  {
+    label: "LinkedIn",
+    href: "https://linkedin.com/in/duyet",
+    desc: "linkedin.com/in/duyet — professional messages and intros.",
+  },
+];
+
+export const Route = createFileRoute("/contact")({
+  component: ContactPage,
+  head: () => ({
+    meta: [
+      { title: "Contact Duyet" },
+      {
+        name: "description",
+        content:
+          "How to reach Duyet Le — email, GitHub, X, LinkedIn, or the MCP send_message tool for AI agents. Open to data engineering work, collaboration, speaking, and feedback.",
+      },
+    ],
+    links: [{ rel: "canonical", href: "https://duyet.net/contact" }],
+  }),
+});
+
+function ContactPage() {
+  return (
+    <div className="page-enter bg-[var(--rd-bg)] text-[var(--rd-text)]">
+      <div className="mx-auto max-w-[640px] px-[var(--rd-pad)] pt-[clamp(40px,5vw,64px)] pb-[clamp(56px,8vw,96px)]">
+        <Reveal>
+          <Eyebrow>Contact</Eyebrow>
+          <h1 className="rd-display mt-[13px] text-[clamp(2rem,4.2vw,3.2rem)] leading-[1.04]">
+            Say hello.
+          </h1>
+          <p className="rd-lead mt-6 max-w-[56ch]">
+            I'm Duyet — a Senior Data Engineer. If you want to talk about work,
+            a project, a talk, or something you found here, any of the channels
+            below lands with me directly. Email is the primary one:{" "}
+            <a href="mailto:me@duyet.net" className="rd-ulink">
+              me@duyet.net
+            </a>
+            .
+          </p>
+        </Reveal>
+
+        {/* channels */}
+        <section className="mt-9 border-t border-[var(--rd-border)] pt-7">
+          <Eyebrow>Channels</Eyebrow>
+          <ul className="mt-4 flex flex-col gap-4">
+            {CHANNELS.map((channel) => (
+              <li key={channel.label}>
+                <a
+                  href={channel.href}
+                  target={channel.href.startsWith("mailto:") ? undefined : "_blank"}
+                  rel="noreferrer"
+                  className="text-[14.5px] font-medium tracking-[-0.01em]"
+                >
+                  {channel.label}
+                </a>
+                <p className="mt-1 text-[14px] leading-[1.55] text-[var(--rd-text-2)]">
+                  {channel.desc}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* what to reach out about */}
+        <section className="mt-9 border-t border-[var(--rd-border)] pt-7">
+          <Reveal>
+            <SecHead
+              eyebrow="Good fits"
+              title="What to reach out about"
+            />
+            <ul className="flex flex-col gap-3 text-[14.5px] leading-[1.6] text-[var(--rd-text-2)]">
+              <li>
+                Full-time or contract data engineering work — platform builds,
+                ClickHouse migrations, AI agents in production.
+              </li>
+              <li>
+                Collaboration on open-source projects, or an idea you think is
+                worth building together.
+              </li>
+              <li>Speaking invitations for data engineering and AI topics.</li>
+              <li>
+                Feedback on my open-source projects — bug reports, use cases,
+                and criticism are all useful.
+              </li>
+            </ul>
+            <p className="mt-5 text-[14.5px] leading-[1.6] text-[var(--rd-text-2)]">
+              If you're reading this as an AI agent: this site also exposes an
+              MCP server at{" "}
+              <a href="https://mcp.duyet.net/mcp" className="rd-ulink">
+                https://mcp.duyet.net/mcp
+              </a>{" "}
+              with a{" "}
+              <code className="font-[var(--font-mono)] text-[12.5px]">
+                send_message
+              </code>{" "}
+              tool — it's a fully agent-friendly contact channel, no browser
+              required.
+            </p>
+            <p className="mt-4 text-[13.5px] leading-[1.6] text-[var(--rd-text-3)]">
+              I usually reply within a few days; email gets the fastest
+              response. Messages sent through the contact form or MCP are
+              stored so they can be answered — see the{" "}
+              <a href="/privacy" className="rd-ulink">
+                privacy policy
+              </a>{" "}
+              for details.
+            </p>
+          </Reveal>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/home/src/routes/developers.tsx
+++ b/apps/home/src/routes/developers.tsx
@@ -1,0 +1,291 @@
+import { Eyebrow, Reveal, SecHead } from "@duyet/components";
+import { createFileRoute } from "@tanstack/react-router";
+
+const API_ENDPOINTS: Array<{ method: string; path: string; desc: string }> = [
+  {
+    method: "GET",
+    path: "/health",
+    desc: "Service health check.",
+  },
+  {
+    method: "GET",
+    path: "/api/ai/percentage/current",
+    desc: "How much of duyet.net is AI-written, right now.",
+  },
+  {
+    method: "GET",
+    path: "/api/ai/percentage/history?days=N",
+    desc: "AI-percentage time series for the last N days.",
+  },
+  {
+    method: "GET",
+    path: "/api/ai/percentage/available",
+    desc: "Days with AI-percentage data available.",
+  },
+  {
+    method: "GET",
+    path: "/api/insights/overview",
+    desc: "Aggregated development insights from this site.",
+  },
+  {
+    method: "POST",
+    path: "/api/llm/generate",
+    desc: "LLM generation (card descriptions). Requires a bearer token.",
+  },
+];
+
+export const Route = createFileRoute("/developers")({
+  component: DevelopersPage,
+  head: () => ({
+    meta: [
+      { title: "Duyet Developer Resources – API, MCP & Tools" },
+      {
+        name: "description",
+        content:
+          "Public stats API, MCP server, and machine-readable indexes for duyet.net — everything developers and AI agents need to integrate with the site.",
+      },
+    ],
+    links: [{ rel: "canonical", href: "https://duyet.net/developers" }],
+  }),
+});
+
+function CodeBlock({ children }: { children: string }) {
+  return (
+    <pre className="rd-card overflow-x-auto p-[14px] font-[var(--font-mono)] text-[12.5px] leading-[1.65] text-[var(--rd-text-2)]">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function DevelopersPage() {
+  return (
+    <div className="page-enter bg-[var(--rd-bg)] text-[var(--rd-text)]">
+      <div className="mx-auto max-w-[var(--rd-maxw)] px-[var(--rd-pad)] pt-[clamp(40px,5vw,64px)] pb-[clamp(56px,8vw,96px)]">
+        {/* intro */}
+        <Reveal>
+          <Eyebrow>Developers · API</Eyebrow>
+          <h1 className="rd-display mt-[13px] text-[clamp(2rem,4.2vw,3.3rem)] leading-[1.04]">
+            Duyet Developer{" "}
+            <span className="text-[var(--rd-accent)]">Resources</span>
+          </h1>
+          <p className="rd-lead mt-6 max-w-[62ch]">
+            Everything on duyet.net is readable by machines, not just people.
+            This page collects what's available for developers and AI agents: a
+            public stats API, an MCP server your assistant can connect to, and
+            machine-readable indexes that describe the rest of the site.
+          </p>
+        </Reveal>
+
+        {/* public api */}
+        <section className="mt-[clamp(48px,7vw,80px)]">
+          <Reveal>
+            <SecHead num="01" eyebrow="Public API" title="Stats & metrics API" />
+            <p className="text-[var(--rd-text-2)] max-w-[62ch] text-[15px] leading-[1.65]">
+              The public API serves site metrics and insights. It is available
+              at{" "}
+              <a href="https://api.duyet.net" className="rd-ulink">
+                https://api.duyet.net
+              </a>{" "}
+              (primary), with a same-origin mirror at{" "}
+              <a href="/api" className="rd-ulink">
+                https://duyet.net/api
+              </a>
+              . All GET endpoints below are public and need no authentication.
+            </p>
+            <div className="mt-5 overflow-x-auto">
+              <table className="w-full min-w-[560px] border-collapse text-left text-[13.5px]">
+                <thead>
+                  <tr className="border-b border-[var(--rd-border)]">
+                    <th className="py-2 pr-4 font-medium tracking-[-0.01em]">
+                      Method
+                    </th>
+                    <th className="py-2 pr-4 font-medium tracking-[-0.01em]">
+                      Endpoint
+                    </th>
+                    <th className="py-2 font-medium tracking-[-0.01em]">
+                      Description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {API_ENDPOINTS.map((endpoint) => (
+                    <tr
+                      key={endpoint.path}
+                      className="border-b border-[var(--rd-border)] align-top"
+                    >
+                      <td className="py-2.5 pr-4 font-[var(--font-mono)] text-[12px] whitespace-nowrap">
+                        <span
+                          className={
+                            endpoint.method === "POST"
+                              ? "text-[var(--rd-warn)]"
+                              : undefined
+                          }
+                        >
+                          {endpoint.method}
+                        </span>
+                      </td>
+                      <td className="py-2.5 pr-4 font-[var(--font-mono)] text-[12.5px]">
+                        {endpoint.path}
+                      </td>
+                      <td className="py-2.5 text-[var(--rd-text-2)] leading-[1.55]">
+                        {endpoint.desc}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="mt-8 rd-g2">
+              <div className="rd-card p-[clamp(18px,2.2vw,26px)]">
+                <Eyebrow>Authentication</Eyebrow>
+                <p className="mt-3 text-[13.5px] leading-[1.65] text-[var(--rd-text-2)]">
+                  Public GET endpoints need no auth.{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">
+                    POST /api/llm/generate
+                  </code>{" "}
+                  uses{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">
+                    Authorization: Bearer &lt;token&gt;
+                  </code>{" "}
+                  — request access by email{" "}
+                  <a href="mailto:me@duyet.net" className="rd-ulink">
+                    me@duyet.net
+                  </a>
+                  . OAuth scopes{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">
+                    read:profile
+                  </code>{" "}
+                  and{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">
+                    chat
+                  </code>{" "}
+                  are declared in{" "}
+                  <a
+                    href="/.well-known/oauth-protected-resource"
+                    className="rd-ulink"
+                  >
+                    /.well-known/oauth-protected-resource
+                  </a>
+                  .
+                </p>
+              </div>
+              <div className="rd-card p-[clamp(18px,2.2vw,26px)]">
+                <Eyebrow>Rate limits</Eyebrow>
+                <p className="mt-3 text-[13.5px] leading-[1.65] text-[var(--rd-text-2)]">
+                  Responses carry{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">
+                    RateLimit-Limit
+                  </code>
+                  ,{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">
+                    RateLimit-Remaining
+                  </code>
+                  , and{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">
+                    RateLimit-Reset
+                  </code>{" "}
+                  headers. Exceeding the limit returns{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">429</code>{" "}
+                  with a{" "}
+                  <code className="font-[var(--font-mono)] text-[12.5px]">
+                    Retry-After
+                  </code>{" "}
+                  header — back off and retry after that many seconds.
+                </p>
+              </div>
+            </div>
+          </Reveal>
+        </section>
+
+        {/* mcp */}
+        <section className="mt-[clamp(48px,7vw,80px)]">
+          <Reveal>
+            <SecHead num="02" eyebrow="MCP" title="Connect AI assistants" />
+            <p className="text-[var(--rd-text-2)] max-w-[62ch] text-[15px] leading-[1.65]">
+              The MCP server exposes Duyet's CV, blog posts, GitHub activity,
+              and contact tools over Streamable HTTP. Point any MCP-compatible
+              client (Claude, Cursor, and others) at{" "}
+              <a href="https://mcp.duyet.net/mcp" className="rd-ulink">
+                https://mcp.duyet.net/mcp
+              </a>
+              :
+            </p>
+            <div className="mt-4 max-w-[640px]">
+              <CodeBlock>{`claude mcp add --transport http duyet https://mcp.duyet.net/mcp`}</CodeBlock>
+            </div>
+          </Reveal>
+        </section>
+
+        {/* machine-readable files */}
+        <section className="mt-[clamp(48px,7vw,80px)]">
+          <Reveal>
+            <SecHead
+              num="03"
+              eyebrow="Discovery"
+              title="Machine-readable files"
+            />
+            <ul className="mt-2 flex flex-col divide-y divide-[var(--rd-border)] border-y border-[var(--rd-border)]">
+              {[
+                {
+                  href: "/openapi.json",
+                  label: "/openapi.json",
+                  desc: "OpenAPI 3.1 spec for the public API.",
+                },
+                {
+                  href: "/llms.txt",
+                  label: "/llms.txt",
+                  desc: "LLM-friendly index of the whole site.",
+                },
+                {
+                  href: "/sitemap.xml",
+                  label: "/sitemap.xml",
+                  desc: "Every indexable page.",
+                },
+                {
+                  href: "/.well-known/api-catalog",
+                  label: "/.well-known/api-catalog",
+                  desc: "Link-set catalog of available APIs.",
+                },
+                {
+                  href: "/.well-known/oauth-protected-resource",
+                  label: "/.well-known/oauth-protected-resource",
+                  desc: "OAuth protected-resource metadata.",
+                },
+                {
+                  href: "/.well-known/mcp/server-card.json",
+                  label: "/.well-known/mcp/server-card.json",
+                  desc: "MCP server card.",
+                },
+              ].map((file) => (
+                <li key={file.href} className="flex flex-wrap gap-x-4 py-3">
+                  <a
+                    href={file.href}
+                    className="rd-ulink font-[var(--font-mono)] text-[13px]"
+                  >
+                    {file.label}
+                  </a>
+                  <span className="text-[var(--rd-text-3)] text-[13.5px]">
+                    {file.desc}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </Reveal>
+        </section>
+
+        {/* quickstart */}
+        <section className="mt-[clamp(48px,7vw,80px)] pb-[clamp(24px,4vw,48px)]">
+          <Reveal>
+            <SecHead num="04" eyebrow="Quickstart" title="Try it in 30 seconds" />
+            <div className="flex flex-col gap-3 max-w-[720px]">
+              <CodeBlock>{`curl https://api.duyet.net/health`}</CodeBlock>
+              <CodeBlock>{`curl https://api.duyet.net/api/ai/percentage/current`}</CodeBlock>
+              <CodeBlock>{`curl https://api.duyet.net/api/insights/overview`}</CodeBlock>
+            </div>
+          </Reveal>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/home/src/routes/index.tsx
+++ b/apps/home/src/routes/index.tsx
@@ -19,9 +19,38 @@ import { NowDeco } from "../components/NowDeco";
 import { Button } from "../components/ui/button";
 import { WorkBento } from "../components/WorkBento";
 import { type AppItem, apps } from "../data/projects";
+import {
+  organizationJsonLd,
+  personJsonLd,
+  websiteJsonLd,
+} from "../lib/jsonld";
 
 export const Route = createFileRoute("/")({
   component: HomePage,
+  head: () => ({
+    meta: [
+      {
+        name: "description",
+        content:
+          "I build AI agents and the data platforms that keep them honest — end-to-end, obsessing over the small details that make software feel right to use.",
+      },
+    ],
+    links: [{ rel: "canonical", href: "https://duyet.net/" }],
+    scripts: [
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(websiteJsonLd()),
+      },
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(personJsonLd()),
+      },
+      {
+        type: "application/ld+json",
+        children: JSON.stringify(organizationJsonLd()),
+      },
+    ],
+  }),
 });
 
 // ---------------------------------------------------------------------------
@@ -188,6 +217,49 @@ function HomePage() {
                   About me <ArrowUpRight size={16} />
                 </Link>
               </Button>
+            </div>
+          </Reveal>
+        </section>
+
+        {/* developer & agent resources */}
+        <section className="mx-auto max-w-[var(--rd-maxw)] px-[var(--rd-pad)] py-[clamp(40px,5vw,64px)] border-t border-[var(--rd-border)]">
+          <Reveal>
+            <SecHead
+              num="04"
+              eyebrow="For developers & agents"
+              title="Machine-readable, on purpose"
+              links={[
+                {
+                  label: "All resources",
+                  onClick: () => window.location.assign("/developers"),
+                },
+              ]}
+            />
+            <p className="rd-lead max-w-[58ch] text-[clamp(0.95rem,1.2vw,1.05rem)]">
+              This site exposes a public stats API, an MCP server for AI
+              assistants, and machine-readable indexes alongside the pages.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Link
+                to="/developers"
+                className="rd-chip rd-chip-btn no-underline"
+              >
+                Developer resources
+              </Link>
+              <a href="/openapi.json" className="rd-chip rd-chip-btn no-underline">
+                API spec
+              </a>
+              <a
+                href="https://mcp.duyet.net/mcp"
+                target="_blank"
+                rel="noreferrer"
+                className="rd-chip rd-chip-btn no-underline"
+              >
+                MCP server
+              </a>
+              <a href="/llms.txt" className="rd-chip rd-chip-btn no-underline">
+                LLM index
+              </a>
             </div>
           </Reveal>
         </section>

--- a/apps/home/src/routes/ls.tsx
+++ b/apps/home/src/routes/ls.tsx
@@ -9,6 +9,9 @@ import UrlsList from "../components/UrlsList";
 
 export const Route = createFileRoute("/ls")({
   component: ListPage,
+  head: () => ({
+    links: [{ rel: "canonical", href: "https://duyet.net/ls" }],
+  }),
 });
 
 const publicUrls = Object.entries(urls)

--- a/apps/home/src/routes/p/$project.tsx
+++ b/apps/home/src/routes/p/$project.tsx
@@ -90,6 +90,12 @@ export const Route = createFileRoute("/p/$project")({
             "A Duyet Le project surface for data, AI, and developer tools.",
         },
       ],
+      links: [
+        {
+          rel: "canonical",
+          href: `https://duyet.net/p/${params.project}`,
+        },
+      ],
     };
   },
   loader: ({ params }) => {

--- a/apps/home/src/routes/privacy.tsx
+++ b/apps/home/src/routes/privacy.tsx
@@ -1,0 +1,103 @@
+import { Eyebrow, Reveal } from "@duyet/components";
+import { createFileRoute } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+
+const EFFECTIVE_DATE = "2026-08-22";
+
+export const Route = createFileRoute("/privacy")({
+  component: PrivacyPage,
+  head: () => ({
+    meta: [
+      { title: "Privacy Policy – duyet.net" },
+      {
+        name: "description",
+        content:
+          "How duyet.net handles data: aggregate privacy-respecting analytics via Cloudflare, no advertising and no sale of personal data, and how to request deletion.",
+      },
+    ],
+    links: [{ rel: "canonical", href: "https://duyet.net/privacy" }],
+  }),
+});
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="mt-9 border-t border-[var(--rd-border)] pt-7">
+      <h2 className="text-[1.05rem] font-medium tracking-[-0.01em]">{title}</h2>
+      <div className="mt-3 flex flex-col gap-3 text-[14.5px] leading-[1.65] text-[var(--rd-text-2)]">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function PrivacyPage() {
+  return (
+    <div className="page-enter bg-[var(--rd-bg)] text-[var(--rd-text)]">
+      <div className="mx-auto max-w-[640px] px-[var(--rd-pad)] pt-[clamp(40px,5vw,64px)] pb-[clamp(56px,8vw,96px)]">
+        <Reveal>
+          <Eyebrow>Legal · Effective {EFFECTIVE_DATE}</Eyebrow>
+          <h1 className="rd-display mt-[13px] text-[clamp(2rem,4.2vw,3.2rem)] leading-[1.04]">
+            Privacy Policy
+          </h1>
+          <p className="rd-lead mt-6 max-w-[56ch]">
+            This site is a personal homepage, and it is built to be read — by
+            people and by machines — without collecting more than it needs.
+            This page describes what data duyet.net handles, in plain terms.
+          </p>
+        </Reveal>
+
+        <Section title="What this site collects">
+          <p>
+            This site uses aggregate, privacy-respecting analytics served
+            through Cloudflare. The analytics are counted in aggregate — they
+            show that visits happened, not who you are. No advertising runs on
+            this site, no personal data is sold, and no cross-site tracking
+            cookies are used to follow you around the web.
+          </p>
+        </Section>
+
+        <Section title="Third-party services">
+          <p>
+            The site is hosted on Cloudflare (Pages and the CDN in front of
+            it), which serves content and protects against abuse. Repository
+            information shown on the site is fetched from GitHub's public API.
+            These services see standard technical request data (such as IP
+            address and user agent) as part of serving the site; their own
+            policies govern what they do with it.
+          </p>
+        </Section>
+
+        <Section title="Contact submissions">
+          <p>
+            Messages you send — through the contact form or through the MCP{" "}
+            <code className="font-[var(--font-mono)] text-[12.5px]">
+              send_message
+            </code>{" "}
+            tool — are stored so they can be read and answered. They are not
+            used for marketing and are not shared with third parties.
+          </p>
+        </Section>
+
+        <Section title="Questions & deletion requests">
+          <p>
+            If you have questions about this policy, or want a message you
+            sent deleted, email{" "}
+            <a href="mailto:me@duyet.net" className="rd-ulink">
+              me@duyet.net
+            </a>{" "}
+            and I'll take care of it.
+          </p>
+          <p className="text-[13px] text-[var(--rd-text-3)]">
+            Effective date: {EFFECTIVE_DATE}
+          </p>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/apps/home/src/routes/projects.tsx
+++ b/apps/home/src/routes/projects.tsx
@@ -25,6 +25,7 @@ export const Route = createFileRoute("/projects")({
           "A complete list of Duyet Le projects, apps, dashboards, AI tools, and open source work.",
       },
     ],
+    links: [{ rel: "canonical", href: "https://duyet.net/projects" }],
   }),
 });
 

--- a/apps/home/vite.config.ts
+++ b/apps/home/vite.config.ts
@@ -38,6 +38,12 @@ export default defineConfig({
         "/ls",
         "/cartrack",
         "/fossil",
+        "/developers",
+        "/contact",
+        "/privacy",
+        "/p/anyrouter",
+        "/p/chm",
+        "/p/stamp",
       ].map((path) => ({
         path,
         prerender: { enabled: true },

--- a/apps/news/src/components/PrefsPanel.tsx
+++ b/apps/news/src/components/PrefsPanel.tsx
@@ -131,7 +131,7 @@ function SettingsTab({ t }: { t: (en: string, vi: string) => string }) {
   const sectionToggles: { key: keyof typeof prefs.sections; label: string }[] =
     [
       { key: "trending", label: t("Trending", "Xu hướng") },
-      { key: "tldr", label: "TL;DR" },
+      { key: "tldr", label: "AI;DR" },
       { key: "days", label: t("Daily feed", "Bảng tin theo ngày") },
       { key: "categories", label: t("Category nav", "Danh mục") },
     ];
@@ -140,7 +140,7 @@ function SettingsTab({ t }: { t: (en: string, vi: string) => string }) {
     <div className="space-y-4">
       <div>
         <span className="mb-1.5 block text-xs text-muted-foreground">
-          {t("TL;DR items", "Số mục TL;DR")}
+          {t("AI;DR items", "Số mục AI;DR")}
         </span>
         <div className="flex gap-1.5">
           {TLDR_COUNTS.map((n) => (

--- a/apps/news/src/components/TldrSection.tsx
+++ b/apps/news/src/components/TldrSection.tsx
@@ -65,7 +65,7 @@ export function TldrSection({
     <section className="border-y-2 border-brand py-4">
       <div className="mb-2.5 flex items-baseline justify-between gap-3">
         <div className="flex items-baseline gap-3">
-          <h2 className="text-lg font-bold tracking-widest">TL;DR</h2>
+          <h2 className="text-lg font-bold tracking-widest">AI;DR</h2>
           <span className="text-xs text-muted-foreground">
             {snapshotDate
               ? snapshotDate

--- a/apps/news/src/components/system/AdminPanel.tsx
+++ b/apps/news/src/components/system/AdminPanel.tsx
@@ -411,7 +411,7 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
           disabled={tldrBusy}
           className="rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-muted disabled:opacity-50"
         >
-          {tldrBusy ? "Regenerating…" : "Regenerate TL;DR"}
+          {tldrBusy ? "Regenerating…" : "Regenerate AI;DR"}
         </button>
         {tldrResult && (
           <span className="text-xs text-muted-foreground">{tldrResult}</span>
@@ -440,7 +440,7 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
 
       <div className="mt-4">
         <p className="text-xs font-medium text-muted-foreground">
-          Telegram / TL;DR
+          Telegram / AI;DR
         </p>
         <pre className="mt-1 max-h-32 overflow-auto rounded border border-border p-2 text-xs text-muted-foreground">
           {status

--- a/apps/news/src/components/system/RunsList.tsx
+++ b/apps/news/src/components/system/RunsList.tsx
@@ -54,7 +54,7 @@ function extraBadges(stats: WorkflowRunStats, lang: "en" | "vi"): ExtraBadge[] {
     }
   }
   if (stats.tldrGenerated) {
-    badges.push({ label: lang === "vi" ? "TL;DR" : "TL;DR", value: 1 });
+    badges.push({ label: lang === "vi" ? "AI;DR" : "AI;DR", value: 1 });
   }
   return badges;
 }

--- a/apps/news/src/components/system/RunsList.tsx
+++ b/apps/news/src/components/system/RunsList.tsx
@@ -54,7 +54,7 @@ function extraBadges(stats: WorkflowRunStats, lang: "en" | "vi"): ExtraBadge[] {
     }
   }
   if (stats.tldrGenerated) {
-    badges.push({ label: lang === "vi" ? "AI;DR" : "AI;DR", value: 1 });
+    badges.push({ label: "AI;DR", value: 1 });
   }
   return badges;
 }

--- a/apps/news/src/lib/highlight.test.ts
+++ b/apps/news/src/lib/highlight.test.ts
@@ -53,6 +53,28 @@ describe("highlightTitle", () => {
     expect(highlighted[0].text.toLowerCase()).toBe("open source");
   });
 
+  it("does not highlight a needle embedded in a larger word", () => {
+    // "SpaceXAI" is a single brand: neither "SpaceX" nor "xAI" may color
+    // a fragment of it — only the standalone "Grok" gets highlighted.
+    const segments = highlightTitle("SpaceXAI Opens Grok Build to All", [
+      "SpaceX",
+      "xAI",
+      "Grok",
+    ]);
+    const highlighted = segments.filter((s) => s.highlighted).map((s) => s.text);
+    expect(highlighted).toEqual(["Grok"]);
+  });
+
+  it("still matches when bordered by digits or punctuation", () => {
+    const gpt = highlightTitle("New GPT-5.6 model announced", ["GPT"]);
+    expect(gpt.filter((s) => s.highlighted).map((s) => s.text)).toEqual(["GPT"]);
+
+    const qwen = highlightTitle("Qwen3 tops the charts", ["qwen"]);
+    expect(qwen.filter((s) => s.highlighted).map((s) => s.text)).toEqual([
+      "Qwen",
+    ]);
+  });
+
   it("caps highlights at 3 distinct tags", () => {
     const title = "Alpha Beta Gamma Delta all launch today";
     const segments = highlightTitle(title, ["alpha", "beta", "gamma", "delta"]);

--- a/apps/news/src/lib/highlight.ts
+++ b/apps/news/src/lib/highlight.ts
@@ -10,6 +10,10 @@ export interface TitleSegment {
 
 const MAX_HIGHLIGHTS = 3;
 
+/** Unicode letters count as "inside a word"; digits and punctuation are
+ * boundaries, so "GPT" still matches in "GPT-5" but not in "OpenAI". */
+const isLetter = (ch: string) => /\p{L}/u.test(ch);
+
 /**
  * Entity / product names that almost always deserve a highlight even
  * when the scoring step left `items.tags` empty (today's ingest often
@@ -108,8 +112,14 @@ export function highlightTitle(title: string, tags: string[]): TitleSegment[] {
       const idx = lowerTitle.indexOf(lowerNeedle, searchFrom);
       if (idx === -1) break;
       const end = idx + lowerNeedle.length;
+      // Whole-word match only: a needle bordered by letters is a fragment
+      // of a larger word ("SpaceX" inside "SpaceXAI") and must not color
+      // half a brand name. Digits/punctuation borders are fine ("GPT-5").
+      const borderedByLetter =
+        (idx > 0 && isLetter(title[idx - 1])) ||
+        (end < title.length && isLetter(title[end]));
       const overlaps = ranges.some((r) => idx < r.end && end > r.start);
-      if (!overlaps) {
+      if (!borderedByLetter && !overlaps) {
         const originalTag = needleTag.get(needle) ?? needle;
         ranges.push({ start: idx, end, tag: originalTag });
         matchedTags.add(lowerNeedle);

--- a/apps/news/src/lib/highlight.ts
+++ b/apps/news/src/lib/highlight.ts
@@ -12,7 +12,7 @@ const MAX_HIGHLIGHTS = 3;
 
 /** Unicode letters count as "inside a word"; digits and punctuation are
  * boundaries, so "GPT" still matches in "GPT-5" but not in "OpenAI". */
-const isLetter = (ch: string) => /\p{L}/u.test(ch);
+const isLetter = (ch: string): boolean => /\p{L}/u.test(ch);
 
 /**
  * Entity / product names that almost always deserve a highlight even
@@ -115,9 +115,10 @@ export function highlightTitle(title: string, tags: string[]): TitleSegment[] {
       // Whole-word match only: a needle bordered by letters is a fragment
       // of a larger word ("SpaceX" inside "SpaceXAI") and must not color
       // half a brand name. Digits/punctuation borders are fine ("GPT-5").
+      // Checked against lowerTitle so the offsets match the indexOf above.
       const borderedByLetter =
-        (idx > 0 && isLetter(title[idx - 1])) ||
-        (end < title.length && isLetter(title[end]));
+        (idx > 0 && isLetter(lowerTitle[idx - 1])) ||
+        (end < lowerTitle.length && isLetter(lowerTitle[end]));
       const overlaps = ranges.some((r) => idx < r.end && end > r.start);
       if (!borderedByLetter && !overlaps) {
         const originalTag = needleTag.get(needle) ?? needle;

--- a/apps/news/src/routes/about.tsx
+++ b/apps/news/src/routes/about.tsx
@@ -56,8 +56,8 @@ const STEPS: Step[] = [
     subVi: "tầm quan trọng × chất lượng, mới hơn thắng",
   },
   {
-    en: "TL;DR + Email",
-    vi: "TL;DR + Email",
+    en: "AI;DR + Email",
+    vi: "AI;DR + Email",
     subEn: "daily digest",
     subVi: "bản tin hằng ngày",
   },

--- a/apps/news/src/routes/changelog.tsx
+++ b/apps/news/src/routes/changelog.tsx
@@ -25,8 +25,8 @@ const ENTRIES: ChangelogEntry[] = [
   },
   {
     date: "2026-05",
-    en: "Initial launch: an hourly ingestion pipeline, a daily TL;DR summary, and English/Vietnamese translations for every story.",
-    vi: "Ra mắt lần đầu: pipeline thu thập tin theo giờ, tóm tắt TL;DR hằng ngày, và bản dịch song ngữ Anh/Việt cho từng tin.",
+    en: "Initial launch: an hourly ingestion pipeline, a daily AI;DR summary, and English/Vietnamese translations for every story.",
+    vi: "Ra mắt lần đầu: pipeline thu thập tin theo giờ, tóm tắt AI;DR hằng ngày, và bản dịch song ngữ Anh/Việt cho từng tin.",
   },
 ];
 

--- a/apps/news/src/routes/system.tsx
+++ b/apps/news/src/routes/system.tsx
@@ -285,7 +285,7 @@ function SystemPage() {
             </li>
             <li className="flex justify-between">
               <span className="text-muted-foreground">
-                {t("TL;DR digests", "Bản tóm tắt")}
+                {t("AI;DR digests", "Bản tóm tắt")}
               </span>
               <span className="font-mono tabular-nums text-foreground">
                 {stats.totals.tldrSnapshots}

--- a/apps/news/worker/__tests__/notify.test.ts
+++ b/apps/news/worker/__tests__/notify.test.ts
@@ -153,7 +153,7 @@ describe("trending story message", () => {
     expect(caption).toContain("…");
   });
 
-  it("builds Read + TL;DR buttons with UTM tracking", () => {
+  it("builds Read + AI;DR buttons with UTM tracking", () => {
     const markup = buildStoryReplyMarkup(story()) as {
       inline_keyboard: { text: string; url: string }[][];
     };

--- a/apps/news/worker/notify/telegram.ts
+++ b/apps/news/worker/notify/telegram.ts
@@ -93,7 +93,7 @@ export function buildStoryReplyMarkup(story: StoryPayload): object {
     inline_keyboard: [
       [
         { text: "Đọc bài →", url: withUtm(story.url) },
-        { text: "TL;DR", url: withUtm(storyUrl(story)) },
+        { text: "AI;DR", url: withUtm(storyUrl(story)) },
       ],
     ],
   };

--- a/apps/news/worker/subscribe/send.ts
+++ b/apps/news/worker/subscribe/send.ts
@@ -135,7 +135,7 @@ export function buildDigestEmail(
   unsubscribeToken: string
 ): { subject: string; html: string; text: string } {
   const unsubscribeUrl = `${SITE_URL}/subscribe?unsubscribe=${unsubscribeToken}`;
-  const title = `AI News TL;DR — ${date}`;
+  const title = `AI News AI;DR — ${date}`;
   const footerText =
     lang === "vi"
       ? `Hủy đăng ký: ${unsubscribeUrl}`

--- a/apps/news/wrangler.toml
+++ b/apps/news/wrangler.toml
@@ -37,11 +37,13 @@ ANYROUTER_BASE_URL = "https://anyrouter.dev/api/v1"
 # and never reached a model that can write title_vi. Translate leads
 # with Gemma 4 (completes a 3-item JSON batch); score/TL;DR lead with
 # Flash-Lite. Paid native Gemini after; no BYOK-only ids.
-ANYROUTER_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash"
-ANYROUTER_TRANSLATE_MODEL = "google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,anyrouter/auto,google/gemma-4-31b,google/gemini-2.5-flash-lite,google/gemini-2.5-flash,google/gemini-3.5-flash"
+# stealth/ox-alpha sits last on each chain as a final fallback: only reached
+# when every native id above fails, so an unproven id cannot eat budget.
+ANYROUTER_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
+ANYROUTER_TRANSLATE_MODEL = "google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,anyrouter/auto,google/gemma-4-31b,google/gemini-2.5-flash-lite,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
 # Bilingual TL;DR used to fall through to ANYROUTER_MODEL (reasoning-first)
 # and time out both attempts, leaving English bullets on the VI homepage.
-ANYROUTER_TLDR_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash"
+ANYROUTER_TLDR_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
 # Derived from VITE_CLERK_PUBLISHABLE_KEY's base64 domain suffix (see
 # apps/news/.env.production): pk_live_Y2xlcmsuZHV5ZXQubmV0JA -> clerk.duyet.net
 CLERK_ISSUER = "https://clerk.duyet.net"


### PR DESCRIPTION
## Summary

Implements the 20-item "Is Agentic" audit fix list for duyet.net (score was 65/100). All Essential failures and all Recommended failures are addressed; two partials improved; two items flagged as needing product decisions.

### Essential fixes

- **Agent-friendly 404s**: removed the `/* /index.html 200` SPA fallback from `_redirects`; added `public/404.html` (served by Cloudflare Pages with a real HTTP 404) whose body points agents at `/llms.txt`, `/sitemap.xml`, `/.well-known/api-catalog`, `/developers`. The three `/p/<slug>` pages are now explicitly prerendered so deep links keep working without the fallback.
- **Markdown content negotiation**: `Vary: Accept, Accept-Encoding` on both the text/markdown and HTML representations served from `/`.
- **OpenAPI spec published**: `GET /openapi.json` on api.duyet.net and a static mirror at `https://duyet.net/openapi.json` — OpenAPI 3.1, 8 operations, unique operationIds, typed schemas.
- **Scoped permissions**: `securitySchemes` declare `bearerAuth` + `oauth2` (clientCredentials) with scopes `read:profile` and `chat`, matching `/.well-known/oauth-protected-resource`; the secured operation declares `security: [{oauth2: ["chat"]}, {bearerAuth: []}]`, public ops `security: []`.

### Recommended fixes

- **Public API reachability**: new same-origin mirror `https://duyet.net/api/*` — a strict-allowlist Pages Function proxy to api.duyet.net (CORS preflight, 502 on upstream failure), listed as a second server in the OpenAPI doc.
- **Developer portal**: `/developers` — API table, auth, rate limits, MCP connect snippet, machine-readable file index, curl quickstart. Linked from the homepage ("For developers & agents"), llms.txt, sitemap.xml, 404.html, and NotFound.
- **JSON-LD**: homepage now ships WebSite + Person + Organization (with `contactPoint` incl. email and `PostalAddress` with `addressCountry`) structured data.
- **API linked from homepage**: new homepage section linking `/developers`, `/openapi.json`, MCP endpoint, `/llms.txt`.
- **When-to-use**: llms.txt gains "When to use this site", "Developer resources", and "Contact & legal" sections.
- **Trust pages**: `/contact` and `/privacy` (500+ chars each, prerendered).
- **Rate limit headers**: api.duyet.net sets `RateLimit-Limit` / `RateLimit-Remaining` / `RateLimit-Reset` on every response; 429s carry `Retry-After` (global 600/min bucket + existing 10/min generate limiter).
- **Metadata completeness**: canonical URLs on every route (root default + per-route overrides).
- **MCP**: `duyet.net/mcp` now 308-redirects to `https://mcp.duyet.net/mcp` (method-preserving, so JSON-RPC POSTs survive); stale `.well-known/mcp/server-card.json` corrected (endpoint + version 0.2.1).
- **API schema complexity / function calling**: every OpenAPI operation has unique operationId + description + typed request/response schemas.

### Companion repo

- duyet-mcp-server#75 (merged): serves RFC 9728 `/.well-known/oauth-protected-resource`, when-to-use + scopes in llms.txt, agent metadata links on its home page.

### Verification

- apps/api: 26/26 vitest, tsc clean, biome clean
- apps/home: 68/68 vitest, tsc clean, biome clean
- Full build passes; verified in `dist/client/`: canonical + 3 JSON-LD objects on `/`, canonical+title on all 13 prerendered pages, `404.html` present, `_redirects` without SPA fallback, `_routes.json` includes `/api/*`, sitemap lists all 13 URLs, openapi.json parses with 3.1 + unique operationIds + scopes
- Live MCP endpoint re-verified: POST initialize returns valid JSON-RPC over SSE

### Remaining (need product decisions / credentials)

- **CLI tool (npm publish)**: needs npm credentials; not attempted
- **Content efficiency (3.8% → 5%)**: homepage bloat is DOM/SVG density; changing it would alter the visual design
- **mcp.duyet.net CI deploy failing (pre-existing)**: D1 binding references a deleted database id (`code: 10181`) — needs the D1 database re-created/re-linked in the Cloudflare dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve duyet.net’s readiness for developers, AI agents, and machine consumption across the API, homepage, deployment configuration, and news experience.

New Features:
- Publish a typed OpenAPI 3.1 specification with documented authentication scopes and API operations.
- Add a same-origin, allowlisted API proxy and a developer portal with API, MCP, and machine-readable resource guidance.
- Add homepage structured data, agent discovery links, contact and privacy pages, and expanded site metadata.
- Rename the news product’s TL;DR branding to AI;DR and add a final model fallback to its provider chains.

Bug Fixes:
- Return real 404 responses for unknown home-page URLs while preserving prerendered deep links.
- Correct MCP discovery and redirect metadata so JSON-RPC requests reach the canonical endpoint.
- Prevent news title highlighting from matching fragments embedded within larger words.

Enhancements:
- Add global API rate limiting with standard rate-limit headers and retry guidance.
- Improve markdown content negotiation and cache variation between HTML and markdown representations.
- Expand sitemap coverage and canonical metadata for newly exposed routes and product pages.

Deployment:
- Update Cloudflare Pages routing, headers, redirects, and function coverage for agent-friendly 404 handling and the same-origin API proxy.

Documentation:
- Add developer, contact, and privacy pages plus expanded llms.txt guidance and machine-readable discovery documents.

Tests:
- Add coverage for OpenAPI validity, API rate limiting, proxy behavior, JSON-LD, markdown negotiation, routing configuration, and expanded sitemap entries.
- Add news tests for whole-word title highlighting and updated AI;DR notification labeling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public developer portal with API documentation, quickstarts, OpenAPI specification, and MCP resources.
  * Added contact and privacy pages, improved 404 navigation, sitemap coverage, and structured metadata.
  * Added API proxy access for supported endpoints and documented machine-readable resources.

* **Bug Fixes**
  * Improved request throttling feedback with rate-limit and retry headers.
  * Improved content negotiation and hydration fallback behavior.
  * Improved title highlighting accuracy for embedded terms.

* **Style**
  * Renamed “TL;DR” labels and actions to “AI;DR” across news experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->