### PR TITLE
feat(tip): rewrite tip copy and link ko-fi.com/duyet in the menu

### DIFF
--- a/apps/tip/src/routes/index.tsx
+++ b/apps/tip/src/routes/index.tsx
@@ -21,8 +21,9 @@ function Page() {
             Buy me a coffee
           </h1>
           <p className="mt-4 text-pretty text-base leading-7 text-muted-foreground sm:text-lg">
-            If something here helped you, a small tip keeps the servers running
-            and the coffee flowing. Thank you!
+            If something here helped you, a small tip keeps everything up and
+            running. Or if you're just feeling generous — either way, the coffee
+            keeps flowing. Thank you!
           </p>
         </header>
 

--- a/packages/components/site-header/GlobalNav.tsx
+++ b/packages/components/site-header/GlobalNav.tsx
@@ -45,15 +45,17 @@ export function GlobalNav({
     <nav ref={containerRef} className="hidden items-center gap-0.5 md:flex">
       {excludeLocalNavItems(
         filterGlobalNav(GLOBAL_NAV, currentApp),
-        localNav,
+        localNav
       ).map((item) => {
         const hasChildren = item.children && item.children.length > 0;
         const isDropdownOpen = openDropdown === item.label;
         const itemActive =
           isNavActive(item.match, currentApp, pathname) ||
-          Boolean(item.children?.some((child) =>
-            isNavActive(child.match, currentApp, pathname),
-          ));
+          Boolean(
+            item.children?.some((child) =>
+              isNavActive(child.match, currentApp, pathname)
+            )
+          );
 
         return (
           <div key={item.href} className="relative">
@@ -63,7 +65,7 @@ export function GlobalNav({
               className={cn(
                 "h-8 px-2.5 text-sm font-normal text-muted-foreground hover:text-foreground",
                 itemActive &&
-                  "bg-muted font-medium text-[var(--rd-accent)] hover:text-[var(--rd-accent)]",
+                  "bg-muted font-medium text-[var(--rd-accent)] hover:text-[var(--rd-accent)]"
               )}
               onClick={
                 hasChildren
@@ -80,7 +82,19 @@ export function GlobalNav({
                   <ChevronsUpDown aria-hidden className="h-3 w-3" />
                 </span>
               ) : (
-                <a href={item.href}>{item.label}</a>
+                <a
+                  href={item.href}
+                  {...(item.external
+                    ? { target: "_blank", rel: "noopener noreferrer" }
+                    : {})}
+                >
+                  <span className="flex items-center gap-1.5">
+                    {item.Icon && (
+                      <item.Icon aria-hidden className="h-3.5 w-3.5" />
+                    )}
+                    {item.label}
+                  </span>
+                </a>
               )}
             </Button>
 
@@ -95,7 +109,7 @@ export function GlobalNav({
                         "flex items-center h-8 px-3 rounded-md text-sm transition-colors",
                         isNavActive(child.match, currentApp, pathname)
                           ? "bg-[var(--rd-muted)] text-[var(--rd-accent)] font-medium"
-                          : "text-[var(--rd-text)] hover:bg-[var(--rd-muted)]",
+                          : "text-[var(--rd-text)] hover:bg-[var(--rd-muted)]"
                       )}
                     >
                       {child.label}

--- a/packages/components/site-header/MobileNav.tsx
+++ b/packages/components/site-header/MobileNav.tsx
@@ -76,7 +76,7 @@ export function MobileNav({
                       : pathname === item.href ||
                         pathname.startsWith(`${item.href}/`))
                     ? "bg-[var(--rd-muted)] text-[var(--rd-accent)]"
-                    : "text-[var(--rd-text-3)] hover:bg-[var(--rd-muted)] hover:text-[var(--rd-text)]",
+                    : "text-[var(--rd-text-3)] hover:bg-[var(--rd-muted)] hover:text-[var(--rd-text)]"
                 )}
                 {...(item.external
                   ? { target: "_blank", rel: "noopener noreferrer" }
@@ -87,7 +87,7 @@ export function MobileNav({
             ))}
             {excludeLocalNavItems(
               filterGlobalNav(GLOBAL_NAV, currentApp),
-              localNav,
+              localNav
             ).map((item) => {
               const hasChildren = item.children && item.children.length > 0;
               const isDropdownOpen = openDropdown === item.label;
@@ -95,15 +95,15 @@ export function MobileNav({
                 isNavActive(item.match, currentApp, pathname) ||
                 Boolean(
                   item.children?.some((child) =>
-                    isNavActive(child.match, currentApp, pathname),
-                  ),
+                    isNavActive(child.match, currentApp, pathname)
+                  )
                 );
 
               const itemClassName = cn(
                 "flex items-center justify-between h-9 px-3 rounded-md text-sm font-medium transition-colors",
                 itemActive
                   ? "bg-[var(--rd-muted)] text-[var(--rd-accent)]"
-                  : "text-[var(--rd-text-3)] hover:bg-[var(--rd-muted)] hover:text-[var(--rd-text)]",
+                  : "text-[var(--rd-text-3)] hover:bg-[var(--rd-muted)] hover:text-[var(--rd-text)]"
               );
 
               return (
@@ -124,7 +124,7 @@ export function MobileNav({
                         aria-hidden
                         className={cn(
                           "h-3 w-3 shrink-0 transition-transform",
-                          isDropdownOpen && "rotate-180",
+                          isDropdownOpen && "rotate-180"
                         )}
                       />
                     </button>
@@ -134,7 +134,13 @@ export function MobileNav({
                       role="menuitem"
                       onClick={() => setOpen(false)}
                       className={itemClassName}
+                      {...(item.external
+                        ? { target: "_blank", rel: "noopener noreferrer" }
+                        : {})}
                     >
+                      {item.Icon && (
+                        <item.Icon aria-hidden className="h-3.5 w-3.5" />
+                      )}
                       {item.label}
                     </a>
                   )}
@@ -150,7 +156,7 @@ export function MobileNav({
                             "flex items-center h-8 px-3 rounded-md text-sm transition-colors",
                             isNavActive(child.match, currentApp, pathname)
                               ? "text-[var(--rd-accent)] font-medium"
-                              : "text-[var(--rd-text)] hover:bg-[var(--rd-muted)]",
+                              : "text-[var(--rd-text)] hover:bg-[var(--rd-muted)]"
                           )}
                         >
                           {child.label}

--- a/packages/components/site-header/apps.ts
+++ b/packages/components/site-header/apps.ts
@@ -289,6 +289,13 @@ export const GLOBAL_NAV: GlobalNavItem[] = [
     ],
   },
   {
+    label: "Tip",
+    href: "https://ko-fi.com/duyet",
+    match: { app: "tip" },
+    external: true,
+    Icon: Coffee,
+  },
+  {
     label: "About",
     href: "https://duyet.net/about",
     match: { path: "/about" },
@@ -391,7 +398,7 @@ export function navHrefKey(href: string): string {
 
 export function excludeLocalNavItems<T extends { href: string }>(
   items: T[],
-  localNav?: LocalNavItem[],
+  localNav?: LocalNavItem[]
 ): T[] {
   if (!localNav?.length) return items;
   const localKeys = new Set(localNav.map((item) => navHrefKey(item.href)));

--- a/packages/components/site-header/types.ts
+++ b/packages/components/site-header/types.ts
@@ -42,12 +42,16 @@ export interface GlobalNavChild {
   label: string;
   href: string;
   match: NavMatch;
+  Icon?: LucideIcon;
 }
 
 export interface GlobalNavItem {
   label: string;
   href: string;
   match: NavMatch;
+  /** External link opened in a new tab (e.g. ko-fi.com). */
+  external?: boolean;
+  Icon?: LucideIcon;
   children?: GlobalNavChild[];
   /** Only rendered when currentApp matches — excluded even from the home
    * app's "show everything" fallback, unlike a plain `match.app`. */


### PR DESCRIPTION
## Summary

Follow-up to #1352 / #1359 for the tip page:

- **Copy rewrite**: the subtitle now reads "If something here helped you, a small tip keeps everything up and running. Or if you're just feeling generous — either way, the coffee keeps flowing. Thank you!"
- **Menu link**: new global nav **Tip** item (Coffee icon) pointing at https://ko-fi.com/duyet — renders in both desktop `GlobalNav` and `MobileNav`, opens in a new tab (`external: true`). Adds optional `Icon` + `external` fields to `GlobalNavItem`.

Verified: tsc clean, biome clean on touched files, prerendered HTML contains the new copy and 3 ko-fi.com/duyet references (menu desktop/mobile + fallback link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the tip experience with refreshed messaging and prominent Ko-fi navigation access.

New Features:
- Add a Tip link with a coffee icon to the global desktop and mobile navigation, linking to Ko-fi in a new tab.

Enhancements:
- Support optional icons and external-link behavior for global navigation items.
- Rewrite the tip page subtitle to clarify how contributions support the project.