### PR TITLE
ci(dx): hygiene, deduped checks, unique dev ports, env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,60 +1,48 @@
 # ┌─────────────────────────────────────────────────────────────────────────────┐
 # │ MONOREPO ENVIRONMENT VARIABLES                                             │
 # │                                                                             │
-# │ This file contains all environment variables used across all apps in the   │
-# │ monorepo. Copy this file to .env.local for local development.              │
-# │                                                                             │
-# │ Usage:                                                                      │
+# │ Copy to .env.local for local development:                                   │
 # │   cp .env.example .env.local                                                │
 # │                                                                             │
-# │ Variables marked with NEXT_PUBLIC_ are exposed to the browser.             │
+# │ VITE_* variables are exposed to browser bundles at build time.             │
 # └─────────────────────────────────────────────────────────────────────────────┘
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CROSS-APP PUBLIC URLs
 # ═══════════════════════════════════════════════════════════════════════════════
-# Shared across all apps for cross-app linking
 
-# Vite apps
 VITE_DUYET_HOME_URL=https://duyet.net
 VITE_DUYET_BLOG_URL=https://blog.duyet.net
 VITE_DUYET_CV_URL=https://cv.duyet.net
 VITE_DUYET_INSIGHTS_URL=https://insights.duyet.net
 VITE_DUYET_PHOTOS_URL=https://photos.duyet.net
 VITE_DUYET_HOMELAB_URL=https://homelab.duyet.net
-# Next.js apps (keep until fully migrated)
-NEXT_PUBLIC_DUYET_HOME_URL=https://duyet.net
-NEXT_PUBLIC_DUYET_BLOG_URL=https://blog.duyet.net
-NEXT_PUBLIC_DUYET_CV_URL=https://cv.duyet.net
-NEXT_PUBLIC_DUYET_INSIGHTS_URL=https://insights.duyet.net
-NEXT_PUBLIC_DUYET_PHOTOS_URL=https://photos.duyet.net
-NEXT_PUBLIC_DUYET_HOMELAB_URL=https://homelab.duyet.net
+VITE_DUYET_LLM_TIMELINE_URL=https://llm-timeline.duyet.net
+VITE_DUYET_BURNS_URL=https://burns.duyet.net
+VITE_DUYET_NEWS_URL=https://news.duyet.net
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # API ENDPOINTS
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Vite apps
 VITE_API_BASE_URL=https://api.duyet.net
-# Next.js apps (keep until fully migrated)
-NEXT_PUBLIC_API_BASE_URL=https://api.duyet.net
-NEXT_PUBLIC_DUYET_API_URL=https://api.duyet.net
-NEXT_PUBLIC_DUYET_AI_URL=https://ai.duyet.net
+VITE_AGENT_API_URL=https://agents-api.duyet.net
+VITE_LANGGRAPH_API_URL=http://localhost:2024
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# VERCEL KV REDDI (Blog App)
+# CLIENT AUTH & ANALYTICS
 # ═══════════════════════════════════════════════════════════════════════════════
-# Used for comments and analytics
 
-KV_URL=
-KV_REST_API_URL=
-KV_REST_API_TOKEN=
-KV_REST_API_READ_ONLY_TOKEN=
+VITE_CLERK_PUBLISHABLE_KEY=
+VITE_ASSISTANT_API_TOKEN=
+VITE_MEASUREMENT_ID=
+VITE_SELINE_TOKEN=
+VITE_BASE_URL=https://insights.duyet.net
+VITE_GITHUB_REPO_URL=https://github.com/duyet/monorepo
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # UNSPLASH API (Photos App)
 # ═══════════════════════════════════════════════════════════════════════════════
-# Get credentials from: https://unsplash.com/developers
 
 UNSPLASH_ACCESS_KEY=
 UNSPLASH_USERNAME=
@@ -63,7 +51,6 @@ PHOTOS_OWNER_USERNAME=
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLOUDINARY (Photos App)
 # ═══════════════════════════════════════════════════════════════════════════════
-# Get credentials from: https://cloudinary.com/
 
 CLOUDINARY_CLOUD_NAME=
 CLOUDINARY_API_KEY=
@@ -74,23 +61,12 @@ CLOUDINARY_FOLDER=
 # ANALYTICS SERVICES
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Google Analytics
-NEXT_PUBLIC_MEASUREMENT_ID=
-
-# PostHog Analytics
 POSTHOG_API_KEY=
 POSTHOG_PROJECT_ID=
