### PR TITLE
fix(tip): keep top padding visible when content overflows

### DIFF
--- a/apps/tip/src/routes/index.tsx
+++ b/apps/tip/src/routes/index.tsx
@@ -7,39 +7,44 @@ export const Route = createFileRoute("/")({
 
 function Page() {
   return (
-    <section className="flex flex-1 flex-col items-center justify-center gap-8 px-4 py-10 sm:gap-10 sm:px-6 sm:py-12">
-      <header className="max-w-xl text-center">
-        <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 font-mono text-xs uppercase tracking-widest text-muted-foreground">
-          <span aria-hidden className="size-1.5 rounded-full bg-accent" />
-          Support
-        </p>
-        <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
-          Buy me a coffee
-        </h1>
-        <p className="mt-4 text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
-          If something here helped you, a small tip keeps the servers running
-          and the coffee flowing. Thank you!
-        </p>
-      </header>
+    <section className="flex flex-1 flex-col items-center px-4 py-10 sm:px-6 sm:py-12">
+      {/* my-auto centers the block when there is room; both auto margins clamp
+          to 0 when content overflows, so the sticky header can never cover the
+          top padding. */}
+      <div className="my-auto flex w-full max-w-[640px] flex-col items-center gap-8 sm:gap-10">
+        <header className="max-w-xl text-center">
+          <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-border px-3 py-1 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            <span aria-hidden className="size-1.5 rounded-full bg-accent" />
+            Support
+          </p>
+          <h1 className="text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
+            Buy me a coffee
+          </h1>
+          <p className="mt-4 text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
+            If something here helped you, a small tip keeps the servers running
+            and the coffee flowing. Thank you!
+          </p>
+        </header>
 
-      <div className="w-full max-w-[640px] overflow-hidden rounded-xl border border-border bg-card shadow-sm">
-        <iframe
-          id="kofiframe"
-          src={KOFI_URL}
-          title="duyet"
-          loading="lazy"
-          className="block h-[clamp(480px,calc(100dvh-24rem),712px)] w-full border-none bg-[#f9f9f9] p-1 dark:bg-[#1a1a1a]"
-        />
+        <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+          <iframe
+            id="kofiframe"
+            src={KOFI_URL}
+            title="duyet"
+            loading="lazy"
+            className="block h-[clamp(480px,calc(100dvh-24rem),712px)] w-full border-none bg-[#f9f9f9] p-1 dark:bg-[#1a1a1a]"
+          />
+        </div>
+
+        <a
+          href={KOFI_PROFILE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm underline underline-offset-4 transition-colors hover:text-accent"
+        >
+          Widget not loading? Open ko-fi.com/duyet
+        </a>
       </div>
-
-      <a
-        href={KOFI_PROFILE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-sm underline underline-offset-4 transition-colors hover:text-accent"
-      >
-        Widget not loading? Open ko-fi.com/duyet
-      </a>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

One-line follow-up to #1352: replace `justify-center` with a `my-auto` wrapper on the tip page.

`justify-center` keeps distributing overflow space in both directions when content is taller than the viewport, so the section's `py-10` top padding gets consumed and the badge slides under the sticky header (visible at common laptop heights, worse with browser zoom / larger text). Auto margins (`my-auto`) center the block exactly the same way when there is room and clamp to 0 on overflow — the top padding always stays visible.

Verified by building the app and screenshotting at 1440×900, 1280×720 and 390×844: rendering is identical to production where content overflows, and properly centered on tall viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent overflowing tip-page content from sliding beneath the sticky header while retaining vertical centering when space allows.

Bug Fixes:
- Keep the tip page’s top padding visible when content overflows, preventing the sticky header from covering the badge and page content.

Enhancements:
- Preserve centered layout on spacious viewports while allowing overflowing content to align safely from the padded top.