### PR TITLE
fix(news): harden APIs, /data page, pipeline throughput, moderation queue

### DIFF
--- a/apps/news/scripts/smoke.ts
+++ b/apps/news/scripts/smoke.ts
@@ -163,7 +163,7 @@ async function main() {
     "/mcp",
     "/changelog",
     "/subscribe",
-    "/system",
+    "/data",
   ];
   for (const route of staticRoutes) {
     await check(`GET ${route} -> 200`, async () => {

--- a/apps/news/src/components/HeaderBar.tsx
+++ b/apps/news/src/components/HeaderBar.tsx
@@ -18,14 +18,14 @@ import { SearchBox } from "./SearchBox";
 // Routes whose content is English-only — the EN|VI toggle is disabled
 // while on one of these, rather than offering a translation that doesn't
 // exist.
-const LANG_TOGGLE_DISABLED_PATHS = new Set(["/system", "/about", "/mail"]);
+const LANG_TOGGLE_DISABLED_PATHS = new Set(["/data", "/about", "/mail"]);
 
 const SITE_LINKS = [
   { href: "/", label: "News", internal: true },
   { href: "/about", label: "About", internal: true },
   { href: "/mcp", label: "MCP", internal: true },
   { href: "/subscribe", label: "Subscribe", internal: true },
-  { href: "/system", label: "Analytics", internal: true },
+  { href: "/data", label: "Data", internal: true },
   { href: "/submit", label: "Submit", internal: true },
   { href: "https://duyet.net", label: "Home", internal: false },
   { href: "https://blog.duyet.net", label: "Blog", internal: false },

--- a/apps/news/src/components/SuggestTranslation.tsx
+++ b/apps/news/src/components/SuggestTranslation.tsx
@@ -11,6 +11,7 @@ function SuggestForm({
   lang,
   userId,
   userName,
+  getToken,
   initialText,
   onInitialTextConsumed,
 }: {
@@ -19,6 +20,7 @@ function SuggestForm({
   lang: Lang;
   userId: string;
   userName: string;
+  getToken: () => Promise<string | null>;
   /** Set by the selection-to-suggest floating button — opens the form
    * pre-filled with the selected text as quoted context. */
   initialText?: string;
@@ -70,6 +72,8 @@ function SuggestForm({
         setStatus("sending");
         setError(null);
         try {
+          const token = await getToken();
+          if (!token) throw new Error("Sign in required");
           await submitSuggestion({
             data: {
               item_id: itemId,
@@ -78,6 +82,7 @@ function SuggestForm({
               user_id: userId,
               user_name: userName,
             },
+            headers: { Authorization: `Bearer ${token}` },
           });
           setStatus("sent");
         } catch (err) {
@@ -164,7 +169,7 @@ function SuggestTranslationInner({
 
   if (!publishableKey || !mod) return signInHint;
 
-  const { SignedIn, SignedOut, useUser } = mod;
+  const { SignedIn, SignedOut, useUser, useAuth } = mod;
 
   // No own <ClerkProvider> here — __root.tsx mounts the single app-wide
   // one; a second provider crashes the whole page.
@@ -177,6 +182,7 @@ function SuggestTranslationInner({
           field={field}
           lang={lang}
           useUser={useUser}
+          useAuth={useAuth}
           initialText={initialText}
           onInitialTextConsumed={onInitialTextConsumed}
         />
@@ -190,6 +196,7 @@ function SuggestFormGate({
   field,
   lang,
   useUser,
+  useAuth,
   initialText,
   onInitialTextConsumed,
 }: {
@@ -197,10 +204,12 @@ function SuggestFormGate({
   field: "title" | "summary";
   lang: Lang;
   useUser: any;
+  useAuth: any;
   initialText?: string;
   onInitialTextConsumed?: () => void;
 }) {
   const { user } = useUser();
+  const { getToken } = useAuth();
   if (!user) return null;
   const userName = user.fullName ?? user.username ?? "user";
   return (
@@ -210,6 +219,7 @@ function SuggestFormGate({
       lang={lang}
       userId={user.id}
       userName={userName}
+      getToken={getToken}
       initialText={initialText}
       onInitialTextConsumed={onInitialTextConsumed}
     />

--- a/apps/news/src/components/mail/MailPanel.tsx
+++ b/apps/news/src/components/mail/MailPanel.tsx
@@ -275,10 +275,10 @@ export function MailPanel({ admin }: { admin: AdminState }) {
           </p>
         </div>
         <Link
-          to="/system"
+          to="/data"
           className="text-sm text-muted-foreground hover:text-foreground"
         >
-          Analytics
+          Data
         </Link>
       </header>
 

--- a/apps/news/src/components/system/AdminPanel.tsx
+++ b/apps/news/src/components/system/AdminPanel.tsx
@@ -128,6 +128,32 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
   const [rateDrafts, setRateDrafts] = useState<
     Record<string, { importance: string; quality: string }>
   >({});
+  const [queueSuggestions, setQueueSuggestions] = useState<
+    {
+      id: string;
+      item_id: string;
+      field: string;
+      suggestion: string;
+      user_name: string | null;
+      rating: number | null;
+      created_at: number;
+    }[]
+  >([]);
+  const [queueSubmissions, setQueueSubmissions] = useState<
+    {
+      id: string;
+      url: string;
+      title: string;
+      note: string | null;
+      user_name: string | null;
+      rating: number | null;
+      created_at: number;
+    }[]
+  >([]);
+  const [queueBusy, setQueueBusy] = useState(false);
+  const [queueActionBusyId, setQueueActionBusyId] = useState<string | null>(
+    null
+  );
 
   async function loadStatus() {
     setStatusBusy(true);
@@ -170,6 +196,52 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
     }
   }
 
+  async function loadQueue() {
+    setQueueBusy(true);
+    try {
+      const [sRes, subRes] = await Promise.all([
+        authedFetch(admin, "/api/admin/suggestions?limit=50"),
+        authedFetch(admin, "/api/admin/submissions?limit=50"),
+      ]);
+      if (sRes.ok) {
+        const data = (await sRes.json()) as {
+          suggestions?: typeof queueSuggestions;
+        };
+        setQueueSuggestions(Array.isArray(data.suggestions) ? data.suggestions : []);
+      }
+      if (subRes.ok) {
+        const data = (await subRes.json()) as {
+          submissions?: typeof queueSubmissions;
+        };
+        setQueueSubmissions(
+          Array.isArray(data.submissions) ? data.submissions : []
+        );
+      }
+    } catch {
+      // leave previous queue in place
+    } finally {
+      setQueueBusy(false);
+    }
+  }
+
+  async function decideQueue(
+    kind: "suggestions" | "submissions",
+    id: string,
+    action: "approve" | "reject"
+  ) {
+    setQueueActionBusyId(id);
+    try {
+      const res = await authedFetch(admin, `/api/admin/${kind}/decide`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, action }),
+      });
+      if (res.ok) await loadQueue();
+    } finally {
+      setQueueActionBusyId(null);
+    }
+  }
+
   async function loadItems() {
     setItemsBusy(true);
     try {
@@ -188,7 +260,13 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
   async function refreshAll() {
     setRefreshError(false);
     try {
-      await Promise.all([loadStatus(), loadCalls(), loadItems(), loadAudit()]);
+      await Promise.all([
+        loadStatus(),
+        loadCalls(),
+        loadItems(),
+        loadAudit(),
+        loadQueue(),
+      ]);
     } catch {
       setRefreshError(true);
     }
@@ -582,6 +660,155 @@ export function AdminPanel({ admin }: { admin: AdminState }) {
                 ))}
               </tbody>
             </table>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-medium text-muted-foreground">Queue</p>
+          <button
+            type="button"
+            onClick={loadQueue}
+            disabled={queueBusy}
+            className="rounded border border-border px-2 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+          >
+            {queueBusy ? "Refreshing…" : "Refresh"}
+          </button>
+        </div>
+        {queueSuggestions.length === 0 && queueSubmissions.length === 0 ? (
+          <p className="mt-1 text-xs text-muted-foreground">
+            No pending suggestions or submissions.
+          </p>
+        ) : (
+          <div className="mt-2 space-y-4">
+            {queueSuggestions.length > 0 && (
+              <div className="overflow-x-auto">
+                <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Suggestions
+                </p>
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border text-left text-muted-foreground">
+                      <th className="py-1 pr-2 font-normal">field</th>
+                      <th className="py-1 pr-2 font-normal">suggestion</th>
+                      <th className="py-1 pr-2 font-normal">user</th>
+                      <th className="py-1 pr-2 font-normal text-right">rating</th>
+                      <th className="py-1 pr-2 font-normal">actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {queueSuggestions.map((row) => {
+                      const busy = queueActionBusyId === row.id;
+                      return (
+                        <tr key={row.id} className="border-b border-border/50">
+                          <td className="py-1 pr-2">{row.field}</td>
+                          <td className="py-1 pr-2 max-w-xs truncate">
+                            {row.suggestion}
+                          </td>
+                          <td className="py-1 pr-2">{row.user_name ?? "—"}</td>
+                          <td className="py-1 pr-2 text-right tabular-nums">
+                            {row.rating ?? "—"}
+                          </td>
+                          <td className="py-1 pr-2">
+                            <div className="flex gap-1">
+                              <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() =>
+                                  decideQueue("suggestions", row.id, "approve")
+                                }
+                                className="rounded border border-border px-1.5 py-0.5 hover:bg-muted disabled:opacity-50"
+                              >
+                                Approve
+                              </button>
+                              <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() =>
+                                  decideQueue("suggestions", row.id, "reject")
+                                }
+                                className="rounded border border-border px-1.5 py-0.5 hover:bg-muted disabled:opacity-50"
+                              >
+                                Reject
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {queueSubmissions.length > 0 && (
+              <div className="overflow-x-auto">
+                <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Submissions
+                </p>
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b border-border text-left text-muted-foreground">
+                      <th className="py-1 pr-2 font-normal">title</th>
+                      <th className="py-1 pr-2 font-normal">url</th>
+                      <th className="py-1 pr-2 font-normal">user</th>
+                      <th className="py-1 pr-2 font-normal text-right">rating</th>
+                      <th className="py-1 pr-2 font-normal">actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {queueSubmissions.map((row) => {
+                      const busy = queueActionBusyId === row.id;
+                      return (
+                        <tr key={row.id} className="border-b border-border/50">
+                          <td className="py-1 pr-2 max-w-xs truncate">
+                            {row.title}
+                          </td>
+                          <td className="py-1 pr-2 max-w-xs truncate">
+                            <a
+                              href={row.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="hover:underline"
+                            >
+                              {row.url}
+                            </a>
+                          </td>
+                          <td className="py-1 pr-2">{row.user_name ?? "—"}</td>
+                          <td className="py-1 pr-2 text-right tabular-nums">
+                            {row.rating ?? "—"}
+                          </td>
+                          <td className="py-1 pr-2">
+                            <div className="flex gap-1">
+                              <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() =>
+                                  decideQueue("submissions", row.id, "approve")
+                                }
+                                className="rounded border border-border px-1.5 py-0.5 hover:bg-muted disabled:opacity-50"
+                              >
+                                Approve
+                              </button>
+                              <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() =>
+                                  decideQueue("submissions", row.id, "reject")
+                                }
+                                className="rounded border border-border px-1.5 py-0.5 hover:bg-muted disabled:opacity-50"
+                              >
+                                Reject
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/news/src/components/system/LlmSection.tsx
+++ b/apps/news/src/components/system/LlmSection.tsx
@@ -1,0 +1,109 @@
+import type { LlmDayTaskCount } from "../../lib/system-queries";
+
+const TASK_COLORS: Record<string, string> = {
+  score: "bg-accent",
+  translate: "bg-muted-foreground/50",
+  tldr: "bg-emerald-500/70",
+};
+
+interface LlmSectionProps {
+  data: LlmDayTaskCount[];
+  formatTokens: (n: number) => string;
+}
+
+function totals(data: LlmDayTaskCount[]) {
+  let calls = 0;
+  let failures = 0;
+  let tokens = 0;
+  for (const row of data) {
+    calls += row.calls;
+    failures += row.failures;
+    tokens += row.tokens;
+  }
+  return { calls, failures, tokens };
+}
+
+/** Stacked daily LLM call chart grouped by task. */
+export function LlmSection({ data, formatTokens }: LlmSectionProps) {
+  if (data.length === 0) {
+    return <p className="text-sm text-muted-foreground">No LLM call data yet.</p>;
+  }
+
+  const byDate = new Map<string, LlmDayTaskCount[]>();
+  for (const row of data) {
+    const list = byDate.get(row.date) ?? [];
+    list.push(row);
+    byDate.set(row.date, list);
+  }
+  const dates = [...byDate.keys()].sort();
+  const maxCalls = Math.max(
+    ...dates.map((d) =>
+      (byDate.get(d) ?? []).reduce((sum, r) => sum + r.calls, 0)
+    ),
+    1
+  );
+  const tasks = [...new Set(data.map((r) => r.task))].sort();
+  const { calls, failures, tokens } = totals(data);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+        <span>
+          calls{" "}
+          <span className="font-mono tabular-nums text-foreground">{calls}</span>
+        </span>
+        <span>
+          failures{" "}
+          <span className="font-mono tabular-nums text-foreground">
+            {failures}
+          </span>
+        </span>
+        <span>
+          tokens{" "}
+          <span className="font-mono tabular-nums text-foreground">
+            {formatTokens(tokens)}
+          </span>
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2 text-[10px] text-muted-foreground">
+        {tasks.map((task) => (
+          <span key={task} className="inline-flex items-center gap-1">
+            <span
+              className={`inline-block h-2 w-2 rounded-sm ${TASK_COLORS[task] ?? "bg-border"}`}
+            />
+            {task}
+          </span>
+        ))}
+      </div>
+      <div className="flex h-28 items-end gap-1">
+        {dates.map((date) => {
+          const rows = byDate.get(date) ?? [];
+          const dayTotal = rows.reduce((sum, r) => sum + r.calls, 0);
+          const heightPct = Math.max((dayTotal / maxCalls) * 100, dayTotal ? 4 : 1);
+          return (
+            <div
+              key={date}
+              className="group relative flex flex-1 flex-col items-center justify-end"
+              title={`${date}: ${dayTotal} calls`}
+            >
+              <div
+                className="flex w-full flex-col justify-end overflow-hidden rounded-t-sm"
+                style={{ height: `${heightPct}%` }}
+              >
+                {rows.map((row) => (
+                  <div
+                    key={`${date}-${row.task}`}
+                    className={`w-full ${TASK_COLORS[row.task] ?? "bg-border"}`}
+                    style={{
+                      height: `${(row.calls / (dayTotal || 1)) * 100}%`,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/news/src/components/system/RankingExplainer.tsx
+++ b/apps/news/src/components/system/RankingExplainer.tsx
@@ -1,0 +1,54 @@
+import type { ModelChains } from "../../lib/system-queries";
+
+interface RankingExplainerProps {
+  models: ModelChains;
+}
+
+/** Surfaces the live ranking formula and model chains for operators. */
+export function RankingExplainer({ models }: RankingExplainerProps) {
+  return (
+    <div className="space-y-3 text-sm">
+      <p className="text-muted-foreground">
+        rankScore = importance × qualityFactor × decay × engagement
+      </p>
+      <ul className="space-y-1 text-xs text-muted-foreground">
+        <li>qualityFactor = 0.6 + 0.4 × (quality / 10)</li>
+        <li>decay = exp(−ageHours / 36)</li>
+        <li>
+          engagement = 1 + log10(1 + points + 0.5 × comments)
+        </li>
+      </ul>
+      <p className="text-xs text-muted-foreground">
+        Full pipeline details:{" "}
+        <a
+          href="https://github.com/duyet/monorepo/blob/master/apps/news/ALGORITHM.md"
+          className="text-accent underline underline-offset-2 hover:no-underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          apps/news/ALGORITHM.md
+        </a>
+      </p>
+      <div className="space-y-1 border-t border-border pt-2 text-xs">
+        <div>
+          scoring:{" "}
+          <span className="font-mono text-foreground">
+            {models.scoring.join(" → ") || "—"}
+          </span>
+        </div>
+        <div>
+          translation:{" "}
+          <span className="font-mono text-foreground">
+            {models.translation.join(" → ") || "—"}
+          </span>
+        </div>
+        <div>
+          tldr:{" "}
+          <span className="font-mono text-foreground">
+            {models.tldr.join(" → ") || "—"}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/news/src/components/system/RunsList.tsx
+++ b/apps/news/src/components/system/RunsList.tsx
@@ -10,12 +10,20 @@ interface RunsListProps {
   lang: "en" | "vi";
 }
 
+function formatDurationSec(
+  started: number | null,
+  finished: number | null
+): number {
+  if (!started || !finished) return 0;
+  return Math.max(finished - started, 0);
+}
+
 function formatDuration(
   started: number | null,
   finished: number | null
 ): string {
-  if (!started || !finished) return "—";
-  const s = Math.max(finished - started, 0);
+  const s = formatDurationSec(started, finished);
+  if (!s) return "—";
   return s < 60 ? `${s}s` : `${Math.round(s / 60)}m`;
 }
 
@@ -69,6 +77,12 @@ export function RunsList({ runs, lang }: RunsListProps) {
       </p>
     );
   }
+
+  const maxDuration = Math.max(
+    ...runs.map((r) => formatDurationSec(r.started_at, r.finished_at)),
+    1
+  );
+
   return (
     <div
       ref={scrollRef}
@@ -85,6 +99,9 @@ export function RunsList({ runs, lang }: RunsListProps) {
             </th>
             <th className="px-3 py-2 text-right font-normal">
               {lang === "vi" ? "Thời lượng" : "Duration"}
+            </th>
+            <th className="px-3 py-2 font-normal">
+              {lang === "vi" ? "Bar" : "Bar"}
             </th>
             <th className="px-3 py-2 text-right font-normal">
               {lang === "vi" ? "Lấy về" : "Fetched"}
@@ -140,6 +157,20 @@ export function RunsList({ runs, lang }: RunsListProps) {
                 </td>
                 <td className="px-3 py-2 text-right font-mono tabular-nums text-foreground">
                   {formatDuration(r.started_at, r.finished_at)}
+                </td>
+                <td className="px-3 py-2">
+                  {(() => {
+                    const sec = formatDurationSec(r.started_at, r.finished_at);
+                    if (!sec) return "—";
+                    const pct = Math.max((sec / maxDuration) * 100, 4);
+                    return (
+                      <div
+                        className="h-2 rounded-sm bg-accent/80"
+                        style={{ width: `${pct}%`, maxWidth: "4rem" }}
+                        title={`${sec}s`}
+                      />
+                    );
+                  })()}
                 </td>
                 <td className="px-3 py-2 text-right font-mono tabular-nums text-foreground">
                   <div>{r.items_fetched ?? 0}</div>

--- a/apps/news/src/lib/clerk-auth-fn.ts
+++ b/apps/news/src/lib/clerk-auth-fn.ts
@@ -1,0 +1,50 @@
+import { getRequestHeader } from "@tanstack/react-start/server";
+import type { ClerkPayload } from "../../worker/admin/clerk.js";
+import type { Env } from "../../worker/types.js";
+
+function bearerToken(): string | null {
+  const authHeader = getRequestHeader("Authorization") ?? "";
+  const match = authHeader.match(/^Bearer (.+)$/);
+  return match?.[1] ?? null;
+}
+
+function displayName(payload: ClerkPayload): string {
+  if (typeof payload.name === "string" && payload.name.trim()) {
+    return payload.name.trim();
+  }
+  const first =
+    typeof payload.first_name === "string"
+      ? payload.first_name
+      : typeof payload.given_name === "string"
+        ? payload.given_name
+        : "";
+  const last =
+    typeof payload.last_name === "string"
+      ? payload.last_name
+      : typeof payload.family_name === "string"
+        ? payload.family_name
+        : "";
+  const combined = [first, last].filter(Boolean).join(" ");
+  if (combined) return combined;
+  if (typeof payload.username === "string" && payload.username.trim()) {
+    return payload.username.trim();
+  }
+  return payload.sub;
+}
+
+/** Verifies the caller's Clerk session JWT from Authorization: Bearer.
+ * Derives user_id/user_name server-side — never trust client-supplied values. */
+export async function requireClerkUser(): Promise<{
+  userId: string;
+  userName: string;
+}> {
+  const token = bearerToken();
+  if (!token) throw new Error("Sign in required");
+
+  const { env } = await import("cloudflare:workers");
+  const { verifyClerkToken } = await import("../../worker/admin/clerk.js");
+  const payload = await verifyClerkToken(token, env as Env);
+  if (!payload) throw new Error("Sign in required");
+
+  return { userId: payload.sub, userName: displayName(payload) };
+}

--- a/apps/news/src/lib/lang.test.ts
+++ b/apps/news/src/lib/lang.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { timeAgo } from "./lang";
+
+describe("timeAgo", () => {
+  const now = 1_700_000_000_000;
+
+  it("formats seconds input", () => {
+    expect(timeAgo(now / 1000 - 90, now, "en")).toBe("1m ago");
+    expect(timeAgo(now / 1000 - 7200, now, "en")).toBe("2h ago");
+    expect(timeAgo(now / 1000 - 86400 * 3, now, "en")).toBe("3d ago");
+  });
+
+  it("normalizes millisecond epoch input", () => {
+    const secAgo = now / 1000 - 120;
+    expect(timeAgo(secAgo * 1000, now, "en")).toBe("2m ago");
+  });
+
+  it("formats Vietnamese branches", () => {
+    expect(timeAgo(now / 1000 - 1800, now, "vi")).toBe("30 phút trước");
+    expect(timeAgo(now / 1000 - 7200, now, "vi")).toBe("2 giờ trước");
+    expect(timeAgo(now / 1000 - 86400, now, "vi")).toBe("1 ngày trước");
+  });
+});

--- a/apps/news/src/lib/lang.ts
+++ b/apps/news/src/lib/lang.ts
@@ -28,7 +28,10 @@ export function timeAgo(
   now = Date.now(),
   lang: Lang = "en"
 ): string {
-  const diff = Math.max(0, Math.floor(now / 1000) - epochSec);
+  const normalizeTs = (v: number) =>
+    v > 1e12 ? Math.floor(v / 1000) : Math.floor(v);
+  const started = normalizeTs(epochSec);
+  const diff = Math.max(0, Math.floor(now / 1000) - started);
   if (lang === "vi") {
     if (diff < 3600) return `${Math.max(1, Math.floor(diff / 60))} phút trước`;
     if (diff < 86400) return `${Math.floor(diff / 3600)} giờ trước`;

--- a/apps/news/src/lib/submit-fn.ts
+++ b/apps/news/src/lib/submit-fn.ts
@@ -1,12 +1,13 @@
 import { createServerFn } from "@tanstack/react-start";
-import { getRequestHeader } from "@tanstack/react-start/server";
+import { getRequest } from "@tanstack/react-start/server";
+import { requireClerkUser } from "./clerk-auth-fn";
 
 export interface SubmissionInput {
   url: string;
   title: string;
   note: string;
-  user_id: string;
-  user_name: string;
+  user_id?: string;
+  user_name?: string;
 }
 
 export interface Submission {
@@ -26,7 +27,11 @@ const TITLE_MAX = 300;
  * worker/D1 constraints the backend enforces. Exported separately so it's
  * unit-testable without touching D1/Cloudflare bindings.
  */
-export function validateSubmission(input: SubmissionInput): {
+export function validateSubmission(input: {
+  url: string;
+  title: string;
+  user_id?: string;
+}): {
   url: string;
   title: string;
 } {
@@ -47,12 +52,10 @@ export function validateSubmission(input: SubmissionInput): {
   return { url: url.toString(), title };
 }
 
-// NOTE: user_id/user_name are trusted as sent by the client for now — there
-// is no server-side Clerk JWT verification yet.
 export const submitStory = createServerFn({ method: "POST" })
   .inputValidator((input: SubmissionInput) => input)
   .handler(async ({ data }) => {
-    if (!data.user_id) throw new Error("Sign in required");
+    const { userId, userName } = await requireClerkUser();
     const { env } = await import("cloudflare:workers");
     const db = (env as { DB?: D1Database }).DB;
     if (!db) throw new Error("D1 binding DB not configured");
@@ -60,27 +63,31 @@ export const submitStory = createServerFn({ method: "POST" })
     const { submitStory: submitStoryToDb } = await import(
       "../../worker/submissions.js"
     );
-    // Passed to the worker layer only to be hashed for per-IP rate
-    // limiting — never stored or logged here.
-    const ip = getRequestHeader("CF-Connecting-IP");
+    const ip = getRequest().cf
+      ? (getRequest().headers.get("CF-Connecting-IP") ?? null)
+      : null;
     const result = await submitStoryToDb(db, {
       url: data.url,
       title: data.title,
       note: data.note,
-      userId: data.user_id,
-      userName: data.user_name,
-      ip,
+      userId,
+      userName,
+      ip: ip ?? undefined,
     });
     if (!result.ok) throw new Error(result.error);
     return { id: result.id };
   });
 
 export const fetchMySubmissions = createServerFn({ method: "GET" })
-  .inputValidator((input: { user_id: string }) => input)
+  .inputValidator((input: { user_id?: string }) => input)
   .handler(async ({ data }): Promise<Submission[]> => {
+    const { userId } = await requireClerkUser();
+    if (data.user_id && data.user_id !== userId) {
+      throw new Error("Sign in required");
+    }
     const { env } = await import("cloudflare:workers");
     const db = (env as { DB?: D1Database }).DB;
-    if (!db || !data.user_id) return [];
+    if (!db) return [];
     try {
       const { results } = await db
         .prepare(
@@ -90,11 +97,10 @@ export const fetchMySubmissions = createServerFn({ method: "GET" })
            ORDER BY created_at DESC
            LIMIT 50`
         )
-        .bind(data.user_id)
+        .bind(userId)
         .all<Submission>();
       return results ?? [];
     } catch {
-      // submissions table may not exist yet (pre-migration)
       return [];
     }
   });

--- a/apps/news/src/lib/suggest-fn.ts
+++ b/apps/news/src/lib/suggest-fn.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
-import { getRequestHeader } from "@tanstack/react-start/server";
+import { getRequest } from "@tanstack/react-start/server";
+import { requireClerkUser } from "./clerk-auth-fn";
 
 export interface SuggestionSummary {
   user_name: string;
@@ -12,21 +13,12 @@ export interface SuggestionInput {
   item_id: string;
   field: "title" | "summary";
   suggestion: string;
-  user_id: string;
-  user_name: string;
+  user_id?: string;
+  user_name?: string;
 }
 
 const MAX_LEN = 2000;
 
-/**
- * Client-side pre-validation only — mirrors worker/suggestions.ts's
- * validateSuggestionText/MAX_SUGGESTION_LENGTH plus the sign-in
- * requirement, so the form can show an error before round-tripping to the
- * server. Kept local (not statically imported from worker/) so this pure
- * check doesn't drag worker-only code into the client bundle; the server
- * fn below dynamically imports worker/suggestions.ts for the real,
- * rate-limited check.
- */
 export function validateSuggestion(input: SuggestionInput): string {
   const suggestion = input.suggestion.trim();
   if (!suggestion) throw new Error("Suggestion cannot be empty");
@@ -41,15 +33,10 @@ export function validateSuggestion(input: SuggestionInput): string {
   return suggestion;
 }
 
-// NOTE: user_id/user_name are trusted as sent by the client for now — there
-// is no server-side Clerk JWT verification yet. Abuse/spoofing is possible
-// until that lands; suggestions are reviewed (LLM + status flag) before
-// their text is shown to anyone but the author, which limits the blast
-// radius in the meantime.
 export const submitSuggestion = createServerFn({ method: "POST" })
   .inputValidator((input: SuggestionInput) => input)
   .handler(async ({ data }) => {
-    if (!data.user_id) throw new Error("Sign in required");
+    const { userId, userName } = await requireClerkUser();
     const { env } = await import("cloudflare:workers");
     const db = (env as { DB?: D1Database }).DB;
     if (!db) throw new Error("D1 binding DB not configured");
@@ -57,16 +44,16 @@ export const submitSuggestion = createServerFn({ method: "POST" })
     const { submitSuggestion: submitSuggestionToDb } = await import(
       "../../worker/suggestions.js"
     );
-    // Passed to the worker layer only to be hashed for per-IP rate
-    // limiting — never stored or logged here.
-    const ip = getRequestHeader("CF-Connecting-IP");
+    const ip = getRequest().cf
+      ? (getRequest().headers.get("CF-Connecting-IP") ?? null)
+      : null;
     const result = await submitSuggestionToDb(db, {
       itemId: data.item_id,
       field: data.field,
       suggestion: data.suggestion,
-      userId: data.user_id,
-      userName: data.user_name,
-      ip,
+      userId,
+      userName,
+      ip: ip ?? undefined,
     });
     if (!result.ok) throw new Error(result.error);
     return { id: result.id };
@@ -79,8 +66,6 @@ export const fetchSuggestions = createServerFn({ method: "GET" })
     const db = (env as { DB?: D1Database }).DB;
     if (!db) return [];
     try {
-      // Only accepted suggestions expose their text — pending/rejected
-      // stay count-only to avoid rendering unreviewed user text to others.
       const { results } = await db
         .prepare(
           `SELECT user_name, status, created_at,
@@ -94,7 +79,6 @@ export const fetchSuggestions = createServerFn({ method: "GET" })
         .all<SuggestionSummary>();
       return results ?? [];
     } catch {
-      // translation_suggestions table may not exist yet (pre-migration)
       return [];
     }
   });

--- a/apps/news/src/lib/system-queries.test.ts
+++ b/apps/news/src/lib/system-queries.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { loadSystemStats } from "./system-queries";
+
+function makeDb(stubs: Record<string, unknown>) {
+  return {
+    prepare(sql: string) {
+      const key = Object.keys(stubs).find((k) => sql.includes(k));
+      const stub = key ? stubs[key] : { first: async () => null, all: async () => ({ results: [] }) };
+      return {
+        bind: (..._args: unknown[]) => stub,
+        first: async () => (stub as { first?: () => Promise<unknown> }).first?.(),
+        all: async () =>
+          (stub as { all?: () => Promise<{ results: unknown[] }> }).all?.() ?? {
+            results: [],
+          },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe("loadSystemStats run timestamp normalization", () => {
+  it("normalizes legacy millisecond workflow_runs timestamps", async () => {
+    const msStarted = 1_700_000_000_000;
+    const db = makeDb({
+      "FROM workflow_runs": {
+        all: async () => ({
+          results: [
+            {
+              id: "run-1",
+              started_at: msStarted,
+              finished_at: msStarted + 60_000,
+              items_fetched: 1,
+              items_new: 1,
+              error: null,
+              stats: null,
+            },
+          ],
+        }),
+      },
+      "SELECT llm_tokens": {
+        all: async () => {
+          throw new Error("no column");
+        },
+      },
+      "FROM llm_calls": {
+        all: async () => {
+          throw new Error("no table");
+        },
+      },
+      "SELECT stats FROM workflow_runs": {
+        all: async () => ({ results: [{ stats: null }] }),
+      },
+    });
+
+    const stats = await loadSystemStats(db, {});
+    expect(stats.runs[0]?.started_at).toBe(Math.floor(msStarted / 1000));
+    expect(stats.runs[0]?.finished_at).toBe(Math.floor((msStarted + 60_000) / 1000));
+  });
+});

--- a/apps/news/src/lib/system-queries.ts
+++ b/apps/news/src/lib/system-queries.ts
@@ -52,6 +52,14 @@ export interface DayCount {
   count: number;
 }
 
+export interface LlmDayTaskCount {
+  date: string;
+  task: string;
+  calls: number;
+  failures: number;
+  tokens: number;
+}
+
 export interface NamedCount {
   name: string;
   count: number;
@@ -80,6 +88,27 @@ export interface SystemStats {
   lastRun: WorkflowRunRow | null;
   latestTldrDate: string | null;
   models: ModelChains;
+  llmCallsPerDay: LlmDayTaskCount[];
+}
+
+/** Legacy workflow_runs rows may store started_at/finished_at in ms. */
+function normalizeTs(v: number | null): number | null {
+  if (v == null) return null;
+  return v > 1e12 ? Math.floor(v / 1000) : v;
+}
+
+function normalizeRunRow(row: Omit<WorkflowRunRow, "stats"> & {
+  stats?: string | null;
+}): WorkflowRunRow {
+  return {
+    id: row.id,
+    started_at: normalizeTs(row.started_at),
+    finished_at: normalizeTs(row.finished_at),
+    items_fetched: row.items_fetched,
+    items_new: row.items_new,
+    error: row.error,
+    stats: parseRunStats(row.stats),
+  };
 }
 
 export interface ModelChains {
@@ -126,6 +155,50 @@ async function supportsLlmTokens(db: D1Database): Promise<boolean> {
   return llmTokensSupported;
 }
 
+let llmCallsSupported: boolean | null = null;
+
+async function supportsLlmCalls(db: D1Database): Promise<boolean> {
+  if (llmCallsSupported !== null) return llmCallsSupported;
+  try {
+    await db.prepare("SELECT ts FROM llm_calls LIMIT 1").all();
+    llmCallsSupported = true;
+  } catch {
+    llmCallsSupported = false;
+  }
+  return llmCallsSupported;
+}
+
+async function loadLlmCallsPerDay(
+  db: D1Database
+): Promise<LlmDayTaskCount[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT date(ts / 1000, 'unixepoch') AS date,
+              task,
+              COUNT(*) AS calls,
+              SUM(CASE WHEN ok = 0 THEN 1 ELSE 0 END) AS failures,
+              SUM(COALESCE(tokens, 0)) AS tokens
+       FROM llm_calls
+       WHERE ts >= (unixepoch('now') - 14 * 86400) * 1000
+       GROUP BY date, task
+       ORDER BY date ASC, task ASC`
+    )
+    .all<{
+      date: string;
+      task: string;
+      calls: number;
+      failures: number;
+      tokens: number | null;
+    }>();
+  return (results ?? []).map((r) => ({
+    date: r.date,
+    task: r.task,
+    calls: r.calls,
+    failures: r.failures,
+    tokens: r.tokens ?? 0,
+  }));
+}
+
 let runStatsSupported: boolean | null = null;
 
 async function supportsRunStats(db: D1Database): Promise<boolean> {
@@ -148,9 +221,10 @@ export async function loadSystemStats(
     ANYROUTER_TLDR_MODEL?: string;
   } = {}
 ): Promise<SystemStats> {
-  const [hasTokens, hasRunStats] = await Promise.all([
+  const [hasTokens, hasRunStats, hasLlmCalls] = await Promise.all([
     supportsLlmTokens(db),
     supportsRunStats(db),
+    supportsLlmCalls(db),
   ]);
 
   const runsQuery = hasRunStats
@@ -242,21 +316,22 @@ export async function loadSystemStats(
     }));
   }
 
-  const runRows: WorkflowRunRow[] = (runs.results ?? []).map((r) => ({
-    id: r.id,
-    started_at: r.started_at,
-    finished_at: r.finished_at,
-    items_fetched: r.items_fetched,
-    items_new: r.items_new,
-    error: r.error,
-    stats: parseRunStats(r.stats),
-  }));
+  const runRows: WorkflowRunRow[] = (runs.results ?? []).map(normalizeRunRow);
   const todayStr = new Date().toISOString().slice(0, 10);
   const runsToday = runRows.filter(
     (r) =>
       r.started_at &&
       new Date(r.started_at * 1000).toISOString().slice(0, 10) === todayStr
   ).length;
+
+  let llmCallsPerDay: LlmDayTaskCount[] = [];
+  if (hasLlmCalls) {
+    try {
+      llmCallsPerDay = await loadLlmCallsPerDay(db);
+    } catch {
+      llmCallsPerDay = [];
+    }
+  }
 
   return {
     totals: {
@@ -281,5 +356,6 @@ export async function loadSystemStats(
     lastRun: runRows[0] ?? null,
     latestTldrDate: latestTldr?.date ?? null,
     models: getModelChains(env),
+    llmCallsPerDay,
   };
 }

--- a/apps/news/src/routeTree.gen.ts
+++ b/apps/news/src/routeTree.gen.ts
@@ -10,14 +10,14 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as SplatRouteImport } from './routes/$'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as ChangelogRouteImport } from './routes/changelog'
+import { Route as DataRouteImport } from './routes/data'
+import { Route as MailRouteImport } from './routes/mail'
 import { Route as McpRouteImport } from './routes/mcp'
 import { Route as SubmitRouteImport } from './routes/submit'
 import { Route as SubscribeRouteImport } from './routes/subscribe'
-import { Route as MailRouteImport } from './routes/mail'
-import { Route as SystemRouteImport } from './routes/system'
-import { Route as SplatRouteImport } from './routes/$'
 import { Route as CatSlugRouteImport } from './routes/$cat.$slug'
 import { Route as ApiFeedRouteImport } from './routes/api/feed'
 import { Route as ApiMcpRouteImport } from './routes/api/mcp'
@@ -31,6 +31,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SplatRoute = SplatRouteImport.update({
+  id: '/$',
+  path: '/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
@@ -39,6 +44,16 @@ const AboutRoute = AboutRouteImport.update({
 const ChangelogRoute = ChangelogRouteImport.update({
   id: '/changelog',
   path: '/changelog',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DataRoute = DataRouteImport.update({
+  id: '/data',
+  path: '/data',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MailRoute = MailRouteImport.update({
+  id: '/mail',
+  path: '/mail',
   getParentRoute: () => rootRouteImport,
 } as any)
 const McpRoute = McpRouteImport.update({
@@ -54,21 +69,6 @@ const SubmitRoute = SubmitRouteImport.update({
 const SubscribeRoute = SubscribeRouteImport.update({
   id: '/subscribe',
   path: '/subscribe',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MailRoute = MailRouteImport.update({
-  id: '/mail',
-  path: '/mail',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SystemRoute = SystemRouteImport.update({
-  id: '/system',
-  path: '/system',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SplatRoute = SplatRouteImport.update({
-  id: '/$',
-  path: '/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CatSlugRoute = CatSlugRouteImport.update({
@@ -109,14 +109,14 @@ const ApiStoryIdRoute = ApiStoryIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/about': typeof AboutRoute
   '/changelog': typeof ChangelogRoute
+  '/data': typeof DataRoute
+  '/mail': typeof MailRoute
   '/mcp': typeof McpRoute
   '/submit': typeof SubmitRoute
   '/subscribe': typeof SubscribeRoute
-  '/mail': typeof MailRoute
-  '/system': typeof SystemRoute
-  '/$': typeof SplatRoute
   '/$cat/$slug': typeof CatSlugRoute
   '/api/feed': typeof ApiFeedRoute
   '/api/mcp': typeof ApiMcpRoute
@@ -127,14 +127,14 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/about': typeof AboutRoute
   '/changelog': typeof ChangelogRoute
+  '/data': typeof DataRoute
+  '/mail': typeof MailRoute
   '/mcp': typeof McpRoute
   '/submit': typeof SubmitRoute
   '/subscribe': typeof SubscribeRoute
-  '/mail': typeof MailRoute
-  '/system': typeof SystemRoute
-  '/$': typeof SplatRoute
   '/$cat/$slug': typeof CatSlugRoute
   '/api/feed': typeof ApiFeedRoute
   '/api/mcp': typeof ApiMcpRoute
@@ -146,14 +146,14 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/about': typeof AboutRoute
   '/changelog': typeof ChangelogRoute
+  '/data': typeof DataRoute
+  '/mail': typeof MailRoute
   '/mcp': typeof McpRoute
   '/submit': typeof SubmitRoute
   '/subscribe': typeof SubscribeRoute
-  '/mail': typeof MailRoute
-  '/system': typeof SystemRoute
-  '/$': typeof SplatRoute
   '/$cat/$slug': typeof CatSlugRoute
   '/api/feed': typeof ApiFeedRoute
   '/api/mcp': typeof ApiMcpRoute
@@ -166,14 +166,14 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/$'
     | '/about'
     | '/changelog'
+    | '/data'
+    | '/mail'
     | '/mcp'
     | '/submit'
     | '/subscribe'
-    | '/mail'
-    | '/system'
-    | '/$'
     | '/$cat/$slug'
     | '/api/feed'
     | '/api/mcp'
@@ -184,14 +184,14 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/$'
     | '/about'
     | '/changelog'
+    | '/data'
+    | '/mail'
     | '/mcp'
     | '/submit'
     | '/subscribe'
-    | '/mail'
-    | '/system'
-    | '/$'
     | '/$cat/$slug'
     | '/api/feed'
     | '/api/mcp'
@@ -202,14 +202,14 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/$'
     | '/about'
     | '/changelog'
+    | '/data'
+    | '/mail'
     | '/mcp'
     | '/submit'
     | '/subscribe'
-    | '/mail'
-    | '/system'
-    | '/$'
     | '/$cat/$slug'
     | '/api/feed'
     | '/api/mcp'
@@ -221,14 +221,14 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SplatRoute: typeof SplatRoute
   AboutRoute: typeof AboutRoute
   ChangelogRoute: typeof ChangelogRoute
+  DataRoute: typeof DataRoute
+  MailRoute: typeof MailRoute
   McpRoute: typeof McpRoute
   SubmitRoute: typeof SubmitRoute
   SubscribeRoute: typeof SubscribeRoute
-  MailRoute: typeof MailRoute
-  SystemRoute: typeof SystemRoute
-  SplatRoute: typeof SplatRoute
   CatSlugRoute: typeof CatSlugRoute
   ApiFeedRoute: typeof ApiFeedRoute
   ApiMcpRoute: typeof ApiMcpRoute
@@ -247,6 +247,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/$': {
+      id: '/$'
+      path: '/$'
+      fullPath: '/$'
+      preLoaderRoute: typeof SplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/about': {
       id: '/about'
       path: '/about'
@@ -259,6 +266,20 @@ declare module '@tanstack/react-router' {
       path: '/changelog'
       fullPath: '/changelog'
       preLoaderRoute: typeof ChangelogRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/data': {
+      id: '/data'
+      path: '/data'
+      fullPath: '/data'
+      preLoaderRoute: typeof DataRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mail': {
+      id: '/mail'
+      path: '/mail'
+      fullPath: '/mail'
+      preLoaderRoute: typeof MailRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/mcp': {
@@ -280,27 +301,6 @@ declare module '@tanstack/react-router' {
       path: '/subscribe'
       fullPath: '/subscribe'
       preLoaderRoute: typeof SubscribeRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mail': {
-      id: '/mail'
-      path: '/mail'
-      fullPath: '/mail'
-      preLoaderRoute: typeof MailRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/system': {
-      id: '/system'
-      path: '/system'
-      fullPath: '/system'
-      preLoaderRoute: typeof SystemRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/$': {
-      id: '/$'
-      path: '/$'
-      fullPath: '/$'
-      preLoaderRoute: typeof SplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$cat/$slug': {
@@ -357,14 +357,14 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SplatRoute: SplatRoute,
   AboutRoute: AboutRoute,
   ChangelogRoute: ChangelogRoute,
+  DataRoute: DataRoute,
+  MailRoute: MailRoute,
   McpRoute: McpRoute,
   SubmitRoute: SubmitRoute,
   SubscribeRoute: SubscribeRoute,
-  MailRoute: MailRoute,
-  SystemRoute: SystemRoute,
-  SplatRoute: SplatRoute,
   CatSlugRoute: CatSlugRoute,
   ApiFeedRoute: ApiFeedRoute,
   ApiMcpRoute: ApiMcpRoute,

--- a/apps/news/src/routes/__root.tsx
+++ b/apps/news/src/routes/__root.tsx
@@ -89,8 +89,8 @@ const FOOTER_LINKS: {
   { to: "/subscribe", label: "Subscribe", icon: Mail },
   { to: "/mcp", label: "MCP", icon: Plug },
   {
-    to: "/system",
-    label: "System",
+    to: "/data",
+    label: "Data",
     icon: BarChart3,
   },
   {

--- a/apps/news/src/routes/about.tsx
+++ b/apps/news/src/routes/about.tsx
@@ -236,10 +236,10 @@ function AboutPage() {
         <p>
           {t("Pipeline stats at", "Thống kê pipeline tại")}{" "}
           <Link
-            to="/system"
+            to="/data"
             className="text-accent underline underline-offset-2 hover:no-underline"
           >
-            /system
+            /data
           </Link>
           {" · "}
           {t("API at", "API tại")}{" "}

--- a/apps/news/src/routes/api/admin.$.ts
+++ b/apps/news/src/routes/api/admin.$.ts
@@ -1,13 +1,21 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { checkAdminAuth, isRequestAdmin } from "../../../worker/admin/auth.js";
+import {
+  checkAdminAuth,
+  checkAdminAuthRateLimit,
+  isRequestAdmin,
+} from "../../../worker/admin/auth.js";
 import {
   deleteSource,
+  decideSubmission,
+  decideSuggestion,
   getLlmCalls,
   getStatus,
   isHandlerError,
   listAudit,
   listNotifications,
   listItems,
+  listPendingSubmissions,
+  listPendingSuggestions,
   listSources,
   pushItems,
   regenerateTldr,
@@ -78,6 +86,8 @@ async function handle(
   // never 401, so unauthenticated callers can use it to detect signed-out
   // state.
   if (method === "GET" && segments.length === 1 && segments[0] === "me") {
+    const rateLimited = await checkAdminAuthRateLimit(request, env);
+    if (rateLimited) return rateLimited;
     const admin = await isRequestAdmin(request, env);
     return Response.json({ admin });
   }
@@ -234,6 +244,70 @@ async function handle(
 
   if (method === "GET" && segments.length === 1 && segments[0] === "audit") {
     return Response.json(await listAudit(env));
+  }
+
+  if (
+    method === "GET" &&
+    segments.length === 1 &&
+    segments[0] === "suggestions"
+  ) {
+    const url = new URL(request.url);
+    return Response.json(
+      await listPendingSuggestions(env, url.searchParams.get("limit"))
+    );
+  }
+
+  if (
+    method === "GET" &&
+    segments.length === 1 &&
+    segments[0] === "submissions"
+  ) {
+    const url = new URL(request.url);
+    return Response.json(
+      await listPendingSubmissions(env, url.searchParams.get("limit"))
+    );
+  }
+
+  if (
+    method === "POST" &&
+    segments.length === 2 &&
+    segments[0] === "suggestions" &&
+    segments[1] === "decide"
+  ) {
+    const { body, error } = await parseJsonBody(request);
+    if (error) return Response.json({ error }, { status: 400 });
+    const result = await decideSuggestion(
+      env,
+      (body ?? {}) as Parameters<typeof decideSuggestion>[1]
+    );
+    if (isHandlerError(result)) {
+      return Response.json(
+        { error: result.error },
+        { status: result.status ?? 400 }
+      );
+    }
+    return Response.json(result);
+  }
+
+  if (
+    method === "POST" &&
+    segments.length === 2 &&
+    segments[0] === "submissions" &&
+    segments[1] === "decide"
+  ) {
+    const { body, error } = await parseJsonBody(request);
+    if (error) return Response.json({ error }, { status: 400 });
+    const result = await decideSubmission(
+      env,
+      (body ?? {}) as Parameters<typeof decideSubmission>[1]
+    );
+    if (isHandlerError(result)) {
+      return Response.json(
+        { error: result.error },
+        { status: result.status ?? 400 }
+      );
+    }
+    return Response.json(result);
   }
 
   if (

--- a/apps/news/src/routes/api/feed.ts
+++ b/apps/news/src/routes/api/feed.ts
@@ -46,10 +46,8 @@ export const Route = createFileRoute("/api/feed")({
             },
           });
         } catch (e) {
-          return Response.json(
-            { error: e instanceof Error ? e.message : "query failed" },
-            { status: 500 }
-          );
+          console.error("feed:", e);
+          return Response.json({ error: "query failed" }, { status: 500 });
         }
       },
     },

--- a/apps/news/src/routes/api/story.$id.ts
+++ b/apps/news/src/routes/api/story.$id.ts
@@ -43,10 +43,8 @@ export const Route = createFileRoute("/api/story/$id")({
             },
           });
         } catch (e) {
-          return Response.json(
-            { error: e instanceof Error ? e.message : "query failed" },
-            { status: 500 }
-          );
+          console.error("story.$id:", e);
+          return Response.json({ error: "query failed" }, { status: 500 });
         }
       },
     },

--- a/apps/news/src/routes/api/subscribe.ts
+++ b/apps/news/src/routes/api/subscribe.ts
@@ -21,7 +21,8 @@ async function resolveEnv(context: any): Promise<Env | undefined> {
 }
 
 function clientIp(request: Request): string | null {
-  return request.headers.get("CF-Connecting-IP");
+  const cf = (request as Request & { cf?: unknown }).cf;
+  return cf ? request.headers.get("CF-Connecting-IP") : null;
 }
 
 function isOneClickBody(request: Request, raw: string): boolean {

--- a/apps/news/src/routes/api/system.ts
+++ b/apps/news/src/routes/api/system.ts
@@ -32,10 +32,8 @@ export const Route = createFileRoute("/api/system")({
             },
           });
         } catch (e) {
-          return Response.json(
-            { error: e instanceof Error ? e.message : "query failed" },
-            { status: 500 }
-          );
+          console.error("system:", e);
+          return Response.json({ error: "query failed" }, { status: 500 });
         }
       },
     },

--- a/apps/news/src/routes/data.tsx
+++ b/apps/news/src/routes/data.tsx
@@ -13,13 +13,15 @@ import { RunDurationBars } from "../components/system/RunDurationBars";
 import { RunOutcomeBars } from "../components/system/RunOutcomeBars";
 import { RunsList } from "../components/system/RunsList";
 import { RunStatusStrip } from "../components/system/RunStatusStrip";
+import { LlmSection } from "../components/system/LlmSection";
+import { RankingExplainer } from "../components/system/RankingExplainer";
 import { StatTile } from "../components/system/StatTile";
 import { useAdmin } from "../lib/admin";
 import { categoryLabel, statusLabel } from "../lib/lang";
 import type { SystemStats } from "../lib/system-queries";
 import type { Lang } from "../lib/types";
 
-export const Route = createFileRoute("/system")({
+export const Route = createFileRoute("/data")({
   component: SystemPage,
 });
 
@@ -78,7 +80,7 @@ function SystemPage() {
     <div className="news-content py-6">
       <header className="mb-6">
         <h1 className="text-lg font-semibold text-foreground">
-          {t("System status", "Trạng thái hệ thống")}
+          {t("Pipeline data", "Dữ liệu pipeline")}
         </h1>
         <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
           {t(
@@ -209,6 +211,20 @@ function SystemPage() {
             emptyLabel={t("No token data yet.", "Chưa có dữ liệu token.")}
             formatValue={formatTokens}
           />
+        </ChartCard>
+
+        <ChartCard
+          title="LLM calls"
+          subtitle="Calls, failures, and token burn by task (14 days)"
+        >
+          <LlmSection data={stats.llmCallsPerDay} formatTokens={formatTokens} />
+        </ChartCard>
+
+        <ChartCard
+          title="Ranking"
+          subtitle="How stories are scored for the feed"
+        >
+          <RankingExplainer models={stats.models} />
         </ChartCard>
 
         <ChartCard

--- a/apps/news/src/routes/submit.tsx
+++ b/apps/news/src/routes/submit.tsx
@@ -31,25 +31,37 @@ function statusLabel(status: Submission["status"], lang: "en" | "vi") {
 function SubmissionsList({
   userId,
   lang,
+  getToken,
 }: {
   userId: string;
   lang: "en" | "vi";
+  getToken: () => Promise<string | null>;
 }) {
   const [items, setItems] = useState<Submission[] | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetchMySubmissions({ data: { user_id: userId } })
-      .then((res) => {
-        if (!cancelled) setItems(res);
-      })
-      .catch(() => {
+    (async () => {
+      const token = await getToken();
+      if (!token) {
         if (!cancelled) setItems([]);
-      });
+        return;
+      }
+      fetchMySubmissions({
+        data: { user_id: userId },
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => {
+          if (!cancelled) setItems(res);
+        })
+        .catch(() => {
+          if (!cancelled) setItems([]);
+        });
+    })();
     return () => {
       cancelled = true;
     };
-  }, [userId]);
+  }, [userId, getToken]);
 
   if (!items || items.length === 0) return null;
 
@@ -89,9 +101,11 @@ function SubmissionsList({
 function SubmitForm({
   userId,
   userName,
+  getToken,
 }: {
   userId: string;
   userName: string;
+  getToken: () => Promise<string | null>;
 }) {
   const lang = useLang();
   const [url, setUrl] = useState("");
@@ -136,8 +150,11 @@ function SubmitForm({
         setStatus("sending");
         setError(null);
         try {
+          const token = await getToken();
+          if (!token) throw new Error("Sign in required");
           await submitStory({
             data: { url, title, note, user_id: userId, user_name: userName },
+            headers: { Authorization: `Bearer ${token}` },
           });
           setStatus("sent");
         } catch (err) {
@@ -208,13 +225,20 @@ function SubmitForm({
         {lang === "vi" ? "Gửi bài" : "Submit"}
       </button>
       {error && <p className="text-sm text-red-600">{error}</p>}
-      <SubmissionsList userId={userId} lang={lang} />
+      <SubmissionsList userId={userId} lang={lang} getToken={getToken} />
     </form>
   );
 }
 
-function SubmitGate({ useUser }: { useUser: any }) {
+function SubmitGate({
+  useUser,
+  useAuth,
+}: {
+  useUser: any;
+  useAuth: any;
+}) {
   const { user } = useUser();
+  const { getToken } = useAuth();
   const lang = useLang();
   if (!user) {
     return (
@@ -224,7 +248,9 @@ function SubmitGate({ useUser }: { useUser: any }) {
     );
   }
   const userName = user.fullName ?? user.username ?? "user";
-  return <SubmitForm userId={user.id} userName={userName} />;
+  return (
+    <SubmitForm userId={user.id} userName={userName} getToken={getToken} />
+  );
 }
 
 function SubmitPage() {
@@ -286,7 +312,7 @@ function SubmitPage() {
                 </ErrorBoundary>
               </mod.SignedOut>
               <mod.SignedIn>
-                <SubmitGate useUser={mod.useUser} />
+                <SubmitGate useUser={mod.useUser} useAuth={mod.useAuth} />
               </mod.SignedIn>
             </>
           )}

--- a/apps/news/worker/__tests__/admin-rate-limit.test.ts
+++ b/apps/news/worker/__tests__/admin-rate-limit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkAdminAuth,
+  checkAdminAuthRateLimit,
+} from "../admin/auth.js";
+import type { Env } from "../types.js";
+
+function makeRateLimitDb(count: number) {
+  const inserts: unknown[][] = [];
+  return {
+    db: {
+      prepare(sql: string) {
+        return {
+          bind: (...args: unknown[]) => ({
+            first: async () =>
+              sql.includes("COUNT(*)") ? { count } : null,
+            run: async () => {
+              if (sql.includes("INSERT INTO subscribe_attempts")) {
+                inserts.push(args);
+              }
+              return { meta: { changes: 1 } };
+            },
+          }),
+        };
+      },
+    } as unknown as D1Database,
+    inserts,
+  };
+}
+
+describe("checkAdminAuth rate limit", () => {
+  it("returns 429 when failure budget is exhausted", async () => {
+    const { db } = makeRateLimitDb(10);
+    const env = { DB: db, NEWS_ADMIN_TOKEN: "secret" } as Env;
+    const req = new Request("https://news.duyet.net/api/admin/items", {
+      headers: {
+        Authorization: "Bearer wrong",
+        "CF-Connecting-IP": "203.0.113.1",
+      },
+    });
+    const limited = await checkAdminAuthRateLimit(req, env);
+    expect(limited?.status).toBe(429);
+  });
+
+  it("records failed auth attempts", async () => {
+    const { db, inserts } = makeRateLimitDb(0);
+    const env = { DB: db, NEWS_ADMIN_TOKEN: "secret" } as Env;
+    const req = new Request("https://news.duyet.net/api/admin/items", {
+      headers: {
+        Authorization: "Bearer wrong",
+        "CF-Connecting-IP": "203.0.113.1",
+      },
+    });
+    const res = await checkAdminAuth(req, env);
+    expect(res?.status).toBe(401);
+    expect(inserts.length).toBe(1);
+  });
+});

--- a/apps/news/worker/__tests__/concurrency.test.ts
+++ b/apps/news/worker/__tests__/concurrency.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { mapWithConcurrency } from "../concurrency.js";
+
+describe("mapWithConcurrency", () => {
+  it("preserves order", async () => {
+    const out = await mapWithConcurrency([1, 2, 3, 4], 2, async (n) => n * 2);
+    expect(out).toEqual([2, 4, 6, 8]);
+  });
+
+  it("propagates errors", async () => {
+    await expect(
+      mapWithConcurrency([1, 2], 2, async (n) => {
+        if (n === 2) throw new Error("boom");
+        return n;
+      })
+    ).rejects.toThrow("boom");
+  });
+
+  it("handles empty input", async () => {
+    expect(await mapWithConcurrency([], 3, async (n) => n)).toEqual([]);
+  });
+});

--- a/apps/news/worker/__tests__/enrich-hostname.test.ts
+++ b/apps/news/worker/__tests__/enrich-hostname.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { isFetchableUrl } from "../enrich.js";
+
+describe("isFetchableUrl", () => {
+  it.each([
+    ["https://example.com/article", true],
+    ["http://news.ycombinator.com/item", true],
+    ["http://localhost/admin", false],
+    ["http://127.0.0.1/", false],
+    ["http://10.0.0.1/", false],
+    ["http://192.168.1.1/", false],
+    ["http://172.16.0.1/", false],
+    ["http://169.254.169.254/", false],
+    ["http://foo.internal/", false],
+    ["http://host.local/", false],
+    ["ftp://example.com/", false],
+    ["not-a-url", false],
+  ])("%s -> %s", (url, expected) => {
+    expect(isFetchableUrl(url)).toBe(expected);
+  });
+
+  it("blocks fetch for disallowed URLs", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { fetchOgData } = await import("../enrich.js");
+    await fetchOgData("http://127.0.0.1/secret");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/apps/news/worker/__tests__/unsubscribe-token.test.ts
+++ b/apps/news/worker/__tests__/unsubscribe-token.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { deriveUnsubscribeToken } from "../subscribe/handlers.js";
+import type { Env } from "../types.js";
+
+describe("deriveUnsubscribeToken", () => {
+  it("uses deterministic HMAC when secret is configured", async () => {
+    const env = { NEWS_UNSUBSCRIBE_SECRET: "test-secret" } as Env;
+    const a = await deriveUnsubscribeToken(env, "User@Example.com");
+    const b = await deriveUnsubscribeToken(env, "user@example.com");
+    const c = await deriveUnsubscribeToken(
+      { NEWS_UNSUBSCRIBE_SECRET: "other" } as Env,
+      "user@example.com"
+    );
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("falls back to UUID when secret is unset", async () => {
+    const env = {} as Env;
+    const a = await deriveUnsubscribeToken(env, "a@b.com");
+    const b = await deriveUnsubscribeToken(env, "a@b.com");
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/news/worker/admin/auth.ts
+++ b/apps/news/worker/admin/auth.ts
@@ -1,5 +1,60 @@
+import {
+  checkRateLimit,
+  hashIp,
+  ONE_DAY_SEC,
+} from "../rate-limit.js";
 import type { Env } from "../types.js";
 import { isClerkAdmin, verifyClerkToken } from "./clerk.js";
+
+/** Per-IP failed admin auth attempts before 429. Tunable if shared NAT bites. */
+const ADMIN_FAIL_LIMIT = 10;
+
+async function adminFailKey(request: Request): Promise<string> {
+  const ip = request.headers.get("CF-Connecting-IP") ?? "unknown";
+  return `admin-fail:${await hashIp(ip)}`;
+}
+
+/** Returns a 429 Response when the IP has exceeded failed auth attempts,
+ * or null to proceed. Only applies when a bearer token is present. */
+export async function checkAdminAuthRateLimit(
+  request: Request,
+  env: Env
+): Promise<Response | null> {
+  if (!bearerToken(request)) return null;
+  try {
+    const key = await adminFailKey(request);
+    const blocked = await checkRateLimit(env.DB, {
+      table: "subscribe_attempts",
+      column: "ip_hash",
+      key,
+      windowSec: ONE_DAY_SEC,
+      limit: ADMIN_FAIL_LIMIT,
+    });
+    if (blocked) {
+      return Response.json({ error: "too many attempts" }, { status: 429 });
+    }
+  } catch {
+    // subscribe_attempts table may be absent in test stubs
+  }
+  return null;
+}
+
+async function recordAdminAuthFailure(
+  request: Request,
+  env: Env
+): Promise<void> {
+  if (!bearerToken(request)) return;
+  const key = await adminFailKey(request);
+  try {
+    await env.DB.prepare(
+      "INSERT INTO subscribe_attempts (ip_hash, created_at) VALUES (?, ?)"
+    )
+      .bind(key, Date.now())
+      .run();
+  } catch {
+    // subscribe_attempts table may not exist yet
+  }
+}
 
 /**
  * Constant-time byte comparison. Consumes both operands up to the max of
@@ -89,6 +144,9 @@ export async function checkAdminAuth(
   request: Request,
   env: Env
 ): Promise<Response | null> {
+  const rateLimited = await checkAdminAuthRateLimit(request, env);
+  if (rateLimited) return rateLimited;
   if (await isRequestAdmin(request, env)) return null;
+  await recordAdminAuthFailure(request, env);
   return Response.json({ error: "unauthorized" }, { status: 401 });
 }

--- a/apps/news/worker/admin/handlers.ts
+++ b/apps/news/worker/admin/handlers.ts
@@ -653,3 +653,81 @@ export async function regenerateTldr(env: Env): Promise<TldrRegenerateResult> {
   );
   return result;
 }
+
+export async function listPendingSuggestions(
+  env: Env,
+  limitParam?: string | null
+) {
+  const limit = Math.min(
+    Math.max(Number.parseInt(limitParam ?? "50", 10) || 50, 1),
+    100
+  );
+  const { results } = await env.DB.prepare(
+    `SELECT id, item_id, field, suggestion, user_name, rating, created_at, status
+     FROM translation_suggestions
+     WHERE status = 'pending'
+     ORDER BY created_at ASC
+     LIMIT ${limit}`
+  ).all();
+  return { suggestions: results ?? [] };
+}
+
+export async function listPendingSubmissions(
+  env: Env,
+  limitParam?: string | null
+) {
+  const limit = Math.min(
+    Math.max(Number.parseInt(limitParam ?? "50", 10) || 50, 1),
+    100
+  );
+  const { results } = await env.DB.prepare(
+    `SELECT id, url, title, note, user_name, rating, created_at, status
+     FROM submissions
+     WHERE status = 'pending'
+     ORDER BY created_at ASC
+     LIMIT ${limit}`
+  ).all();
+  return { submissions: results ?? [] };
+}
+
+export async function decideSuggestion(
+  env: Env,
+  body: { id?: string; action?: string }
+): Promise<{ ok: true } | HandlerError> {
+  const id = body.id;
+  const action = body.action;
+  if (!id || (action !== "approve" && action !== "reject")) {
+    return { error: "id and action (approve|reject) required", status: 400 };
+  }
+  const { approveSuggestionById, rejectSuggestionById } = await import(
+    "../suggestions.js"
+  );
+  const result =
+    action === "approve"
+      ? await approveSuggestionById(env, id)
+      : await rejectSuggestionById(env, id);
+  if (!result.ok) return { error: result.error, status: 404 };
+  await writeAudit(env, `suggestions.${action}`, id);
+  return { ok: true };
+}
+
+export async function decideSubmission(
+  env: Env,
+  body: { id?: string; action?: string }
+): Promise<{ ok: true } | HandlerError> {
+  const id = body.id;
+  const action = body.action;
+  if (!id || (action !== "approve" && action !== "reject")) {
+    return { error: "id and action (approve|reject) required", status: 400 };
+  }
+  const { acceptSubmissionById, rejectSubmissionById } = await import(
+    "../submissions.js"
+  );
+  const result =
+    action === "approve"
+      ? await acceptSubmissionById(env, id)
+      : await rejectSubmissionById(env, id);
+  if (!result.ok) return { error: result.error, status: 404 };
+  await writeAudit(env, `submissions.${action}`, id);
+  return { ok: true };
+}

--- a/apps/news/worker/concurrency.ts
+++ b/apps/news/worker/concurrency.ts
@@ -1,0 +1,23 @@
+/** Runs `fn` over `items` with at most `n` concurrent executions,
+ * preserving result order. */
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const width = Math.max(1, Math.min(n, items.length));
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (true) {
+      const i = nextIndex++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  }
+
+  await Promise.all(Array.from({ length: width }, () => worker()));
+  return results;
+}

--- a/apps/news/worker/enrich.ts
+++ b/apps/news/worker/enrich.ts
@@ -66,6 +66,33 @@ function isAbsoluteHttpUrl(url: string): boolean {
   }
 }
 
+/** Hostname-only SSRF guard before server-side fetches. No DNS resolution
+ * in Workers — blocks obvious private/link-local targets by name. */
+export function isFetchableUrl(raw: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return false;
+  const h = u.hostname.toLowerCase();
+  if (
+    h === "localhost" ||
+    h.endsWith(".localhost") ||
+    h.endsWith(".internal") ||
+    h.endsWith(".local")
+  ) {
+    return false;
+  }
+  if (/^(10|127)\./.test(h)) return false;
+  if (/^192\.168\./.test(h)) return false;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return false;
+  if (/^169\.254\./.test(h)) return false;
+  if (/^(::1|fc00:|fd[0-9a-f]{2}:|fe80:)/i.test(h)) return false;
+  return true;
+}
+
 /** Matches a <meta> tag's `content` regardless of whether `content` comes
  * before or after the property/name attribute, single- or double-quoted. */
 function extractMetaContent(
@@ -147,6 +174,14 @@ async function readCappedText(
  * responses are read. Any failure (network, non-2xx, wrong content type)
  * resolves to `{}`, never throws. */
 export async function fetchOgData(url: string): Promise<OgData> {
+  if (!isFetchableUrl(url)) {
+    try {
+      console.warn("enrich: blocked url", new URL(url).hostname);
+    } catch {
+      console.warn("enrich: blocked url", url);
+    }
+    return {};
+  }
   try {
     const res = await fetch(url, {
       signal: AbortSignal.timeout(ENRICH_FETCH_TIMEOUT_MS),

--- a/apps/news/worker/llm.ts
+++ b/apps/news/worker/llm.ts
@@ -1,5 +1,6 @@
 import { looksVietnamese } from "./tldr-lang.js";
 import type { Env } from "./types.js";
+import { mapWithConcurrency } from "./concurrency.js";
 
 const BATCH_SIZE = 15;
 /** 15-item translate JSON + VI_STYLE routinely times out native Gemma 4
@@ -640,10 +641,14 @@ export async function scoreItems(
   env: Env,
   items: ScoreInput[]
 ): Promise<ScoreResult[]> {
-  const results: ScoreResult[] = [];
-
-  for (const batch of chunk(items, BATCH_SIZE)) {
-    const prompt = `You are scoring AI/tech news items for relevance and importance.
+  const batches = chunk(items, BATCH_SIZE);
+  // Token spend unchanged; wall-clock divided (~3× at SCORE_CONCURRENCY).
+  const SCORE_CONCURRENCY = 3;
+  const batchResults = await mapWithConcurrency(
+    batches,
+    SCORE_CONCURRENCY,
+    async (batch) => {
+      const prompt = `You are scoring AI/tech news items for relevance and importance.
 For each item, return relevance (0-1, is this genuinely AI/tech news), importance (0-10), quality (0-10, writing/source quality), category (one of: ${CATEGORIES.join(", ")}), and tags — 3 to 6 topic labels per item.
 
 Topic label rules (this feeds a dynamic topic taxonomy, so consistency matters):
@@ -662,24 +667,26 @@ ${JSON.stringify(batch.map(({ i, title, summary, source }) => ({ i, title, summa
 
 Respond with strict JSON only: {"results":[{"i":0,"relevance":0.9,"importance":7,"quality":8,"category":"Models","tags":["anthropic","claude","multi-agent","open-source"]}]}`;
 
-    try {
-      const { content: raw, tokens } = await callAnyrouter(
-        env,
-        [{ role: "user", content: prompt }],
-        { json: true, task: "score" }
-      );
-      const parsed = parseJson<{ results?: unknown } | unknown[]>(raw);
-      // Some small models return the bare array instead of {results: [...]}.
-      const rows = Array.isArray(parsed) ? parsed : parsed.results;
-      results.push(
-        ...sanitizeScoreResults(rows, batch, Math.ceil(tokens / batch.length))
-      );
-    } catch (error) {
-      console.error("scoreItems batch failed:", error);
+      try {
+        const { content: raw, tokens } = await callAnyrouter(
+          env,
+          [{ role: "user", content: prompt }],
+          { json: true, task: "score" }
+        );
+        const parsed = parseJson<{ results?: unknown } | unknown[]>(raw);
+        const rows = Array.isArray(parsed) ? parsed : parsed.results;
+        return sanitizeScoreResults(
+          rows,
+          batch,
+          Math.ceil(tokens / batch.length)
+        );
+      } catch (error) {
+        console.error("scoreItems batch failed:", error);
+        return [];
+      }
     }
-  }
-
-  return results;
+  );
+  return batchResults.flat();
 }
 
 export interface TranslateInput {
@@ -832,8 +839,6 @@ export async function translateItems(
     }
   }
 
-  const translated = new Set(results.map((row) => row.i));
-
   const runBatch = async (
     batch: TranslateInput[],
     titlesOnly: boolean
@@ -857,12 +862,15 @@ export async function translateItems(
     }
   };
 
-  for (const batch of chunk(needLlm, TRANSLATE_BATCH_SIZE)) {
+  const processBatch = async (
+    batch: TranslateInput[]
+  ): Promise<TranslateResult[]> => {
     if (deadline - Date.now() <= 0) {
       logTranslateBatchFailed("translate deadline exhausted", batch, false);
-      break;
+      return [];
     }
 
+    const batchResults: TranslateResult[] = [];
     let got = await runBatch(batch, false);
     const hasSummary = batch.some((item) => Boolean(item.summary));
     if (got.length < batch.length && hasSummary) {
@@ -872,18 +880,28 @@ export async function translateItems(
         got = [...got, ...(await runBatch(leftover, true))];
       }
     }
-    results.push(...got);
-    for (const row of got) translated.add(row.i);
+    batchResults.push(...got);
 
-    // One poisoned item in a 3-row batch used to leave every title_vi null
-    // (EN badge) until backfill. Retry leftovers one at a time.
-    const stillMissing = batch.filter((item) => !translated.has(item.i));
+    const batchTranslated = new Set(got.map((row) => row.i));
+    const stillMissing = batch.filter((item) => !batchTranslated.has(item.i));
     for (const item of stillMissing) {
       if (deadline - Date.now() <= 0) break;
       const one = await runBatch([item], true);
-      results.push(...one);
-      for (const row of one) translated.add(row.i);
+      batchResults.push(...one);
     }
+    return batchResults;
+  };
+
+  // Token spend unchanged; wall-clock divided (~3× at TRANSLATE_CONCURRENCY).
+  const TRANSLATE_CONCURRENCY = 3;
+  const batches = chunk(needLlm, TRANSLATE_BATCH_SIZE);
+  const parallelResults = await mapWithConcurrency(
+    batches,
+    TRANSLATE_CONCURRENCY,
+    processBatch
+  );
+  for (const batchOut of parallelResults) {
+    results.push(...batchOut);
   }
 
   return results;

--- a/apps/news/worker/submissions.ts
+++ b/apps/news/worker/submissions.ts
@@ -313,4 +313,60 @@ export async function reviewPendingSubmissions(
   return { reviewed, tokens };
 }
 
+export async function acceptSubmissionById(
+  env: Env,
+  id: string
+): Promise<{ ok: true; itemId: string } | { ok: false; error: string }> {
+  const submission = await env.DB.prepare(
+    "SELECT id, url, title, note FROM submissions WHERE id = ? AND status = 'pending'"
+  )
+    .bind(nn(id))
+    .first<PendingSubmissionRow>();
+  if (!submission) return { ok: false, error: "not found or not pending" };
+
+  const og = await fetchOgData(submission.url);
+  const itemId = await sha256Hex(submission.url);
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO items (id, source_id, external_id, url, title, summary, published_at, fetched_at, image_url)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO NOTHING`
+  )
+    .bind(
+      nn(itemId),
+      nn("user"),
+      nn(submission.id),
+      nn(submission.url),
+      nn(submission.title),
+      nn(og.description),
+      nn(toEpochSeconds(now)),
+      nn(toEpochSeconds(now)),
+      nn(og.imageUrl)
+    )
+    .run();
+
+  await env.DB.prepare(
+    "UPDATE submissions SET status = 'accepted', rating = ?, review_note = ?, item_id = ? WHERE id = ?"
+  )
+    .bind(nn(1), nn("human approved"), nn(itemId), nn(submission.id))
+    .run();
+  return { ok: true, itemId };
+}
+
+export async function rejectSubmissionById(
+  env: Env,
+  id: string,
+  note = "human rejected"
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const result = await env.DB.prepare(
+    "UPDATE submissions SET status = 'rejected', review_note = ? WHERE id = ? AND status = 'pending'"
+  )
+    .bind(nn(note), nn(id))
+    .run();
+  if ((result.meta?.changes ?? 0) === 0) {
+    return { ok: false, error: "not found or not pending" };
+  }
+  return { ok: true };
+}
+
 export { buildSubmissionReviewPrompt as _buildSubmissionReviewPromptForTests };

--- a/apps/news/worker/subscribe/handlers.ts
+++ b/apps/news/worker/subscribe/handlers.ts
@@ -44,6 +44,39 @@ export const SUBSCRIBE_SOURCES = ["blog", "news", "home"] as const;
 export type SubscribeSource = (typeof SUBSCRIBE_SOURCES)[number];
 const SUBSCRIBE_IP_LIMIT = 8;
 
+async function hmacUnsubscribeToken(
+  email: string,
+  secret: string
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(email.toLowerCase())
+  );
+  return [...new Uint8Array(mac)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** HMAC(email, secret) when configured; legacy UUID otherwise. Pre-existing
+ * rows keep their stored token until the subscriber re-subscribes. */
+export async function deriveUnsubscribeToken(
+  env: Env,
+  email: string
+): Promise<string> {
+  if (env.NEWS_UNSUBSCRIBE_SECRET) {
+    return hmacUnsubscribeToken(email, env.NEWS_UNSUBSCRIBE_SECRET);
+  }
+  return crypto.randomUUID();
+}
+
 export function normalizeSource(source: unknown): SubscribeSource {
   return SUBSCRIBE_SOURCES.includes(source as SubscribeSource)
     ? (source as SubscribeSource)
@@ -69,7 +102,7 @@ export async function subscribe(
     ? timezone
     : DEFAULT_TIMEZONE;
   const normalizedSource = normalizeSource(source);
-  const token = crypto.randomUUID();
+  const token = await deriveUnsubscribeToken(env, email);
   const now = Date.now();
 
   await ensureMailSchema(env.DB);
@@ -92,6 +125,8 @@ export async function subscribe(
     )
       .bind(ipHash, now)
       .run();
+  } else {
+    console.warn("subscribe: no cf context; skipping rate limit");
   }
 
   await env.DB.prepare(

--- a/apps/news/worker/suggestions.ts
+++ b/apps/news/worker/suggestions.ts
@@ -416,4 +416,88 @@ export async function reviewPendingSuggestions(
   return { reviewed, tokens };
 }
 
+export async function approveSuggestionById(
+  env: Env,
+  id: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const row = await env.DB.prepare(
+    `SELECT id, item_id, field, suggestion FROM translation_suggestions
+     WHERE id = ? AND status = 'pending'`
+  )
+    .bind(nn(id))
+    .first<PendingSuggestionRow>();
+  if (!row) return { ok: false, error: "not found or not pending" };
+
+  const item = await env.DB.prepare(
+    "SELECT title, summary FROM items WHERE id = ?"
+  )
+    .bind(row.item_id)
+    .first<ItemSourceRow>();
+  if (!item) return { ok: false, error: "item not found" };
+
+  const translation = await env.DB.prepare(
+    "SELECT title, summary FROM translations WHERE item_id = ? AND lang = 'vi'"
+  )
+    .bind(row.item_id)
+    .first<TranslationRow>();
+
+  const sourceText = row.field === "title" ? item.title : (item.summary ?? "");
+  const currentForField =
+    row.field === "title"
+      ? (translation?.title ?? null)
+      : (translation?.summary ?? null);
+  const { translation: retranslated } = await retranslateFieldWithGuidance(env, {
+    field: row.field,
+    sourceText,
+    currentTranslation: currentForField,
+    suggestion: row.suggestion,
+  });
+
+  if (!retranslated) {
+    await env.DB.prepare(
+      "UPDATE translation_suggestions SET status = 'rejected', rating = ?, review_note = ? WHERE id = ?"
+    )
+      .bind(nn(1), nn("human approved but re-translation failed"), nn(id))
+      .run();
+    return { ok: false, error: "re-translation failed" };
+  }
+
+  let currentTitle = translation?.title ?? null;
+  let currentSummary = translation?.summary ?? null;
+  if (row.field === "title") currentTitle = retranslated;
+  else currentSummary = retranslated;
+
+  await env.DB.prepare(
+    `INSERT INTO translations (item_id, lang, title, summary)
+     VALUES (?, 'vi', ?, ?)
+     ON CONFLICT(item_id, lang) DO UPDATE SET
+       title = excluded.title, summary = excluded.summary`
+  )
+    .bind(nn(row.item_id), nn(currentTitle), nn(currentSummary))
+    .run();
+
+  await env.DB.prepare(
+    "UPDATE translation_suggestions SET status = 'accepted', rating = ?, review_note = ? WHERE id = ?"
+  )
+    .bind(nn(1), nn("human approved"), nn(id))
+    .run();
+  return { ok: true };
+}
+
+export async function rejectSuggestionById(
+  env: Env,
+  id: string,
+  note = "human rejected"
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const result = await env.DB.prepare(
+    "UPDATE translation_suggestions SET status = 'rejected', review_note = ? WHERE id = ? AND status = 'pending'"
+  )
+    .bind(nn(note), nn(id))
+    .run();
+  if ((result.meta?.changes ?? 0) === 0) {
+    return { ok: false, error: "not found or not pending" };
+  }
+  return { ok: true };
+}
+
 export { buildReviewPrompt as _buildReviewPromptForTests };

--- a/apps/news/worker/types.ts
+++ b/apps/news/worker/types.ts
@@ -35,4 +35,6 @@ export interface Env {
   /** Cloudflare Email Sending binding. Optional: absent until Email Sending
    *  is onboarded for the account, so all use sites must guard for it. */
   EMAIL?: SendEmail;
+  /** HMAC secret for unsubscribe tokens. When unset, legacy UUID tokens are used. */
+  NEWS_UNSUBSCRIBE_SECRET?: string;
 }

--- a/apps/news/worker/workflow.ts
+++ b/apps/news/worker/workflow.ts
@@ -102,7 +102,7 @@ interface ItemRow {
 
 export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
   async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
-    const startedAt = Date.now();
+    const startedAt = toEpochSeconds(Date.now());
     const runId = crypto.randomUUID();
     let itemsFetched = 0;
     let itemsNew = 0;
@@ -149,20 +149,30 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
       const sinceEpochSec = Math.floor(Date.now() / 1000) - SINCE_WINDOW_SEC;
       const fetchedBySource: { source: SourceRow; items: FetchedItem[] }[] = [];
 
-      for (const source of sources) {
-        const items = await step.do<FetchedItem[]>(
-          `fetch-${source.id}`,
-          { retries: { limit: 3, delay: 10_000, backoff: "exponential" } },
-          async () => {
-            const adapter = adapters[source.type];
-            if (!adapter) return [];
-            const config = JSON.parse(source.config || "{}");
-            return adapter.fetchItems(config, sinceEpochSec);
-          }
+      const SOURCE_FETCH_GROUP = 4;
+      for (let gi = 0; gi < sources.length; gi += SOURCE_FETCH_GROUP) {
+        const group = sources.slice(gi, gi + SOURCE_FETCH_GROUP);
+        const groupResults = await Promise.all(
+          group.map((source) =>
+            step.do<FetchedItem[]>(
+              `fetch-${source.id}`,
+              { retries: { limit: 3, delay: 10_000, backoff: "exponential" } },
+              async () => {
+                const adapter = adapters[source.type];
+                if (!adapter) return [];
+                const config = JSON.parse(source.config || "{}");
+                return adapter.fetchItems(config, sinceEpochSec);
+              }
+            )
+          )
         );
-        fetchedBySource.push({ source, items });
-        itemsFetched += items.length;
-        bySource[source.id] = (bySource[source.id] ?? 0) + items.length;
+        for (let j = 0; j < group.length; j++) {
+          const source = group[j];
+          const items = groupResults[j];
+          fetchedBySource.push({ source, items });
+          itemsFetched += items.length;
+          bySource[source.id] = (bySource[source.id] ?? 0) + items.length;
+        }
       }
       recordStep(
         steps,
@@ -171,31 +181,41 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
       );
 
       let newRows = await step.do("dedupe", async () => {
-        const rows: {
+        const candidates: {
           id: string;
           source: SourceRow;
           item: FetchedItem;
         }[] = [];
 
         for (const { source, items } of fetchedBySource) {
-          for (const item of items) {
-            const id = await sha256Hex(item.url);
-            const existing = await this.env.DB.prepare(
-              "SELECT id FROM items WHERE id = ?"
-            )
-              .bind(id)
-              .first();
-            if (existing) continue;
-            // Normalize once here: adapters may emit ms (e.g. hn.ts
-            // converts Algolia's seconds back to ms) or already-seconds
-            // timestamps; every downstream consumer treats this as seconds.
-            const normalizedItem: FetchedItem = {
-              ...item,
-              publishedAt: toEpochSeconds(item.publishedAt),
-            };
-            rows.push({ id, source, item: normalizedItem });
-          }
+          const hashed = await Promise.all(
+            items.map(async (item) => ({
+              id: await sha256Hex(item.url),
+              source,
+              item: {
+                ...item,
+                publishedAt: toEpochSeconds(item.publishedAt),
+              },
+            }))
+          );
+          candidates.push(...hashed);
         }
+
+        const existingIds = new Set<string>();
+        const DEDUPE_IN_CHUNK = 50;
+        for (let i = 0; i < candidates.length; i += DEDUPE_IN_CHUNK) {
+          const chunk = candidates.slice(i, i + DEDUPE_IN_CHUNK);
+          if (chunk.length === 0) continue;
+          const placeholders = chunk.map(() => "?").join(",");
+          const { results } = await this.env.DB.prepare(
+            `SELECT id FROM items WHERE id IN (${placeholders})`
+          )
+            .bind(...chunk.map((c) => c.id))
+            .all<{ id: string }>();
+          for (const row of results ?? []) existingIds.add(row.id);
+        }
+
+        const rows = candidates.filter((c) => !existingIds.has(c.id));
 
         // Rows inserted directly with status='new' (e.g. an accepted user
         // submission, or an admin push) never came through a source's
@@ -1181,7 +1201,7 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
           .bind(
             nn(runId),
             nn(startedAt),
-            nn(Date.now()),
+            nn(toEpochSeconds(Date.now())),
             nn(itemsFetched),
             nn(itemsNew),
             nn(runError),

--- a/packages/components/site-header/apps.ts
+++ b/packages/components/site-header/apps.ts
@@ -322,9 +322,9 @@ export const GLOBAL_NAV: GlobalNavItem[] = [
     onlyApp: "news",
   },
   {
-    label: "Analytics",
-    href: "/system",
-    match: { app: "news", path: "/system" },
+    label: "Data",
+    href: "/data",
+    match: { app: "news", path: "/data" },
     onlyApp: "news",
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes a batch of open news security, UX, and throughput issues in one focused PR.

### Fixes

- Fixes #1373 — `/data` page: epoch-second workflow run timestamps (writer + legacy reader compat), route rename from `/system`, LLM calls chart, ranking explainer, RunsList duration bars
- Fixes #1374 — Per-IP admin auth failure rate limit (429 after 10/day); generic `{ error: "query failed" }` on public GET routes
- Fixes #1379 — HMAC-derived unsubscribe tokens when `NEWS_UNSUBSCRIBE_SECRET` is set (UUID fallback preserved); subscribe IP trust gated on Cloudflare `request.cf`
- Fixes #1380 — `isFetchableUrl` hostname screen before enrich fetches
- Fixes #1383 — Admin moderation queue API + AdminPanel tab for pending suggestions/submissions
- Fixes #1388 — Batch dedupe IN queries, 3-wide score/translate concurrency, parallel source fetches (groups of 4)
- Fixes #1356 — Clerk JWT verification for submit/suggest server functions; client sends `Authorization: Bearer`

### Notes

- `/api/system` endpoint unchanged (only page route renamed to `/data`).
- Legacy unsubscribe rows keep stored UUID tokens until re-subscribe.
- Set `NEWS_UNSUBSCRIBE_SECRET` via wrangler secret when ready to roll out HMAC tokens.

### Verification

- `cd apps/news && pnpm run check-types` — pass
- `cd apps/news && pnpm test` — 606 tests pass
- `cd apps/news && pnpm run build` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2effc7fa-3bea-400b-aca3-588028029447?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2effc7fa-3bea-400b-aca3-588028029447&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Harden the news application’s APIs and ingestion pipeline while improving data visibility and moderation workflows.

New Features:
- Add a data dashboard with LLM usage metrics, ranking explanations, and workflow duration visualizations.
- Add admin moderation queue APIs and UI controls for reviewing pending suggestions and submissions.

Bug Fixes:
- Harden public and administrative APIs by standardizing error responses, rate-limiting failed admin authentication, validating server-side user identity with Clerk, and restricting server-side URL fetching.
- Improve unsubscribe token security and only trust subscription IP metadata in Cloudflare requests.
- Normalize workflow timestamps across current and legacy data formats.

Enhancements:
- Increase news pipeline throughput through batched deduplication and bounded concurrency for source fetching, scoring, and translation.
- Rename the analytics page and navigation from /system to /data while preserving the /api/system endpoint.

Tests:
- Add coverage for authentication throttling, concurrency behavior, URL safety, unsubscribe token derivation, timestamp normalization, and localized time formatting.