-
-# Axiom Analytics
-NEXT_PUBLIC_AXIOM_DATASET=
-
-# Seline Analytics
-NEXT_PUBLIC_SELINE_TOKEN=
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # CLOUDFLARE API (Insights App)
 # ═══════════════════════════════════════════════════════════════════════════════
-# Supports both API_KEY (local dev) and API_TOKEN (production)
 
 CLOUDFLARE_API_KEY=
 CLOUDFLARE_API_TOKEN=
@@ -100,18 +76,12 @@ CLOUDFLARE_ZONE_ID=
 # EXTERNAL APIS
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# GitHub API (Insights App)
 GITHUB_TOKEN=
-
-# WakaTime API (Insights App)
 WAKATIME_API_KEY=
-
-# OpenRouter API (API App)
-# Get your key at: https://openrouter.ai/keys
 OPENROUTER_API_KEY=
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# CLICKHOUSE DATABASE (Insights App - CCUsage Analytics)
+# CLICKHOUSE DATABASE (Insights App)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 CLICKHOUSE_HOST=
@@ -122,23 +92,29 @@ CLICKHOUSE_DATABASE=
 CLICKHOUSE_PROTOCOL=
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# MOTHERDUCK (Burns App - CCUsage Analytics)
+# MOTHERDUCK (Burns App)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 MOTHERDUCK_TOKEN=
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# AUTHENTICATION (Blog App)
+# AUTHENTICATION
 # ═══════════════════════════════════════════════════════════════════════════════
-# Clerk Authentication - Get from https://dashboard.clerk.com/
 
-NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
 CLERK_JWT_KEY=
-
-# Agents API
 AGENT_API_TOKEN=
 CLERK_AUTHORIZED_PARTIES=
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# NEWS WORKER (apps/news)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+NEWS_ADMIN_TOKEN=change-me
+ANYROUTER_API_KEY=change-me
+TELEGRAM_BOT_TOKEN=change-me
+CLICKHOUSE_NEWS_USER=change-me
+CLICKHOUSE_NEWS_PASSWORD=change-me
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # FRAMEWORK & DEPLOYMENT

--- a/.github/workflows/cf-deploy.yml
+++ b/.github/workflows/cf-deploy.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -58,108 +62,13 @@ jobs:
             --base "${{ github.event.before || github.event.pull_request.base.sha || '' }}" \
             --head "${{ github.sha }}"
 
-  typecheck:
-    name: Type check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
-        with:
-          submodules: false
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
-        with:
-          node-version: 24
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Type check
-        run: pnpm exec turbo check-types
-
-  unittest:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
-        with:
-          submodules: false
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
-        with:
-          node-version: 24
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Test
-        run: pnpm run test
-        env:
-          NODE_ENV: test
-          CI: true
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
-        with:
-          submodules: false
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
-        with:
-          node-version: 24
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        run: pnpm run lint
+  checks:
+    uses: ./.github/workflows/checks.yml
+    secrets: inherit
 
   deploy:
     name: Deploy ${{ matrix.app }}
