### PR TITLE
fix(ci): pass workflow_run branch through env to prevent pwn-request

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -23,10 +23,14 @@ jobs:
     # Only run when:
     # - CI actually failed (not cancelled/skipped)
     # - There is an associated pull request
+    # - The PR is from this repository (not a fork). workflow_run jobs run in
+    #   the base-repo context with write tokens; auto-fixing forks would be a
+    #   pwn-request even after the env: fix below.
     # - The branch is not already a Claude-generated fix branch (prevents loops)
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.pull_requests[0] != null &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       !startsWith(github.event.workflow_run.head_branch, 'claude/')
     runs-on: ubuntu-latest
     steps:
@@ -43,13 +47,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Pass untrusted workflow_run values through env. GitHub interpolates
+      # ${{ }} before Bash parses `run:`, so inlining head_branch would let a
+      # crafted ref execute as shell. Env vars are assigned without shell parsing;
+      # sanitizing after interpolation does not help.
       - name: Sanitize branch name
         id: sanitize
+        env:
+          RAW_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
-          SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9/_-]//g')
-          echo "safe_branch=$SAFE_BRANCH" >> $GITHUB_OUTPUT
-          echo "Original: $BRANCH"
+          SAFE_BRANCH=$(printf '%s' "$RAW_BRANCH" | sed 's/[^a-zA-Z0-9/_-]//g')
+          echo "safe_branch=$SAFE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Original: $RAW_BRANCH"
           echo "Sanitized: $SAFE_BRANCH"
 
       - name: Run Claude to diagnose and fix CI failure


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1355.

## Problem

`.github/workflows/claude-ci-fix.yml` interpolated `${{ github.event.workflow_run.head_branch }}` directly into a `run:` script. GitHub expands `${{ }}` **before** Bash parses the line, so a crafted fork branch name (backticks / `$()`) executes as shell in the **base-repo** runner — which has `contents: write`, `pull-requests: write`, and `CLAUDE_CODE_OAUTH_TOKEN`. The later `sed` sanitizer never sees the original payload.

That is a classic pwn-request: any fork PR that fails Lint/Test can run arbitrary commands with this repo's write credentials.

## Fix

1. Bind `head_branch` through `env:` (`RAW_BRANCH`) so Bash never parses the raw value as shell. Sanitize with `printf` + `sed` after that.
2. Gate the job to same-repo PRs only: `head_repository.full_name == github.repository`.
3. Comment in the workflow explaining why `env:` is required (interpolation-before-parse).

`claude-nightly.yml` was checked: it is `schedule` / `workflow_dispatch` only, with no `workflow_run` payload and no `run:` interpolation of untrusted event fields.

Remaining `${{ github.event.workflow_run.* }}` uses in this file are action `with:` / `prompt:` strings (not `run:`), plus checkout `ref:` (not shell). Numeric / GitHub-generated fields (`id`, `html_url`, PR number, workflow name) are not attacker-controlled refnames.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Confirmed the only `run:` interpolation of `workflow_run.*` was the sanitize step.
- No other workflow in this change set.

Do not squash-merge this from the agent; leave merge to a human.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40788246-48ad-4868-b186-21ec1eb8aaa1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40788246-48ad-4868-b186-21ec1eb8aaa1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Harden the CI auto-fix workflow against pwn-request attacks by restricting it to same-repository pull requests and safely passing branch names through the environment.

Bug Fixes:
- Prevent fork pull requests from running the CI auto-fix workflow with base-repository write credentials.
- Eliminate shell injection risk when handling untrusted workflow-run branch names.

Enhancements:
- Document the workflow’s security constraints and safe handling of interpolated event data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated workflow security by restricting execution to eligible pull request failures.
  - Added safer handling for branch names and workflow outputs to prevent shell-related issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->