### PR TITLE
fix(news): replace paid gemini ids with stealth/ox-alpha in LLM chains

### DIFF
--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -99,9 +99,11 @@ anyrouter's queue for long prompts), JSON mode, `max_tokens` 8192 (2048 on trans
 reasoning-model fallback (extracts JSON from `message.reasoning` when content
 is starved), comma-separated model fallback chains (`ANYROUTER_MODEL`), and
 per-task overrides (`ANYROUTER_TRANSLATE_MODEL` / `ANYROUTER_TLDR_MODEL` —
-Gemma 4 / GLM-4.7 / Ling-3.0 / `anyrouter/auto` first
-for translate (native ids that finish a 3-item batch), then Gemma 4 31B / Flash-Lite / Gemini 2.5/3.5;
-BYOK-only ids such as SEA-LION and Gemini 3.7 are omitted). Translate
+stealth/ox-alpha first for score/TL;DR; translate leads with Gemma 4 /
+GLM-4.7 / Ling-3.0 / `anyrouter/auto` (native ids that finish a 3-item
+batch), then Gemma 4 31B, with stealth/ox-alpha last on every chain;
+BYOK-only ids such as SEA-LION and Gemini 3.6/3.7 are omitted, and all
+paid Gemini ids were replaced by stealth/ox-alpha). Translate
 runs in batches of 3 (summaries clipped, title-only retry) and each
 backfill slice is its own Workflow step so a finished batch is written
 even if a later slice times out. A hang, empty sanitize, timeout, or 402 advances the chain

--- a/apps/news/worker/__tests__/schedule.test.ts
+++ b/apps/news/worker/__tests__/schedule.test.ts
@@ -57,11 +57,12 @@ describe("live AnyRouter model chains", () => {
     }
   });
 
