### PR TITLE
docs: record apps/tip in internal knowledge

### DIFF
--- a/apps/tip/src/routes/index.tsx
+++ b/apps/tip/src/routes/index.tsx
@@ -7,39 +7,44 @@ export const Route = createFileRoute("/")({
 
 function Page() {
   return (
-    <section className="flex flex-1 flex-col items-center justify-center gap-8 px-4 py-10 sm:gap-10 sm:px-6 sm:py-12">
-      <header className="max-w-xl text-center">
-        <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 font-mono text-xs uppercase tracking-widest text-muted-foreground">
-          <span aria-hidden className="size-1.5 rounded-full bg-accent" />
-          Support
-        </p>
-        <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-          Buy me a coffee
-        </h1>
-        <p className="mt-4 text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
-          If something here helped you, a small tip keeps the servers running
-          and the coffee flowing. Thank you!
-        </p>
-      </header>
+    <section className="flex flex-1 flex-col items-center px-4 py-10 sm:px-6 sm:py-12">
+      {/* my-auto centers the block when there is room; both auto margins clamp
+          to 0 when content overflows, so the sticky header can never cover the
+          top padding. */}
+      <div className="my-auto flex w-full max-w-[640px] flex-col items-center gap-8 sm:gap-10">
+        <header className="max-w-xl text-center">
+          <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            <span aria-hidden className="size-1.5 rounded-full bg-accent" />
+            Support
+          </p>
+          <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+            Buy me a coffee
+          </h1>
+          <p className="mt-4 text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
+            If something here helped you, a small tip keeps the servers running
+            and the coffee flowing. Thank you!
+          </p>
+        </header>
 
-      <div className="w-full max-w-[640px] overflow-hidden rounded-xl border border-border bg-card shadow-sm">
-        <iframe
-          id="kofiframe"
-          src={KOFI_URL}
-          title="duyet"
-          loading="lazy"
-          className="block h-[clamp(480px,calc(100dvh-24rem),712px)] w-full border-none bg-[#f9f9f9] p-1 dark:bg-[#1a1a1a]"
-        />
+        <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+          <iframe
+            id="kofiframe"
+            src={KOFI_URL}
+            title="duyet"
+            loading="lazy"
+            className="block h-[clamp(480px,calc(100dvh-24rem),712px)] w-full border-none bg-[#f9f9f9] p-1 dark:bg-[#1a1a1a]"
+          />
+        </div>
+
+        <a
+          href={KOFI_PROFILE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm underline underline-offset-4 transition-colors hover:text-accent"
+        >
+          Widget not loading? Open ko-fi.com/duyet
+        </a>
       </div>
-
-      <a
-        href={KOFI_PROFILE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-sm underline underline-offset-4 transition-colors hover:text-accent"
-      >
-        Widget not loading? Open ko-fi.com/duyet
-      </a>
     </section>
   );
 }

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -78,7 +78,7 @@ herdr agent prompt feat-<short> "<full task spec>" --wait --timeout 600000
 - `apps/kb`: static TanStack Start knowledge base for `https://kb.duyet.net`, bundling `content/**/*.md` at build time and generating `llms.txt`, `llms-full.txt`, `sitemap.xml`, `robots.txt`, and raw `public/k/*.md` article endpoints.
 - `apps/burns`: Vite/Cloudflare Pages dashboard (`duyet-burns`) that prerenders Claude Code usage stats. `build` runs `scripts/fetch-burns-data.ts`, which pulls `ccusage` data from MotherDuck (`MOTHERDUCK_TOKEN`); a daily cron refreshes it. Preview CI uses the GitHub `staging` environment secret (synced from local `.env.production.local`). If the token is missing, preview/local builds keep committed `public/token-data.json`; master/cron/manual deploys still require the token.
 - `apps/x-algo`: static TanStack Start explainer for the open-sourced X For You ranking weights at `https://x-algo.duyet.net`. Numbers live in `src/lib/scoring.ts` and must match `xai-org/x-algorithm` `home-mixer/params/param.rs`.
-- `apps/tip`: Ko-fi tip page for `https://tip.duyet.net` (Pages project `duyet-tip`). Single centered section embedding the official Ko-fi widget; widget URL lives in `src/lib/site.ts`. Keep the shared `SiteHeader`/`SiteFooter` chrome and the prerendered static HTML.
+- `apps/tip`: Ko-fi tip page on Cloudflare Pages for `https://tip.duyet.net` (Pages project `duyet-tip`). A single centered section embeds the official Ko-fi widget; widget URL lives in `src/lib/site.ts`. Keep the shared `SiteHeader`/`SiteFooter` chrome and the prerendered static HTML.
 - `apps/paid-api`: standalone x402 USDC-gated chat Worker for `https://paid.duyet.net` (`duyet-paid-api`). Payment replaces auth; see `apps/paid-api/README.md`.
 
 ## Shared Packages

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -38,7 +38,7 @@ herdr agent prompt feat-<short> "<full task spec>" --wait --timeout 600000
 
 ## Static rendering
 
-- `apps/blog`, `apps/home`, `apps/cv`, `apps/insights`, `apps/photos`, `apps/kb`, `apps/llm-timeline`, `apps/ai-percentage`, `apps/burns`, `apps/homelab`, `apps/x-algo` emit static HTML for public pages at build time (Vite/TanStack prerender or Pages output).
+- `apps/blog`, `apps/home`, `apps/cv`, `apps/insights`, `apps/photos`, `apps/kb`, `apps/llm-timeline`, `apps/ai-percentage`, `apps/burns`, `apps/homelab`, `apps/x-algo`, `apps/tip` emit static HTML for public pages at build time (Vite/TanStack prerender or Pages output).
 - `apps/agent-ui` is a signed-in chat surface at `https://agents.duyet.net`. Its `index.html` must still contain a prerendered chat shell (`Ask Duyet anything.`). Conversation rows use shared shadcn chat primitives; Clerk/auth and streaming stay client-only.
 - `apps/insights` is static HTML plus calls to `apps/api`. Do not use TanStack Start server functions for runtime data loading.
 
@@ -78,6 +78,7 @@ herdr agent prompt feat-<short> "<full task spec>" --wait --timeout 600000
 - `apps/kb`: static TanStack Start knowledge base for `https://kb.duyet.net`, bundling `content/**/*.md` at build time and generating `llms.txt`, `llms-full.txt`, `sitemap.xml`, `robots.txt`, and raw `public/k/*.md` article endpoints.
 - `apps/burns`: Vite/Cloudflare Pages dashboard (`duyet-burns`) that prerenders Claude Code usage stats. `build` runs `scripts/fetch-burns-data.ts`, which pulls `ccusage` data from MotherDuck (`MOTHERDUCK_TOKEN`); a daily cron refreshes it. Preview CI uses the GitHub `staging` environment secret (synced from local `.env.production.local`). If the token is missing, preview/local builds keep committed `public/token-data.json`; master/cron/manual deploys still require the token.
 - `apps/x-algo`: static TanStack Start explainer for the open-sourced X For You ranking weights at `https://x-algo.duyet.net`. Numbers live in `src/lib/scoring.ts` and must match `xai-org/x-algorithm` `home-mixer/params/param.rs`.
+- `apps/tip`: Ko-fi tip page for `https://tip.duyet.net` (Pages project `duyet-tip`). Single centered section embedding the official Ko-fi widget; widget URL lives in `src/lib/site.ts`. Keep the shared `SiteHeader`/`SiteFooter` chrome and the prerendered static HTML.
 - `apps/paid-api`: standalone x402 USDC-gated chat Worker for `https://paid.duyet.net` (`duyet-paid-api`). Payment replaces auth; see `apps/paid-api/README.md`.
 
 ## Shared Packages
@@ -103,7 +104,7 @@ herdr agent prompt feat-<short> "<full task spec>" --wait --timeout 600000
 - `apps/api` uses Wrangler as a Worker, not a Pages app.
 - `apps/agent-api` uses Wrangler as a Worker, not a Pages app.
 - `apps/agent-assistant` compiles via Vite/TanStack Start into a unified Worker + Assets bundle and deploys to the `duyet-agent-assistant` project. Features an automated deployment processor (`deploy.ts`) that injects `ThreadStateDO` SQLite schemas and patches browser-incompatible `createRequire` and `import.meta.url` hooks in compiled server chunks.
-- **Cloudflare Workers Cache** (`[cache] enabled = true`) is a **Workers-only** wrangler key — it is not valid in a Pages config (`pages_build_output_dir`). It is set on the three real Workers (`api`, `agent-api`, `agent-assistant`) as a safe no-op: they only cache responses with an explicit `Cache-Control: public`. The static **Pages** apps (`agent-ui`, `blog`, `cv`, `home`, `photos`, `insights`, `ai-percentage`, `homelab`, `burns`, `kb`, `llm-timeline`, `x-algo`) do **not** get `[cache]`; their public cache policy lives in each app's `public/_headers` (zone cache + deploy purge). See [`docs/ai/workers-cache.md`](workers-cache.md) for the per-app matrix, TTL rationale, and how to extend.
+- **Cloudflare Workers Cache** (`[cache] enabled = true`) is a **Workers-only** wrangler key — it is not valid in a Pages config (`pages_build_output_dir`). It is set on the three real Workers (`api`, `agent-api`, `agent-assistant`) as a safe no-op: they only cache responses with an explicit `Cache-Control: public`. The static **Pages** apps (`agent-ui`, `blog`, `cv`, `home`, `photos`, `insights`, `ai-percentage`, `homelab`, `burns`, `kb`, `llm-timeline`, `x-algo`, `tip`) do **not** get `[cache]`; their public cache policy lives in each app's `public/_headers` (zone cache + deploy purge). See [`docs/ai/workers-cache.md`](workers-cache.md) for the per-app matrix, TTL rationale, and how to extend.
 
 ## App-Specific Command Notes
 

--- a/docs/ai/workers-cache.md
+++ b/docs/ai/workers-cache.md
@@ -49,7 +49,7 @@ Classify with: `grep -q pages_build_output_dir apps/<app>/wrangler.toml`.
 | `agent-api` | **Worker** (`main`) | `[cache]` enabled |
 | `agent-assistant` | **Worker** (`main`, Durable Objects) | `[cache]` enabled |
 | `agent-ui` | Pages | `_headers` only (no `[cache]`) |
-| `ai-percentage`, `blog`, `burns`, `cv`, `home`, `homelab`, `insights`, `kb`, `llm-timeline`, `photos`, `x-algo` | Pages | `_headers` only (no `[cache]`) |
+| `ai-percentage`, `blog`, `burns`, `cv`, `home`, `homelab`, `insights`, `kb`, `llm-timeline`, `photos`, `tip`, `x-algo` | Pages | `_headers` only (no `[cache]`) |
 
 ## Workers — `[cache] enabled = true`
 


### PR DESCRIPTION
Follow-up to #1352: adds `apps/tip` to the static-rendering list, app list, and Pages cache matrix in `docs/ai/internal-knowledge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document apps/tip as a static Pages app and refine its page layout for reliable responsive rendering.

Bug Fixes:
- Improve the tip page layout so its content remains centered without being obscured by the sticky site header on short or overflowing viewports.

Enhancements:
- Document apps/tip as a statically rendered Cloudflare Pages application and add it to the Pages cache matrix.

Documentation:
- Record the tip app’s URL, deployment project, Ko-fi widget, shared site chrome, and static HTML requirements in the internal knowledge base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated support page with an embedded Ko-fi tipping option and a fallback link.
  * Improved the page layout with a centered, width-constrained presentation for easier viewing.

* **Documentation**
  * Updated application documentation to include the support page and its static-rendered deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->