### PR TITLE
fix(api): guard duyet-api memory hotspots; document #1370 binding gap

### DIFF
--- a/apps/api/src/routes/ai-percentage.test.ts
+++ b/apps/api/src/routes/ai-percentage.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../env.js";
 import {
   buildClickHouseRequest,
+  clampHistoryDays,
   executeClickHouseQuery,
   getClickHouseConfig,
 } from "./ai-percentage.js";
@@ -38,6 +39,15 @@ describe("ClickHouse request builder", () => {
   it("returns null when ClickHouse is not configured", () => {
     expect(getClickHouseConfig({})).toBeNull();
     expect(buildClickHouseRequest({}, "SELECT 1")).toBeNull();
+  });
+});
+
+describe("clampHistoryDays", () => {
+  it("defaults invalid values to 365 and caps large requests", () => {
+    expect(clampHistoryDays(NaN)).toBe(365);
+    expect(clampHistoryDays(0)).toBe(365);
+    expect(clampHistoryDays(365)).toBe(365);
+    expect(clampHistoryDays(9999)).toBe(730);
   });
 });
 

--- a/apps/api/src/routes/ai-percentage.ts
+++ b/apps/api/src/routes/ai-percentage.ts
@@ -9,6 +9,8 @@ import type { Env } from "../env.js";
 
 const aiPercentageRouter = new Hono<{ Bindings: Env }>();
 const FETCH_TIMEOUT_MS = 10_000;
+const MAX_HISTORY_DAYS = 730;
+const MAX_CLICKHOUSE_RESPONSE_BYTES = 1_048_576;
 
 export interface ClickHouseRequestConfig {
   headers: Record<string, string>;
@@ -91,8 +93,21 @@ export async function executeClickHouseQuery(
   }
 
   const text = await response.text();
+  if (text.length > MAX_CLICKHOUSE_RESPONSE_BYTES) {
+    throw new Error(
+      `[REDACTED] response exceeded ${MAX_CLICKHOUSE_RESPONSE_BYTES} bytes`
+    );
+  }
+
   const lines = text.trim().split("\n").filter(Boolean);
   return lines.map((line) => JSON.parse(line));
+}
+
+export function clampHistoryDays(rawDays: number): number {
+  if (!Number.isFinite(rawDays) || rawDays <= 0) {
+    return 365;
+  }
+  return Math.min(Math.floor(rawDays), MAX_HISTORY_DAYS);
 }
 
 /**
@@ -184,7 +199,7 @@ aiPercentageRouter.get("/history", async (c) => {
     return c.json({ error: "ClickHouse not configured" }, 500);
   }
 
-  const days = Number(c.req.query("days") || "365");
+  const days = clampHistoryDays(Number(c.req.query("days") || "365"));
   const dateCondition = getDateCondition(days);
 
   try {

--- a/apps/api/src/routes/insights.ts
+++ b/apps/api/src/routes/insights.ts
@@ -3,6 +3,10 @@ import type { Env } from "../env.js";
 
 const insightsRouter = new Hono<{ Bindings: Env }>();
 const FETCH_TIMEOUT_MS = 10_000;
+/** Reject oversized [REDACTED] bodies before materializing in JS (OOM guard). */
+const MAX_CLICKHOUSE_RESPONSE_BYTES = 1_048_576;
+/** Monthly trend only needs ~12 buckets; all_time can return thousands of days. */
+const WAKA_TREND_RANGE = "last_year";
 const FALLBACK_CORS_ORIGIN = "https://insights.duyet.net";
 
 interface TrafficGroup {
@@ -102,6 +106,13 @@ async function queryClickHouse(
     }
 
     const text = await response.text();
+    if (text.length > MAX_CLICKHOUSE_RESPONSE_BYTES) {
+      console.warn(
+        `[REDACTED] insights response exceeded ${MAX_CLICKHOUSE_RESPONSE_BYTES} bytes`
+      );
+      return [];
+    }
+
     const results: Record<string, unknown>[] = [];
 
     for (const line of text.trim().split("\n").filter(Boolean)) {
@@ -257,7 +268,7 @@ async function getWakaOverview(env: Env) {
 
 async function getWakaMonthlyTrend(auth: string) {
   const response = await fetch(
-    "https://wakatime.com/api/v1/users/current/insights/days/all_time",
+    `https://wakatime.com/api/v1/users/current/insights/days/${WAKA_TREND_RANGE}`,
     {
       headers: { Authorization: auth },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## #1369 — exceededMemory burst (2026-08-23 16:00Z)

**Hypothesis:** `/api/insights/overview` was the likely trigger. The handler fans out parallel upstream fetches; the WakaTime monthly trend called `insights/days/all_time`, which can return thousands of daily rows and materialize the full JSON in worker memory. Concurrent overview requests during that hour could explain 11 `exceededMemory` events without a steady recurrence.

**Changes:**
- WakaTime trend: `all_time` → `last_year` (monthly chart only needs ~12 buckets).
- ClickHouse: reject JSONEachRow bodies larger than 1MB before `split`/`JSON.parse` in insights and ai-percentage routes.
- AI percentage history: clamp `days` query param to 730 (invalid/zero → 365).

Deployed worker bundle confirmed the `all_time` URL was live on `duyet-api` at investigation time.

Fixes #1369

## #1370 — AE/R2 bindings on hub and mcp

Investigated on `master` and all remote branches:

- No `wrangler.jsonc` at repo root (hub `duyet`) and no `apps/mcp/` tree in `duyet/monorepo`.
- No `analytics_engine_datasets`, `removed while AE/R2 disabled`, or `signup-attribution` strings anywhere in git history.
- `apps/api` uses `wrangler.toml` with no AE/R2 bindings; deployed `duyet-api` code does not reference `ANALYTICS`, `ARCHIVE`, or `BODIES` bindings.
- Production MCP is `duyet-mcp-server` (separate repo `duyet/duyet-mcp-server`), which tracks usage via ClickHouse HTTP—not Analytics Engine datasets.

No monorepo-side binding restoration is possible without first landing the hub/mcp worker trees the issue describes. Left unfixed; see comment on #1370.

## Validation

- `cd apps/api && pnpm run test` (27 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-227df955-2b58-42e6-b6f7-86ba74b65f73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-227df955-2b58-42e6-b6f7-86ba74b65f73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Guard API data-fetching paths against oversized responses and unbounded history queries to reduce memory spikes.

Bug Fixes:
- Reduce API memory usage by limiting WakaTime monthly trends to the last year and rejecting oversized ClickHouse responses before parsing.
- Bound AI percentage history requests to a safe maximum and provide sane defaults for invalid day ranges.

Documentation:
- Document that the requested hub and MCP Analytics Engine/R2 binding restoration cannot be addressed because the referenced worker trees and bindings are absent from this repository.

Tests:
- Add coverage for AI percentage history range validation.