-    needs: [detect-changes, typecheck, unittest, lint]
+    needs: [detect-changes, checks]
     if: ${{ needs.detect-changes.outputs.matrix != '{"include":[]}' }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/cf-worker-deploy.yml
+++ b/.github/workflows/cf-worker-deploy.yml
@@ -24,6 +24,10 @@ on:
           - news
           - all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -80,6 +84,18 @@ jobs:
           node-version: 24
 
       - uses: pnpm/action-setup@v4
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -193,6 +209,18 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -259,6 +287,18 @@ jobs:
           node-version: 24
 
       - uses: pnpm/action-setup@v4
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,63 @@
+name: Checks
+
+on:
+  workflow_call:
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  TURBO_REMOTE_ONLY: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm exec turbo check-types
+
+      - name: Test
+        run: pnpm run test
+        env:
+          NODE_ENV: test
+          CI: true
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-coverage
+          path: |
+            **/coverage
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -61,6 +61,29 @@ jobs:
           echo "Original: $RAW_BRANCH"
           echo "Sanitized: $SAFE_BRANCH"
 
+      # Pass untrusted workflow_run values through env before they reach the
+      # Claude prompt. GitHub interpolates ${{ }} in YAML before actions run;
+      # mapping via env + outputs keeps workflow_run fields out of the prompt
+      # block (same pattern as RAW_BRANCH above).
+      - name: Prepare workflow context
+        id: workflow_context
+        env:
+          RUN_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          {
+            echo "run_name<<EOF"
+            printf '%s' "$RUN_NAME"
+            echo "EOF"
+            echo "run_url<<EOF"
+            printf '%s' "$RUN_URL"
+            echo "EOF"
+            echo "pr_number=$PR_NUMBER"
+            echo "run_id=$RUN_ID"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run Claude to diagnose and fix CI failure
         uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678  # v1
         with:
@@ -71,13 +94,13 @@ jobs:
             actions: read
 
           prompt: |
-            The **"${{ github.event.workflow_run.name }}"** CI workflow failed on a pull request.
+            The **"${{ steps.workflow_context.outputs.run_name }}"** CI workflow failed on a pull request.
 
             **Details:**
               - Branch: `${{ steps.sanitize.outputs.safe_branch }}`
-              - PR: #${{ github.event.workflow_run.pull_requests[0].number }}
-              - Failed run: ${{ github.event.workflow_run.html_url }}
-              - Run ID: `${{ github.event.workflow_run.id }}`
+              - PR: #${{ steps.workflow_context.outputs.pr_number }}
+              - Failed run: ${{ steps.workflow_context.outputs.run_url }}
+              - Run ID: `${{ steps.workflow_context.outputs.run_id }}`
 
             **Your task — follow these steps in order:**
 
@@ -85,7 +108,7 @@ jobs:
 
             2. **Get the failure logs** to understand what went wrong:
                 ```
-                gh run view ${{ github.event.workflow_run.id }} --log-failed
+                gh run view ${{ steps.workflow_context.outputs.run_id }} --log-failed
                 ```
 
             3. **Reproduce the failure locally** to confirm you understand it:
@@ -100,16 +123,16 @@ jobs:
             5. **Verify the fix** by re-running the same commands from step 3. All must pass.
 
             6. **Create a fix branch** named exactly:
-                `claude/fix-ci-${{ github.event.workflow_run.pull_requests[0].number }}-${{ github.run_id }}`
+                `claude/fix-ci-${{ steps.workflow_context.outputs.pr_number }}-${{ github.run_id }}`
                 ```
-                git checkout -b "claude/fix-ci-${{ github.event.workflow_run.pull_requests[0].number }}-${{ github.run_id }}" "${{ steps.sanitize.outputs.safe_branch }}"
+                git checkout -b "claude/fix-ci-${{ steps.workflow_context.outputs.pr_number }}-${{ github.run_id }}" "${{ steps.sanitize.outputs.safe_branch }}"
                 ```
 
             7. **Commit** following the conventions in CLAUDE.md (semantic prefix, co-authors):
                 ```
-                git commit -m "fix(ci): fix ${{ github.event.workflow_run.name }} failures
+                git commit -m "fix(ci): fix ${{ steps.workflow_context.outputs.run_name }} failures
 
-                Auto-fix for failed run: ${{ github.event.workflow_run.html_url }}
+                Auto-fix for failed run: ${{ steps.workflow_context.outputs.run_url }}
 
                 Co-Authored-By: duyet <me@duyet.net>
                 Co-Authored-By: duyetbot <duyetbot@users.noreply.github.com>"
@@ -117,18 +140,18 @@ jobs:
 
             8. **Push and open a PR** targeting the original branch:
                 ```
-                git push origin claude/fix-ci-${{ github.event.workflow_run.pull_requests[0].number }}-${{ github.run_id }}
+                git push origin claude/fix-ci-${{ steps.workflow_context.outputs.pr_number }}-${{ github.run_id }}
                 gh pr create \
-                  --title "fix(ci): auto-fix ${{ github.event.workflow_run.name }} failures on PR #${{ github.event.workflow_run.pull_requests[0].number }}" \
-                  --body "Automated fix for CI failure on PR #${{ github.event.workflow_run.pull_requests[0].number }}.
+                  --title "fix(ci): auto-fix ${{ steps.workflow_context.outputs.run_name }} failures on PR #${{ steps.workflow_context.outputs.pr_number }}" \
+                  --body "Automated fix for CI failure on PR #${{ steps.workflow_context.outputs.pr_number }}.
 
-                **Failed run:** ${{ github.event.workflow_run.html_url }}
+                **Failed run:** ${{ steps.workflow_context.outputs.run_url }}
 
                 Please review and merge into \`${{ steps.sanitize.outputs.safe_branch }}\` if the fix looks correct." \
                   --base "${{ steps.sanitize.outputs.safe_branch }}" \
                 ```
 
-            **If you cannot confidently fix the issue** (e.g., the failure requires business logic decisions, or is a flaky test), instead post a comment on PR #${{ github.event.workflow_run.pull_requests[0].number }} explaining:
+            **If you cannot confidently fix the issue** (e.g., the failure requires business logic decisions, or is a flaky test), instead post a comment on PR #${{ steps.workflow_context.outputs.pr_number }} explaining:
             - What the failure is
             - What you investigated
             - Why you couldn't auto-fix it

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "26 5 * * 0"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Run Biome linting

--- a/.github/workflows/news-ingest.yml
+++ b/.github/workflows/news-ingest.yml
@@ -20,7 +20,11 @@ jobs:
           code=$(curl -s -o /tmp/resp.json -w '%{http_code}' -X POST \
             "https://news.duyet.net/api/admin/ingest" \
             -H "Authorization: Bearer ${{ secrets.NEWS_ADMIN_TOKEN }}")
-          cat /tmp/resp.json
+          if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
+            cat /tmp/resp.json
+          else
+            echo "ingest failed (HTTP $code); body suppressed"
+          fi
           if [ "$code" -lt 200 ] || [ "$code" -ge 300 ]; then
             echo "Trigger failed with HTTP $code" >&2
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # https://turbo.build/repo/docs/guides/ci-vendors/github-actions
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -20,81 +24,32 @@ permissions:
   security-events: write
 
 jobs:
-  typecheck:
+  checks:
+    uses: ./.github/workflows/checks.yml
+    secrets: inherit
+
+  rust-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: 24
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
-      - uses: pnpm/action-setup@v4
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
+      - name: Cache cargo registry & build
         uses: actions/cache@v6
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Type check
-        run: pnpm exec turbo check-types
-
-  unittest:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
-
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: 24
-
-      - uses: pnpm/action-setup@v4
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Test
-        run: pnpm run test
-        env:
-          NODE_ENV: test
-          CI: true
-
-      - name: Upload coverage reports
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-coverage
           path: |
-            **/coverage
-          retention-days: 7
-          if-no-files-found: ignore
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run Rust tests
+        run: cargo test --workspace
 
   security-scan:
     runs-on: ubuntu-latest
@@ -104,7 +59,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7  # v3  # v1  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/apps/agent-assistant/.env.example
+++ b/apps/agent-assistant/.env.example
@@ -1,19 +1,12 @@
-# Backend (LangGraph server)
+# Vite dev client (agent-assistant.duyet.net local)
+VITE_LANGGRAPH_API_URL=http://localhost:2024
+VITE_ASSISTANT_API_TOKEN=
+
+# Backend / LangGraph (Worker + local agent)
 OPENAI_API_KEY=
-# Optional override; defaults to gpt-4o-mini
 OPENAI_MODEL=
 
 # LangSmith tracing (optional)
 LANGSMITH_TRACING=true
 LANGSMITH_API_KEY=
 LANGSMITH_PROJECT=assistant-ui-with-langgraph-template
-
-# Frontend (Next.js proxy to LangGraph)
-LANGGRAPH_API_URL=http://localhost:2024
-# Forwarded as `x-api-key`. Leave blank for local dev.
-LANGCHAIN_API_KEY=
-# Graph id. Must match a key under "graphs" in langgraph.json.
-NEXT_PUBLIC_LANGGRAPH_ASSISTANT_ID=agent
-# Optional. Bypasses the /api proxy and lets the browser hit LangGraph directly.
-# Leave unset to route everything through the Next.js proxy on the current host.
-NEXT_PUBLIC_LANGGRAPH_API_URL=

--- a/apps/agent-assistant/README.md
+++ b/apps/agent-assistant/README.md
@@ -30,7 +30,7 @@ This is the [assistant-ui](https://github.com/assistant-ui/assistant-ui) starter
    ```
 
    - `localhost:2024` — LangGraph dev server (serves the `agent` graph)
-   - `localhost:3000` — Next.js app (proxies `/api/*` → `LANGGRAPH_API_URL`)
+   - `localhost:3004` — Vite dev client (proxies API routes to LangGraph)
 
    Run them individually with `bun run dev:backend` and `bun run dev:frontend`.
 

--- a/apps/agent-assistant/package.json
+++ b/apps/agent-assistant/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite dev --port 3000",
+    "dev": "vite dev --port 3004",
     "build": "vite build",
     "check-types": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/agent-assistant/vite.config.ts
+++ b/apps/agent-assistant/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3000,
+    port: 3004,
+    strictPort: true,
   },
 });

--- a/apps/ai-percentage/lib/utils.test.ts
+++ b/apps/ai-percentage/lib/utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { DATE_RANGES, formatPercentage, getDateCondition } from "../lib/utils";
+
+describe("ai-percentage utils", () => {
+  it("defines the supported date ranges", () => {
+    expect(DATE_RANGES.map((range) => range.value)).toEqual([
+      "30d",
+      "90d",
+      "6m",
+      "1y",
+      "all",
+    ]);
+  });
+
+  it("builds ClickHouse date filters", () => {
+    expect(getDateCondition(30)).toContain("INTERVAL 30 DAY");
+    expect(getDateCondition("all")).toBe("");
+  });
+
+  it("formats percentage values", () => {
+    expect(formatPercentage(0)).toBe("0%");
+    expect(formatPercentage(12.34)).toBe("12.3%");
+  });
+});

--- a/apps/ai-percentage/package.json
+++ b/apps/ai-percentage/package.json
@@ -7,9 +7,10 @@
     "config": "tsx ../../scripts/sync-app-secrets.ts duyet-ai-percentage",
     "build": "node --import ../../scripts/force-workspace-react.mjs ../../node_modules/vite/bin/vite.js build && tsx ../../scripts/patch-html-for-cloudflare.ts",
     "check-types": "tsc --noEmit",
-    "dev": "vite dev --port 3002",
+    "dev": "vite dev --port 3015",
     "fmt": "pnpm run fix",
     "lint": "biome lint .",
+    "test": "vitest run",
     "cf:deploy:prod": "../../scripts/cf-deploy-prod.sh ai-percentage duyet-ai-percentage"
   },
   "dependencies": {
@@ -32,6 +33,7 @@
     "@types/react-dom": "^19.1.5",
     "typescript": "*",
     "vite": "^8.0.0",
-    "vite-tsconfig-paths": "^6.0.0"
+    "vite-tsconfig-paths": "^6.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/ai-percentage/vite.config.ts
+++ b/apps/ai-percentage/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     },
   ],
   server: {
-    port: 3002,
+    port: 3015,
+    strictPort: true,
   },
 });

--- a/apps/blog/vite.config.ts
+++ b/apps/blog/vite.config.ts
@@ -14,7 +14,7 @@ function getPostRoutes(): string[] {
 }
 
 export default defineConfig({
-  server: { port: 3000 },
+  server: { port: 3000, strictPort: true },
   // Native tsconfig `paths` resolution (replaces the vite-tsconfig-paths plugin).
   resolve: { tsconfigPaths: true, dedupe: ["react", "react-dom"] },
   plugins: [

--- a/apps/burns/vite.config.ts
+++ b/apps/burns/vite.config.ts
@@ -27,5 +27,6 @@ export default defineConfig({
   ],
   server: {
     port: 3010,
+    strictPort: true,
   },
 });

--- a/apps/cv/package.json
+++ b/apps/cv/package.json
@@ -8,7 +8,7 @@
     "config": "tsx ../../scripts/sync-app-secrets.ts duyet-cv",
     "build": "node --import ../../scripts/force-workspace-react.mjs ../../node_modules/vite/bin/vite.js build && tsx ../../scripts/patch-html-for-cloudflare.ts",
     "check-types": "tsc --noEmit",
-    "dev": "vite dev",
+    "dev": "vite dev --port 3017",
     "fmt": "pnpm run fix",
     "lint": "biome lint .",
     "preview": "vite preview",

--- a/apps/cv/vite.config.ts
+++ b/apps/cv/vite.config.ts
@@ -3,7 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
-  server: { port: 3002 },
+  server: { port: 3017, strictPort: true },
   resolve: { dedupe: ["react", "react-dom"] },
   plugins: [
     tanstackStart({

--- a/apps/home/vite.config.ts
+++ b/apps/home/vite.config.ts
@@ -3,7 +3,7 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 export default defineConfig({
-  server: { port: 3001 },
+  server: { port: 3001, strictPort: true },
   build: {
     rollupOptions: {
       output: {

--- a/apps/homelab/package.json
+++ b/apps/homelab/package.json
@@ -7,7 +7,7 @@
     "config": "tsx ../../scripts/sync-app-secrets.ts duyet-homelab",
     "build": "node --import ../../scripts/force-workspace-react.mjs ../../node_modules/vite/bin/vite.js build && tsx ../../scripts/patch-html-for-cloudflare.ts",
     "check-types": "tsc --noEmit",
-    "dev": "vite dev --port 3002",
+    "dev": "vite dev --port 3016",
     "fmt": "pnpm run fix",
     "lint": "biome lint .",
     "start": "vite preview --port 3002",

--- a/apps/homelab/vite.config.ts
+++ b/apps/homelab/vite.config.ts
@@ -3,7 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
-  server: { port: 3002 },
+  server: { port: 3016, strictPort: true },
   resolve: { dedupe: ["react", "react-dom"] },
   plugins: [
     tanstackStart({

--- a/apps/insights/README.md
+++ b/apps/insights/README.md
@@ -24,7 +24,7 @@ Do not use `NEXT_PUBLIC_*` names. This app is Vite / TanStack Start, not Next.js
 ## Development
 
 ```bash
-pnpm run dev          # http://localhost:3001
+pnpm run dev          # http://localhost:3013
 pnpm run test
 pnpm run check-types
 pnpm run cf:deploy:prod

--- a/apps/insights/package.json
+++ b/apps/insights/package.json
@@ -15,7 +15,7 @@
     "prebuild": "cd ../blog && tsx scripts/generate-posts-data.ts",
     "build": "node --import ../../scripts/force-workspace-react.mjs ../../node_modules/vite/bin/vite.js build && tsx ../../scripts/patch-html-for-cloudflare.ts",
     "check-types": "tsc --noEmit",
-    "dev": "vite dev --port 3001",
+    "dev": "vite dev --port 3013",
     "fmt": "pnpm run fix",
     "lint": "biome lint .",
     "start": "vite preview --port 3001",

--- a/apps/insights/vite.config.ts
+++ b/apps/insights/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
     },
   ],
   server: {
-    port: 3001,
+    port: 3013,
+    strictPort: true,
   },
 });

--- a/apps/news/package.json
+++ b/apps/news/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite dev --port 3010",
+    "dev": "vite dev --port 3014",
     "build": "vite build",
     "test": "vitest run",
     "check-types": "tsc --noEmit",

--- a/apps/news/vite.config.ts
+++ b/apps/news/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 3010,
+    port: 3014,
+    strictPort: true,
   },
 });

--- a/apps/tip/package.json
+++ b/apps/tip/package.json
@@ -9,6 +9,7 @@
     "dev": "vite dev --port 3012",
     "fmt": "biome format --write .",
     "lint": "biome lint .",
+    "test": "vitest run",
     "cf:deploy:prod": "../../scripts/cf-deploy-prod.sh tip duyet-tip"
   },
   "dependencies": {
@@ -27,6 +28,7 @@
     "@types/react-dom": "^19.1.5",
     "typescript": "*",
     "vite": "^8.0.0",
-    "vite-tsconfig-paths": "^6.0.0"
+    "vite-tsconfig-paths": "^6.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/tip/src/lib/site.test.ts
+++ b/apps/tip/src/lib/site.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  KOFI_PROFILE_URL,
+  KOFI_URL,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_URL,
+} from "./site";
+
+describe("tip site config", () => {
+  it("exports the Ko-fi embed constants", () => {
+    expect(SITE_TITLE).toBe("Tip");
+    expect(SITE_DESCRIPTION).toContain("Ko-fi");
+    expect(SITE_URL).toBe("https://tip.duyet.net");
+    expect(KOFI_URL).toContain("ko-fi.com/duyet");
+    expect(KOFI_PROFILE_URL).toBe("https://ko-fi.com/duyet");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,6 +478,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(happy-dom@20.11.6)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)(yaml@2.9.0)
 
   apps/api:
     dependencies:
@@ -1407,6 +1410,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^6.0.0
         version: 6.1.1(typescript@6.0.3)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(happy-dom@20.11.6)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)(yaml@2.9.0)
 
   apps/x-algo:
     dependencies:

--- a/scripts/sync-app-secrets.ts
+++ b/scripts/sync-app-secrets.ts
@@ -18,7 +18,8 @@
  * consistency with Cloudflare secret configuration.
  */
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -26,6 +27,21 @@ import { spawnSync } from "node:child_process";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, "..");
+
+function warnStaleSeedFiles(): void {
+  try {
+    const stale = readdirSync(os.tmpdir()).filter(
+      (file) => file.startsWith("wrangler-seeds-") && file.endsWith(".json")
+    );
+    if (stale.length > 0) {
+      console.warn(
+        `  [WARN] Found ${stale.length} stale seed file(s) in ${os.tmpdir()}: ${stale.join(", ")}`
+      );
+    }
+  } catch {
+    // Ignore tmpdir read errors
+  }
+}
 
 // CLI args (only defined when running as main script)
 const appName = process.argv[2] ?? "";
@@ -376,42 +392,46 @@ async function setSecretsBulk(
     const dirName = appName.replace("duyet-", "");
     const appDir = join(rootDir, "apps", dirName);
 
-    // Create a temporary JSON file in the app directory
-    const tmpFile = join(appDir, `.wrangler-seeds-${appName}.json`);
-    writeFileSync(tmpFile, JSON.stringify(secrets, null, 2));
+    const tmpFile = join(
+      os.tmpdir(),
+      `wrangler-seeds-${appName}-${Date.now()}.json`
+    );
 
-    // Check if this is a Pages project (has pages_build_output_dir) or Workers project
-    const wranglerTomlPath = join(appDir, "wrangler.toml");
-    const wranglerToml = readFileSync(wranglerTomlPath, "utf-8");
-    const isPagesProject = wranglerToml.includes("pages_build_output_dir");
-
-    // Use different commands for Pages vs Workers
-    const cmd = isPagesProject
-      ? ["pnpm", "dlx", "wrangler", "pages", "secret", "bulk", tmpFile]
-      : ["pnpm", "dlx", "wrangler", "secret", "bulk", tmpFile, "--env="];
-
-    // Run wrangler from the app directory so it finds wrangler.toml
-    const result = spawnSync(cmd[0], cmd.slice(1), {
-      cwd: appDir,
-      stdio: ["inherit", "pipe", "pipe"],
-      env: { ...process.env, ...env },
-      encoding: "utf-8",
-    });
-
-    // Clean up temp file
     try {
-      unlinkSync(tmpFile);
-    } catch {
-      // Ignore cleanup errors
-    }
+      writeFileSync(tmpFile, JSON.stringify(secrets, null, 2));
 
-    if (result.status !== 0) {
-      const stderr = result.stderr ?? "";
-      console.error(`  [ERROR] Failed to sync secrets: ${stderr}`);
-      return false;
-    }
+      // Check if this is a Pages project (has pages_build_output_dir) or Workers project
+      const wranglerTomlPath = join(appDir, "wrangler.toml");
+      const wranglerToml = readFileSync(wranglerTomlPath, "utf-8");
+      const isPagesProject = wranglerToml.includes("pages_build_output_dir");
 
-    return true;
+      // Use different commands for Pages vs Workers
+      const cmd = isPagesProject
+        ? ["pnpm", "dlx", "wrangler", "pages", "secret", "bulk", tmpFile]
+        : ["pnpm", "dlx", "wrangler", "secret", "bulk", tmpFile, "--env="];
+
+      // Run wrangler from the app directory so it finds wrangler.toml
+      const result = spawnSync(cmd[0], cmd.slice(1), {
+        cwd: appDir,
+        stdio: ["inherit", "pipe", "pipe"],
+        env: { ...process.env, ...env },
+        encoding: "utf-8",
+      });
+
+      if (result.status !== 0) {
+        const stderr = result.stderr ?? "";
+        console.error(`  [ERROR] Failed to sync secrets: ${stderr}`);
+        return false;
+      }
+
+      return true;
+    } finally {
+      try {
+        unlinkSync(tmpFile);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
   } catch (error) {
     console.error(`  [ERROR] Exception syncing secrets:`, error);
     return false;
@@ -466,6 +486,7 @@ async function setBuildVarsForPages(
 }
 
 async function main() {
+  warnStaleSeedFiles();
   console.log(`\n[${appName}] Syncing secrets and build vars...`);
 
   // Load environment variables from root


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes three advisor plans in one focused PR covering CI hygiene, developer-experience fixes, and CI deduplication.

Fixes #1377
Fixes #1382
Fixes #1389

### #1377 — CI hygiene
- `claude-ci-fix.yml`: map `workflow_run` fields through a preparatory step (`workflow_context` outputs) instead of interpolating them directly in the Claude prompt
- `news-ingest.yml`: only print response bodies on HTTP 2xx; suppress body on failure
- `sync-app-secrets.ts`: write wrangler seed JSON to `os.tmpdir()` with `try/finally` cleanup; warn on stale seed files at script start
- Added `concurrency: cancel-in-progress` to `lint.yml`, `test.yml`, `cf-deploy.yml`, and `cf-worker-deploy.yml`

### #1382 — DX
- Assigned unique dev ports with `strictPort: true` for all colliding apps (blog 3000, agent-assistant 3004, insights 3013, news 3014, ai-percentage 3015, homelab 3016, cv 3017; burns stays 3010)
- Added `vitest` smoke tests and `"test": "vitest run"` scripts to `apps/tip` and `apps/ai-percentage`
- Regenerated root `.env.example` (removed legacy `NEXT_PUBLIC_*`, KV/Postgres dead blocks; added missing `VITE_*` and news worker secret names)
- Rewrote `apps/agent-assistant/.env.example` for the real Vite/LangGraph vars

### #1389 — CI dedupe & Rust tests
- New reusable `.github/workflows/checks.yml` (`workflow_call`) runs typecheck + test + lint in one checkout/install
- `test.yml` and `cf-deploy.yml` call the shared checks workflow instead of duplicating three jobs
- Added pnpm store cache to all three `cf-worker-deploy` jobs
- Added `rust-tests` job in `test.yml` running `cargo test --workspace` with pinned `dtolnay/rust-toolchain@stable`

## Verification
- `pnpm exec biome lint` on changed script/test files
- `pnpm vitest run` in `apps/tip` and `apps/ai-percentage`
- Python `yaml.safe_load` on all touched workflow files
- Local `cargo test --workspace` requires newer stable Rust (CI toolchain pin handles this)

## Notes
- `lint.yml` still runs independently on PRs; the shared checks workflow consolidates the duplicate gate inside `test.yml` / `cf-deploy.yml`.
- Port map README updates limited to files with explicit localhost port mentions (`agent-assistant`, `insights`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d40cc160-e022-4fc2-9f24-5a2ef6efe8d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d40cc160-e022-4fc2-9f24-5a2ef6efe8d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Improve CI reliability and efficiency while standardizing local development configuration and expanding automated test coverage.

New Features:
- Add reusable CI checks covering type checking, tests, linting, and coverage artifacts.
- Run workspace Rust tests in CI with a pinned stable toolchain.
- Assign non-overlapping strict development ports and add smoke-test coverage to the Tip and AI Percentage apps.

Bug Fixes:
- Prevent failed news ingestion requests from exposing response bodies.
- Ensure temporary Wrangler seed files are created outside the repository and cleaned up reliably.
- Protect Claude CI prompts from direct interpolation of untrusted workflow metadata.

Enhancements:
- Consolidate duplicated typecheck, test, and lint jobs across test and deployment workflows.
- Warn about stale Wrangler seed files and improve CI concurrency handling by cancelling superseded runs.

CI:
- Use the shared checks workflow for test and Cloudflare deployment validation.
- Add pnpm store caching to Cloudflare worker deployment jobs.

Documentation:
- Update developer environment examples and app documentation to reflect current Vite ports and environment variables.

Tests:
- Add Vitest smoke tests for the Tip and AI Percentage applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized local development ports across applications, with clear failures when assigned ports are unavailable.
  * Updated setup documentation and environment templates for current frontend, authentication, analytics, and service integrations.
  * Improved deployment reliability by cancelling redundant runs, caching dependencies, and consolidating automated checks.
  * Improved deployment error reporting with clearer failure messages and safer temporary secret handling.

* **Tests**
  * Added automated coverage for AI percentage calculations and tip site configuration.
  * Expanded validation to include Rust workspace tests, type checks, linting, and coverage artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->