-  it("leads score/tldr with ox-alpha and translate with a fast native id", () => {
+  it("leads score/tldr with ox-alpha and translate with Gemma 4", () => {
     expect(idsOf("ANYROUTER_MODEL")[0]).toBe("stealth/ox-alpha");
     expect(idsOf("ANYROUTER_TLDR_MODEL")[0]).toBe("stealth/ox-alpha");
-    const native = ["google/gemma-4-26b-a4b-it", "stealth/ox-alpha"];
-    expect(native).toContain(idsOf("ANYROUTER_TRANSLATE_MODEL")[0]);
+    expect(idsOf("ANYROUTER_TRANSLATE_MODEL")[0]).toBe(
+      "google/gemma-4-26b-a4b-it"
+    );
   });
 
   it("omits known BYOK-only and paid gemini ids from every live chain", () => {

--- a/apps/news/worker/__tests__/schedule.test.ts
+++ b/apps/news/worker/__tests__/schedule.test.ts
@@ -41,28 +41,35 @@ describe("free-plan hourly ingest", () => {
 });
 
 describe("live AnyRouter model chains", () => {
-  function firstId(varName: string): string {
+  function idsOf(varName: string): string[] {
     const match = wrangler.match(new RegExp(`${varName} = "([^"]+)"`));
     expect(match, `${varName} missing`).toBeTruthy();
-    return match![1].split(",")[0];
+    return match![1].split(",").map((s) => s.trim());
   }
 
-  it("leads translate/tldr/score with a native (non-BYOK-only) catalog id", () => {
-    const native = [
-      "google/gemini-2.5-flash-lite",
-      "google/gemini-2.5-flash",
-      "google/gemma-4-26b-a4b-it",
-      "z-ai/glm-4.7-flash",
-      "inclusionai/ling-3.0-flash",
-    ];
-    expect(native).toContain(firstId("ANYROUTER_TRANSLATE_MODEL"));
-    expect(native).toContain(firstId("ANYROUTER_TLDR_MODEL"));
-    expect(native).toContain(firstId("ANYROUTER_MODEL"));
+  it("uses stealth/ox-alpha on every live chain", () => {
+    for (const name of [
+      "ANYROUTER_MODEL",
+      "ANYROUTER_TRANSLATE_MODEL",
+      "ANYROUTER_TLDR_MODEL",
+    ]) {
+      expect(idsOf(name), name).toContain("stealth/ox-alpha");
+    }
   });
 
-  it("omits known BYOK-only ids from every live chain", () => {
-    const byokOnly = [
+  it("leads score/tldr with ox-alpha and translate with a fast native id", () => {
+    expect(idsOf("ANYROUTER_MODEL")[0]).toBe("stealth/ox-alpha");
+    expect(idsOf("ANYROUTER_TLDR_MODEL")[0]).toBe("stealth/ox-alpha");
+    const native = ["google/gemma-4-26b-a4b-it", "stealth/ox-alpha"];
+    expect(native).toContain(idsOf("ANYROUTER_TRANSLATE_MODEL")[0]);
+  });
+
+  it("omits known BYOK-only and paid gemini ids from every live chain", () => {
+    const blocked = [
       "aisingapore/gemma-sea-lion-v4-27b-it",
+      "google/gemini-2.5-flash-lite",
+      "google/gemini-2.5-flash",
+      "google/gemini-3.5-flash",
       "google/gemini-3.7-flash",
       "google/gemini-3.6-flash",
       "qwen/qwen3.7-flash",
@@ -72,10 +79,9 @@ describe("live AnyRouter model chains", () => {
       "ANYROUTER_TRANSLATE_MODEL",
       "ANYROUTER_TLDR_MODEL",
     ]) {
-      const match = wrangler.match(new RegExp(`${name} = "([^"]+)"`));
-      const ids = (match?.[1] ?? "").split(",").map((s) => s.trim());
-      for (const blocked of byokOnly) {
-        expect(ids, name).not.toContain(blocked);
+      const ids = idsOf(name);
+      for (const id of blocked) {
+        expect(ids, name).not.toContain(id);
       }
     }
   });

--- a/apps/news/wrangler.toml
+++ b/apps/news/wrangler.toml
@@ -31,19 +31,17 @@ database_id = "8e692ccf-ec38-4e41-b011-50adbc891322"
 
 [vars]
 ANYROUTER_BASE_URL = "https://anyrouter.dev/api/v1"
-# Live AnyRouter ids with native (non-BYOK) providers only. #1322 led
-# with aisingapore/gemma-sea-lion-v4-27b-it + gemini-3.7/3.6 + qwen3.7
-# — all BYOK-only — so a hang/401 on the first id ate the 300s budget
-# and never reached a model that can write title_vi. Translate leads
-# with Gemma 4 (completes a 3-item JSON batch); score/TL;DR lead with
-# Flash-Lite. Paid native Gemini after; no BYOK-only ids.
-# stealth/ox-alpha sits last on each chain as a final fallback: only reached
-# when every native id above fails, so an unproven id cannot eat budget.
-ANYROUTER_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
-ANYROUTER_TRANSLATE_MODEL = "google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,anyrouter/auto,google/gemma-4-31b,google/gemini-2.5-flash-lite,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
-# Bilingual TL;DR used to fall through to ANYROUTER_MODEL (reasoning-first)
-# and time out both attempts, leaving English bullets on the VI homepage.
-ANYROUTER_TLDR_MODEL = "google/gemini-2.5-flash-lite,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,google/gemini-2.5-flash,google/gemini-3.5-flash,stealth/ox-alpha"
+# Live model chains on stealth/ox-alpha (replaced every paid google/gemini-*
+# id). Score/TL;DR lead with ox-alpha and fall back to the cheap native ids
+# (non-BYOK); translate still leads with Gemma 4 (completes a 3-item JSON
+# batch fast) and keeps ox-alpha as the final fallback. No BYOK-only ids
+# (SEA-LION, gemini-3.6/3.7, qwen3.7) — a hang/401 on the first id used to
+# eat the whole budget before reaching a model that can write title_vi.
+ANYROUTER_MODEL = "stealth/ox-alpha,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash"
+ANYROUTER_TRANSLATE_MODEL = "google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,anyrouter/auto,google/gemma-4-31b,stealth/ox-alpha"
+# Bilingual TL;DR used to fall through to a reasoning-first chain and time
+# out both attempts, leaving English bullets on the VI homepage.
+ANYROUTER_TLDR_MODEL = "stealth/ox-alpha,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash"
 # Derived from VITE_CLERK_PUBLISHABLE_KEY's base64 domain suffix (see
 # apps/news/.env.production): pk_live_Y2xlcmsuZHV5ZXQubmV0JA -> clerk.duyet.net
 CLERK_ISSUER = "https://clerk.duyet.net"


### PR DESCRIPTION
## Summary
- Replace every `google/gemini-2.5-flash-lite` / `gemini-2.5-flash` / `gemini-3.5-flash` id in the news pipeline's model chains with `stealth/ox-alpha`
- Score (`ANYROUTER_MODEL`) and TL;DR now lead with ox-alpha, falling back to the cheap native ids (Gemma 4 / GLM / Ling); translate still leads with Gemma 4 for fast 3-item JSON batches, ox-alpha last
- Update `ALGORITHM.md\) transport notes and `schedule.test.ts` chain assertions (ox-alpha required on all chains; dropped gemini ids added to blocked list)

## Test plan
- [x] `pnpm run test` in apps/news — 582 passed
- [x] biome check on changed files clean (one pre-existing warning untouched)
- [x] pre-existing unrelated `check-types` failure confirmed identical on clean tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Use stealth/ox-alpha and reliable native fallbacks across the news pipeline’s live LLM chains.

Bug Fixes:
- Replace paid Gemini model IDs in the news LLM chains to avoid unreliable or unavailable routes and improve fallback behavior.

Enhancements:
- Prioritize stealth/ox-alpha for scoring and TL;DR while retaining a fast native model for translation and cheaper native fallbacks.
- Update the news model-chain documentation and assertions to enforce ox-alpha coverage and block removed Gemini and BYOK-only IDs.

Tests:
- Update schedule tests to validate chain ordering, required models, and blocked model IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated AI model fallback configurations for content scoring, translation, and bilingual summaries.
  * Prioritized more reliable models to improve consistency across automated results.
  * Removed outdated, paid, and restricted model options from fallback selections.
  * Improved validation to confirm complete fallback chains, expected model ordering, and required restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->