### PR TITLE
feat(news): small thumbnails on homepage AI;DR bullets

### DIFF
--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -20,8 +20,8 @@ for `chrome-extension://` origins. Use this instead:
 {
   "tldr": {
     "date": "2026-08-27",
-    "bullets_en": [{ "text": "...", "item_ids": ["..."] }],
-    "bullets_vi": [{ "text": "...", "item_ids": ["..."] }]
+    "bullets_en": [{ "text": "...", "item_ids": ["..."], "image_url": "https://..." }],
+    "bullets_vi": [{ "text": "...", "item_ids": ["..."], "image_url": "https://..." }]
   },
   "stories": [
     {
@@ -39,7 +39,8 @@ for `chrome-extension://` origins. Use this instead:
 ```
 
 Up to 16 bullets per language and 8 top stories by `rank_score`. Typical
-payload is well under 50KB.
+payload is well under 50KB. `image_url` on a bullet is additive and only
+present when the linked story has an og/thumbnail.
 
 Hourly ingest is triggered by GitHub Actions
 (`.github/workflows/news-ingest.yml`, cron `5 * * * *`) via

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -40,7 +40,8 @@ for `chrome-extension://` origins. Use this instead:
 
 Up to 16 bullets per language and 8 top stories by `rank_score`. Typical
 payload is well under 50KB. `image_url` on a bullet is additive and only
-present when the linked story has an og/thumbnail.
+present when the linked story has an og/thumbnail. `published_at` is epoch
+**seconds**; `updatedAt` is epoch milliseconds.
 
 Hourly ingest is triggered by GitHub Actions
 (`.github/workflows/news-ingest.yml`, cron `5 * * * *`) via

--- a/apps/news/src/components/StoryThumb.tsx
+++ b/apps/news/src/components/StoryThumb.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type ReactElement, useState } from "react";
 
 /** Branded site mark — used when a story has no og/thumbnail, or the
  * remote image fails. Same asset as the favicon so it never 404s. */
@@ -15,9 +15,9 @@ export function StoryThumb({
 }: {
   src?: string | null;
   alt?: string;
-}) {
-  const [failed, setFailed] = useState(false);
-  const remote = src && !failed ? src : null;
+}): ReactElement {
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+  const remote = src && src !== failedSrc ? src : null;
   const showSrc = remote ?? STORY_THUMB_PLACEHOLDER;
 
   return (
@@ -31,7 +31,7 @@ export function StoryThumb({
       aria-hidden={alt ? undefined : true}
       onError={(event) => {
         if (remote) {
-          setFailed(true);
+          setFailedSrc(remote);
           return;
         }
         event.currentTarget.style.visibility = "hidden";

--- a/apps/news/src/components/StoryThumb.tsx
+++ b/apps/news/src/components/StoryThumb.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+
+/** Branded site mark — used when a story has no og/thumbnail, or the
+ * remote image fails. Same asset as the favicon so it never 404s. */
+export const STORY_THUMB_PLACEHOLDER = "/favicon.svg";
+
+/**
+ * Compact story thumbnail matching the feed card language: rounded,
+ * bordered, object-cover. Stays 40px on the phone and 48px from `sm`
+ * up — never a hero image.
+ */
+export function StoryThumb({
+  src,
+  alt = "",
+}: {
+  src?: string | null;
+  alt?: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const remote = src && !failed ? src : null;
+  const showSrc = remote ?? STORY_THUMB_PLACEHOLDER;
+
+  return (
+    <img
+      src={showSrc}
+      alt={alt}
+      width={48}
+      height={48}
+      loading="lazy"
+      decoding="async"
+      aria-hidden={alt ? undefined : true}
+      onError={(event) => {
+        if (remote) {
+          setFailed(true);
+          return;
+        }
+        event.currentTarget.style.visibility = "hidden";
+      }}
+      className="h-10 w-10 shrink-0 overflow-hidden rounded-md border border-border bg-brand-soft object-cover sm:h-12 sm:w-12"
+    />
+  );
+}

--- a/apps/news/src/components/TldrSection.tsx
+++ b/apps/news/src/components/TldrSection.tsx
@@ -5,6 +5,7 @@ import { type TldrCount, usePrefs } from "../lib/prefs";
 import { topicColor } from "../lib/topic-color";
 import type { Lang, TldrBullet } from "../lib/types";
 import { StoryDialog } from "./StoryDialog";
+import { StoryThumb } from "./StoryThumb";
 
 export function TldrSection({
   bullets,
@@ -14,6 +15,7 @@ export function TldrSection({
   updatedAt,
   lastFetchedAt,
   topicByItemId,
+  imageByItemId,
   snapshotDate,
 }: {
   bullets: TldrBullet[];
@@ -23,6 +25,8 @@ export function TldrSection({
   updatedAt: number;
   lastFetchedAt: number | null;
   topicByItemId?: Map<string, string>;
+  /** Fallback when a bullet has no read-time `image_url` (cached feeds). */
+  imageByItemId?: Map<string, string>;
   snapshotDate?: string;
 }) {
   const [openBullet, setOpenBullet] = useState<{
@@ -50,15 +54,19 @@ export function TldrSection({
   }
 
   const selectedOption =
-    options.find((o) => o.nominal === defaultCount) ?? options[options.length - 1];
-  const effectiveDefault = selectedOption ? selectedOption.effective : bullets.length;
+    options.find((o) => o.nominal === defaultCount) ??
+    options[options.length - 1];
+  const effectiveDefault = selectedOption
+    ? selectedOption.effective
+    : bullets.length;
 
   const shown = bullets.slice(0, effectiveDefault);
   const mid = Math.ceil(shown.length / 2);
   const cols = [shown.slice(0, mid), shown.slice(mid)];
 
   const selectedIndex = selectedOption ? options.indexOf(selectedOption) : -1;
-  const nextOption = selectedIndex >= 0 ? options[selectedIndex + 1] : undefined;
+  const nextOption =
+    selectedIndex >= 0 ? options[selectedIndex + 1] : undefined;
   const canCollapse = selectedIndex > 0;
 
   return (
@@ -99,15 +107,19 @@ export function TldrSection({
           <ol
             key={col[0]?.text ?? ci}
             start={ci * mid + 1}
-            className="list-decimal space-y-1.5 pl-6 leading-snug marker:text-muted-foreground"
+            className="list-decimal space-y-2 pl-6 leading-snug marker:text-muted-foreground"
           >
             {col.map((b) => {
               const primaryId = b.item_ids?.[0];
               const otherIds = (b.item_ids ?? []).slice(1);
               const tag = primaryId ? topicByItemId?.get(primaryId) : undefined;
               const color = tag ? topicColor(tag) : null;
-              return (
-                <li key={b.text}>
+              const thumbSrc =
+                b.image_url ??
+                (primaryId ? imageByItemId?.get(primaryId) : undefined) ??
+                null;
+              const text = (
+                <>
                   {color && tag && (
                     <span
                       className="topic-colored mr-1.5 text-xs font-semibold uppercase tracking-wide"
@@ -135,7 +147,10 @@ export function TldrSection({
                           return;
                         }
                         e.preventDefault();
-                        setOpenBullet({ itemId: primaryId, relatedIds: otherIds });
+                        setOpenBullet({
+                          itemId: primaryId,
+                          relatedIds: otherIds,
+                        });
                       }}
                       className="underline decoration-border underline-offset-2 hover:decoration-accent"
                     >
@@ -149,6 +164,14 @@ export function TldrSection({
                       +{otherIds.length}
                     </span>
                   )}
+                </>
+              );
+              return (
+                <li key={b.text}>
+                  <span className="flex items-start gap-2">
+                    <StoryThumb src={thumbSrc} />
+                    <span className="min-w-0">{text}</span>
+                  </span>
                 </li>
               );
             })}

--- a/apps/news/src/components/TldrSection.tsx
+++ b/apps/news/src/components/TldrSection.tsx
@@ -1,11 +1,52 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactElement, ReactNode } from "react";
 import { useState } from "react";
+import { type AidrLayout, DEFAULT_AIDR_LAYOUT } from "../lib/aidr-layout";
 import { timeAgo } from "../lib/lang";
 import { type TldrCount, usePrefs } from "../lib/prefs";
 import { topicColor } from "../lib/topic-color";
 import type { Lang, TldrBullet } from "../lib/types";
 import { StoryDialog } from "./StoryDialog";
 import { StoryThumb } from "./StoryThumb";
+
+function TldrBulletRow({
+  layout,
+  n,
+  thumbSrc,
+  children,
+}: {
+  layout: AidrLayout;
+  n: number;
+  thumbSrc: string | null;
+  children: ReactNode;
+}): ReactElement {
+  const copy = <span className="min-w-0 flex-1">{children}</span>;
+  switch (layout) {
+    case "a":
+    case "b":
+      return (
+        <span className="flex items-start gap-2">
+          {copy}
+          <StoryThumb src={thumbSrc} />
+        </span>
+      );
+    case "c":
+      return (
+        <span className="flex items-start gap-2">
+          {copy}
+          <span className="relative shrink-0">
+            <StoryThumb src={thumbSrc} />
+            <span className="absolute bottom-0.5 left-0.5 flex h-4 min-w-4 items-center justify-center rounded-sm bg-foreground/80 px-0.5 text-[10px] font-bold tabular-nums text-background">
+              {n}
+            </span>
+          </span>
+        </span>
+      );
+    default: {
+      const _exhaustive: never = layout;
+      throw new Error(`unhandled AI;DR layout: ${_exhaustive}`);
+    }
+  }
+}
 
 export function TldrSection({
   bullets,
@@ -17,6 +58,8 @@ export function TldrSection({
   topicByItemId,
   imageByItemId,
   snapshotDate,
+  layout = DEFAULT_AIDR_LAYOUT,
+  layoutLabeled = false,
 }: {
   bullets: TldrBullet[];
   defaultCount: number;
@@ -28,7 +71,10 @@ export function TldrSection({
   /** Fallback when a bullet has no read-time `image_url` (cached feeds). */
   imageByItemId?: Map<string, string>;
   snapshotDate?: string;
-}) {
+  layout?: AidrLayout;
+  /** Show a tiny "Layout A/B/C" chip when `?aidr=` is set for QA. */
+  layoutLabeled?: boolean;
+}): ReactElement | null {
   const [openBullet, setOpenBullet] = useState<{
     itemId: string;
     relatedIds: string[];
@@ -68,9 +114,10 @@ export function TldrSection({
   const nextOption =
     selectedIndex >= 0 ? options[selectedIndex + 1] : undefined;
   const canCollapse = selectedIndex > 0;
+  const numbered = layout === "a";
 
   return (
-    <section className="border-y-2 border-brand py-4">
+    <section className="border-y-2 border-brand py-4" data-aidr-layout={layout}>
       <div className="mb-2.5 flex items-baseline justify-between gap-3">
         <div className="flex items-baseline gap-3">
           <h2 className="text-lg font-bold tracking-widest">AI;DR</h2>
@@ -81,6 +128,11 @@ export function TldrSection({
                 ? "24 giờ qua"
                 : "past 24 hours"}
           </span>
+          {layoutLabeled && (
+            <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Layout {layout.toUpperCase()}
+            </span>
+          )}
         </div>
         {options.length > 0 && (
           <div className="flex gap-1 text-xs">
@@ -107,9 +159,14 @@ export function TldrSection({
           <ol
             key={col[0]?.text ?? ci}
             start={ci * mid + 1}
-            className="list-decimal space-y-2 pl-6 leading-snug marker:text-muted-foreground"
+            className={
+              numbered
+                ? "list-decimal space-y-2 pl-6 leading-snug marker:text-muted-foreground"
+                : "list-none space-y-2 pl-0 leading-snug"
+            }
           >
-            {col.map((b) => {
+            {col.map((b, i) => {
+              const n = ci * mid + i + 1;
               const primaryId = b.item_ids?.[0];
               const otherIds = (b.item_ids ?? []).slice(1);
               const tag = primaryId ? topicByItemId?.get(primaryId) : undefined;
@@ -118,60 +175,54 @@ export function TldrSection({
                 b.image_url ??
                 (primaryId ? imageByItemId?.get(primaryId) : undefined) ??
                 null;
-              const text = (
-                <>
-                  {color && tag && (
-                    <span
-                      className="topic-colored mr-1.5 text-xs font-semibold uppercase tracking-wide"
-                      style={
-                        {
-                          "--tc-light": color.light,
-                          "--tc-dark": color.dark,
-                        } as CSSProperties
-                      }
-                    >
-                      {tag}
-                    </span>
-                  )}
-                  {primaryId ? (
-                    <a
-                      href={`/ai/${primaryId}`}
-                      onClick={(e) => {
-                        if (
-                          e.button !== 0 ||
-                          e.metaKey ||
-                          e.ctrlKey ||
-                          e.shiftKey ||
-                          e.altKey
-                        ) {
-                          return;
-                        }
-                        e.preventDefault();
-                        setOpenBullet({
-                          itemId: primaryId,
-                          relatedIds: otherIds,
-                        });
-                      }}
-                      className="underline decoration-border underline-offset-2 hover:decoration-accent"
-                    >
-                      {b.text}
-                    </a>
-                  ) : (
-                    b.text
-                  )}
-                  {otherIds.length > 0 && (
-                    <span className="ml-1 text-[11px] font-semibold text-muted-foreground">
-                      +{otherIds.length}
-                    </span>
-                  )}
-                </>
-              );
               return (
                 <li key={b.text}>
-                  <span className="flex items-start gap-2">
-                    <StoryThumb src={thumbSrc} />
-                    <span className="min-w-0">{text}</span>
-                  </span>
+                  <TldrBulletRow layout={layout} n={n} thumbSrc={thumbSrc}>
+                    {color && tag && (
+                      <span
+                        className="topic-colored mr-1.5 text-xs font-semibold uppercase tracking-wide"
+                        style={
+                          {
+                            "--tc-light": color.light,
+                            "--tc-dark": color.dark,
+                          } as CSSProperties
+                        }
+                      >
+                        {tag}
+                      </span>
+                    )}
+                    {primaryId ? (
+                      <a
+                        href={`/ai/${primaryId}`}
+                        onClick={(e) => {
+                          if (
+                            e.button !== 0 ||
+                            e.metaKey ||
+                            e.ctrlKey ||
+                            e.shiftKey ||
+                            e.altKey
+                          ) {
+                            return;
+                          }
+                          e.preventDefault();
+                          setOpenBullet({
+                            itemId: primaryId,
+                            relatedIds: otherIds,
+                          });
+                        }}
+                        className="underline decoration-border underline-offset-2 hover:decoration-accent"
+                      >
+                        {b.text}
+                      </a>
+                    ) : (
+                      b.text
+                    )}
+                    {otherIds.length > 0 && (
+                      <span className="ml-1 text-[11px] font-semibold text-muted-foreground">
+                        +{otherIds.length}
+                      </span>
+                    )}
+                  </TldrBulletRow>
                 </li>
               );
             })}

--- a/apps/news/src/lib/aidr-layout.test.ts
+++ b/apps/news/src/lib/aidr-layout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_AIDR_LAYOUT, parseAidrLayout } from "./aidr-layout";
+
+describe("parseAidrLayout", () => {
+  it("defaults to A", () => {
+    expect(parseAidrLayout(undefined)).toBe(DEFAULT_AIDR_LAYOUT);
+    expect(parseAidrLayout("")).toBe("a");
+    expect(parseAidrLayout("z")).toBe("a");
+  });
+
+  it("accepts a, b, and c only", () => {
+    expect(parseAidrLayout("a")).toBe("a");
+    expect(parseAidrLayout("b")).toBe("b");
+    expect(parseAidrLayout("c")).toBe("c");
+  });
+});

--- a/apps/news/src/lib/aidr-layout.ts
+++ b/apps/news/src/lib/aidr-layout.ts
@@ -1,0 +1,11 @@
+export const AIDR_LAYOUTS = ["a", "b", "c"] as const;
+export type AidrLayout = (typeof AIDR_LAYOUTS)[number];
+
+/** Homepage default: numbered copy on the left, thumb on the right. */
+export const DEFAULT_AIDR_LAYOUT: AidrLayout = "a";
+
+/** QA-only `?aidr=a|b|c`. Anything else (including missing) is Version A. */
+export function parseAidrLayout(raw: unknown): AidrLayout {
+  if (raw === "b" || raw === "c" || raw === "a") return raw;
+  return DEFAULT_AIDR_LAYOUT;
+}

--- a/apps/news/src/lib/feed-queries.ts
+++ b/apps/news/src/lib/feed-queries.ts
@@ -4,6 +4,7 @@ import {
   resolveTldrForDisplay,
   shouldRebuildTldrForDisplay,
 } from "./tldr-fallback";
+import { imageUrlByItemId, withTldrImages } from "./tldr-images";
 import type { DayGroup, FeedItem, FeedResponse, TldrBullet } from "./types";
 
 /** Older `tldr_snapshots` rows were written with a single `item_id` string
@@ -284,7 +285,7 @@ export async function getFeed(
   }
 
   return {
-    tldr: resolved,
+    tldr: withTldrImages(resolved, imageUrlByItemId(items)),
     days: groupByDay(items),
     categories: catsRes.results ?? [],
     trending,

--- a/apps/news/src/lib/public-queries.test.ts
+++ b/apps/news/src/lib/public-queries.test.ts
@@ -41,7 +41,7 @@ function makeDb(opts: {
   extraImages?: Array<{ id: string; image_url: string | null }>;
   failImageColumn?: boolean;
   throwOnItems?: boolean;
-}) {
+}): D1Database {
   return {
     prepare(sql: string) {
       const stub = {
@@ -94,6 +94,17 @@ describe("normalizeStoredBullets", () => {
     ]);
     const many = Array.from({ length: 20 }, (_, i) => ({ text: `b${i}` }));
     expect(normalizeStoredBullets(many)).toHaveLength(16);
+  });
+
+  it("truncates oversized bullet text and item_ids", () => {
+    const bullets = normalizeStoredBullets([
+      {
+        text: "x".repeat(500),
+        item_ids: Array.from({ length: 20 }, (_, i) => `id${i}`),
+      },
+    ]);
+    expect(bullets[0]?.text).toHaveLength(400);
+    expect(bullets[0]?.item_ids).toHaveLength(8);
   });
 });
 

--- a/apps/news/src/lib/public-queries.test.ts
+++ b/apps/news/src/lib/public-queries.test.ts
@@ -38,6 +38,7 @@ function story(id: string, extra: Partial<StoryRow> = {}): StoryRow {
 function makeDb(opts: {
   tldr?: TldrRow | null;
   stories?: StoryRow[];
+  extraImages?: Array<{ id: string; image_url: string | null }>;
   failImageColumn?: boolean;
   throwOnItems?: boolean;
 }) {
@@ -55,6 +56,9 @@ function makeDb(opts: {
             }
             if (opts.failImageColumn && sql.includes("image_url")) {
               throw new Error("no such column: image_url");
+            }
+            if (sql.includes("id IN")) {
+              return { results: opts.extraImages ?? [] };
             }
             return { results: opts.stories ?? [] };
           }
@@ -111,6 +115,15 @@ describe("getPublicDigest", () => {
     expect(digest.tldr?.date).toBe("2026-08-27");
     expect(digest.tldr?.bullets_vi[0]?.text).toContain("Hugging Face");
     expect(digest.tldr?.bullets_en).toHaveLength(2);
+    expect(digest.tldr?.bullets_en[0]?.image_url).toBe(
+      "https://img.example/a.jpg"
+    );
+    expect(digest.tldr?.bullets_en[1]?.image_url).toBe(
+      "https://img.example/b.jpg"
+    );
+    expect(digest.tldr?.bullets_vi[0]?.image_url).toBe(
+      "https://img.example/a.jpg"
+    );
     expect(digest.stories).toHaveLength(3);
     expect(digest.stories[0]).toEqual({
       id: "a",
@@ -168,6 +181,39 @@ describe("getPublicDigest", () => {
     const digest = await getPublicDigest(db);
     expect(digest.stories[0]?.image_url).toBeNull();
     expect(digest.stories[0]?.id).toBe("a");
+    expect(digest.tldr?.bullets_en[0]).not.toHaveProperty("image_url");
+  });
+
+  it("looks up a bullet image even when the story is outside the top 8", async () => {
+    const db = makeDb({
+      tldr: bilingualTldr,
+      stories: [story("z")],
+      extraImages: [
+        { id: "a", image_url: "https://img.example/a.jpg" },
+        { id: "b", image_url: "https://img.example/b.jpg" },
+      ],
+    });
+    const digest = await getPublicDigest(db);
+    expect(digest.tldr?.bullets_en[0]?.image_url).toBe(
+      "https://img.example/a.jpg"
+    );
+    expect(digest.tldr?.bullets_en[1]?.image_url).toBe(
+      "https://img.example/b.jpg"
+    );
+    expect(digest.stories[0]?.id).toBe("z");
+  });
+
+  it("omits image_url on a bullet when the linked story has none", async () => {
+    const db = makeDb({
+      tldr: bilingualTldr,
+      stories: [
+        story("a", { image_url: null }),
+        story("b", { image_url: null }),
+      ],
+    });
+    const digest = await getPublicDigest(db);
+    expect(digest.tldr?.bullets_en[0]).not.toHaveProperty("image_url");
+    expect(digest.tldr?.bullets_en[1]).not.toHaveProperty("image_url");
   });
 });
 

--- a/apps/news/src/lib/public-queries.ts
+++ b/apps/news/src/lib/public-queries.ts
@@ -1,4 +1,9 @@
 import { isThinDisplayTldr, synthesizeTldrFromItems } from "./tldr-fallback";
+import {
+  collectTldrItemIds,
+  imageUrlByItemId,
+  withTldrImages,
+} from "./tldr-images";
 import type { TldrBullet } from "./types";
 
 /** Top stories on the public digest — keep the payload well under 50KB. */
@@ -54,6 +59,9 @@ LIMIT ?`;
 
 const TLDR_SQL =
   "SELECT date, bullets_en, bullets_vi FROM tldr_snapshots ORDER BY date DESC LIMIT 1";
+
+const IMAGES_SQL = `SELECT id, image_url FROM items
+WHERE id IN ({placeholders}) AND image_url IS NOT NULL AND image_url != ''`;
 
 function capBullets(raw: TldrBullet[]): TldrBullet[] {
   return raw.slice(0, PUBLIC_BULLET_CAP).map((b) => ({
@@ -154,9 +162,37 @@ export async function getPublicDigest(db: D1Database): Promise<PublicDigest> {
     stories
   );
 
+  const images = imageUrlByItemId(stories);
+  const missing = collectTldrItemIds(tldr).filter((id) => !images.has(id));
+  if (missing.length > 0) {
+    for (const [id, url] of await loadImagesForIds(db, missing)) {
+      images.set(id, url);
+    }
+  }
+
   return {
-    tldr,
+    tldr: withTldrImages(tldr, images),
     stories,
     updatedAt: Date.now(),
   };
+}
+
+/** Look up og/thumbnails for TL;DR item ids that are not in the top-8
+ * stories payload. Best-effort: a missing `image_url` column returns
+ * an empty map so the digest still ships. */
+async function loadImagesForIds(
+  db: D1Database,
+  ids: string[]
+): Promise<Map<string, string>> {
+  if (ids.length === 0) return new Map();
+  const placeholders = ids.map(() => "?").join(",");
+  try {
+    const { results } = await db
+      .prepare(IMAGES_SQL.replace("{placeholders}", placeholders))
+      .bind(...ids)
+      .all<{ id: string; image_url: string }>();
+    return imageUrlByItemId(results ?? []);
+  } catch {
+    return new Map();
+  }
 }

--- a/apps/news/src/lib/public-queries.ts
+++ b/apps/news/src/lib/public-queries.ts
@@ -10,6 +10,13 @@ import type { TldrBullet } from "./types";
 export const PUBLIC_STORY_LIMIT = 8;
 /** Snapshots store at most 16; cap again so a bloated row cannot balloon. */
 export const PUBLIC_BULLET_CAP = 16;
+const PUBLIC_BULLET_TEXT_MAX = 400;
+const PUBLIC_ITEM_IDS_MAX = 8;
+const PUBLIC_STORY_TEXT_MAX = 400;
+
+function clip(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max);
+}
 
 export interface PublicStory {
   id: string;
@@ -65,10 +72,14 @@ WHERE id IN ({placeholders}) AND image_url IS NOT NULL AND image_url != ''`;
 
 function capBullets(raw: TldrBullet[]): TldrBullet[] {
   return raw.slice(0, PUBLIC_BULLET_CAP).map((b) => ({
-    text: typeof b.text === "string" ? b.text : "",
-    item_ids: Array.isArray(b.item_ids)
+    text: clip(
+      typeof b.text === "string" ? b.text : "",
+      PUBLIC_BULLET_TEXT_MAX
+    ),
+    item_ids: (Array.isArray(b.item_ids)
       ? b.item_ids.filter((id): id is string => typeof id === "string")
-      : [],
+      : []
+    ).slice(0, PUBLIC_ITEM_IDS_MAX),
   }));
 }
 
@@ -108,12 +119,14 @@ function parseTldrRow(
 
 function toPublicStory(row: StoryRow): PublicStory {
   return {
-    id: row.id,
-    url: row.url,
-    title: row.title,
-    title_vi: row.title_vi ?? null,
-    category: row.category ?? null,
-    image_url: row.image_url ?? null,
+    id: clip(row.id, 128),
+    url: clip(row.url, PUBLIC_STORY_TEXT_MAX),
+    title: clip(row.title, PUBLIC_STORY_TEXT_MAX),
+    title_vi: row.title_vi ? clip(row.title_vi, PUBLIC_STORY_TEXT_MAX) : null,
+    category: row.category ? clip(row.category, 64) : null,
+    image_url: row.image_url
+      ? clip(row.image_url, PUBLIC_STORY_TEXT_MAX)
+      : null,
     published_at: row.published_at,
   };
 }

--- a/apps/news/src/lib/tldr-images.test.ts
+++ b/apps/news/src/lib/tldr-images.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  attachTldrBulletImages,
+  collectTldrItemIds,
+  imageUrlByItemId,
+  withTldrImages,
+} from "./tldr-images";
+
+describe("imageUrlByItemId", () => {
+  it("keeps only non-empty image URLs", () => {
+    const map = imageUrlByItemId([
+      { id: "a", image_url: "https://img.example/a.jpg" },
+      { id: "b", image_url: null },
+      { id: "c", image_url: "" },
+      { id: "d" },
+    ]);
+    expect([...map.entries()]).toEqual([["a", "https://img.example/a.jpg"]]);
+  });
+});
+
+describe("collectTldrItemIds", () => {
+  it("unions item_ids from both languages without duplicates", () => {
+    expect(
+      collectTldrItemIds({
+        bullets_en: [
+          { text: "A", item_ids: ["a"] },
+          { text: "B", item_ids: ["b", "c"] },
+        ],
+        bullets_vi: [{ text: "A vi", item_ids: ["a"] }, { text: "orphan" }],
+      }).sort()
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty for a missing snapshot", () => {
+    expect(collectTldrItemIds(null)).toEqual([]);
+  });
+});
+
+describe("attachTldrBulletImages", () => {
+  const images = new Map([
+    ["a", "https://img.example/a.jpg"],
+    ["c", "https://img.example/c.jpg"],
+  ]);
+
+  it("copies the first linked story image and leaves others unchanged", () => {
+    expect(
+      attachTldrBulletImages(
+        [
+          { text: "Has image", item_ids: ["a"] },
+          { text: "No image", item_ids: ["b"] },
+          { text: "Cluster", item_ids: ["b", "c"] },
+          {
+            text: "Already set",
+            item_ids: ["a"],
+            image_url: "https://keep.me/x.png",
+          },
+          { text: "No ids" },
+        ],
+        images
+      )
+    ).toEqual([
+      {
+        text: "Has image",
+        item_ids: ["a"],
+        image_url: "https://img.example/a.jpg",
+      },
+      { text: "No image", item_ids: ["b"] },
+      {
+        text: "Cluster",
+        item_ids: ["b", "c"],
+        image_url: "https://img.example/c.jpg",
+      },
+      {
+        text: "Already set",
+        item_ids: ["a"],
+        image_url: "https://keep.me/x.png",
+      },
+      { text: "No ids" },
+    ]);
+  });
+});
+
+describe("withTldrImages", () => {
+  it("attaches images on both languages without mutating the input", () => {
+    const tldr = {
+      date: "2026-08-27",
+      bullets_en: [{ text: "EN", item_ids: ["a"] }],
+      bullets_vi: [{ text: "VI", item_ids: ["a"] }],
+    };
+    const out = withTldrImages(
+      tldr,
+      new Map([["a", "https://img.example/a.jpg"]])
+    );
+    expect(out?.bullets_en[0]?.image_url).toBe("https://img.example/a.jpg");
+    expect(out?.bullets_vi[0]?.image_url).toBe("https://img.example/a.jpg");
+    expect(tldr.bullets_en[0]).not.toHaveProperty("image_url");
+  });
+
+  it("passes null through", () => {
+    expect(withTldrImages(null, new Map())).toBeNull();
+  });
+});

--- a/apps/news/src/lib/tldr-images.ts
+++ b/apps/news/src/lib/tldr-images.ts
@@ -1,0 +1,62 @@
+import type { TldrBullet } from "./types";
+
+/** Build id → story image for attaching to AI;DR bullets at read time. */
+export function imageUrlByItemId(
+  items: Array<{ id: string; image_url?: string | null }>
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const item of items) {
+    if (item.id && item.image_url) map.set(item.id, item.image_url);
+  }
+  return map;
+}
+
+/** Every story id cited by either language's bullets. */
+export function collectTldrItemIds(
+  tldr: { bullets_en: TldrBullet[]; bullets_vi: TldrBullet[] } | null
+): string[] {
+  if (!tldr) return [];
+  const ids = new Set<string>();
+  for (const bullet of [...tldr.bullets_en, ...tldr.bullets_vi]) {
+    for (const id of bullet.item_ids ?? []) {
+      if (id) ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
+/** Additive `image_url` from the first linked story that has one.
+ * Omits the field when none of the cited stories have an image so the
+ * stored snapshot shape (`text` + `item_ids`) stays unchanged. */
+export function attachTldrBulletImages(
+  bullets: TldrBullet[],
+  imageByItemId: Map<string, string>
+): TldrBullet[] {
+  return bullets.map((bullet) => {
+    if (bullet.image_url) return bullet;
+    for (const id of bullet.item_ids ?? []) {
+      const url = imageByItemId.get(id);
+      if (url) return { ...bullet, image_url: url };
+    }
+    return bullet;
+  });
+}
+
+export function withTldrImages<
+  T extends { bullets_en: TldrBullet[]; bullets_vi: TldrBullet[] },
+>(
+  tldr: T | null,
+  imageByItemId: Map<string, string>
+):
+  | (Omit<T, "bullets_en" | "bullets_vi"> & {
+      bullets_en: TldrBullet[];
+      bullets_vi: TldrBullet[];
+    })
+  | null {
+  if (!tldr) return tldr;
+  return {
+    ...tldr,
+    bullets_en: attachTldrBulletImages(tldr.bullets_en, imageByItemId),
+    bullets_vi: attachTldrBulletImages(tldr.bullets_vi, imageByItemId),
+  };
+}

--- a/apps/news/src/lib/types.ts
+++ b/apps/news/src/lib/types.ts
@@ -30,6 +30,9 @@ export interface FeedItem {
 export interface TldrBullet {
   text: string;
   item_ids?: string[];
+  /** Story og/thumbnail for the first linked item that has one.
+   * Additive read-time field — not stored on `tldr_snapshots`. */
+  image_url?: string | null;
 }
 
 export interface DayGroup {

--- a/apps/news/src/routes/changelog.tsx
+++ b/apps/news/src/routes/changelog.tsx
@@ -10,6 +10,11 @@ interface ChangelogEntry {
 const ENTRIES: ChangelogEntry[] = [
   {
     date: "2026-08",
+    en: "AI;DR bullets now show a small story thumbnail (or the site mark when a story has no image).",
+    vi: "Mỗi gạch đầu dòng AI;DR có ảnh thumbnail nhỏ (hoặc logo trang nếu tin chưa có ảnh).",
+  },
+  {
+    date: "2026-08",
     en: "Added a reader-preferences panel (font, text size, density, background, and section visibility), saved to your browser.",
     vi: "Thêm bảng tuỳ chỉnh hiển thị (font chữ, cỡ chữ, mật độ, màu nền, ẩn/hiện từng mục), lưu trên trình duyệt của bạn.",
   },

--- a/apps/news/src/routes/changelog.tsx
+++ b/apps/news/src/routes/changelog.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import type { ReactElement } from "react";
 import { useLang } from "../lib/lang-context";
 
 interface ChangelogEntry {
@@ -10,8 +11,8 @@ interface ChangelogEntry {
 const ENTRIES: ChangelogEntry[] = [
   {
     date: "2026-08",
-    en: "AI;DR bullets now show a small story thumbnail (or the site mark when a story has no image).",
-    vi: "Mỗi gạch đầu dòng AI;DR có ảnh thumbnail nhỏ (hoặc logo trang nếu tin chưa có ảnh).",
+    en: "AI;DR bullets show a small story thumbnail on the right (or the site mark when a story has no image).",
+    vi: "Mỗi gạch đầu dòng AI;DR có ảnh thumbnail nhỏ bên phải (hoặc logo trang nếu tin chưa có ảnh).",
   },
   {
     date: "2026-08",
@@ -42,7 +43,7 @@ export const Route = createFileRoute("/changelog")({
   component: ChangelogPage,
 });
 
-function ChangelogPage() {
+function ChangelogPage(): ReactElement {
   const lang = useLang();
 
   return (

--- a/apps/news/src/routes/index.tsx
+++ b/apps/news/src/routes/index.tsx
@@ -40,12 +40,23 @@ export const Route = createFileRoute("/")({
 });
 
 function SkeletonRow({ i }: { i: number }) {
-  const widths = ["w-3/4", "w-2/3", "w-3/4", "w-1/2", "w-2/3", "w-3/4", "w-1/2", "w-2/3"];
+  const widths = [
+    "w-3/4",
+    "w-2/3",
+    "w-3/4",
+    "w-1/2",
+    "w-2/3",
+    "w-3/4",
+    "w-1/2",
+    "w-2/3",
+  ];
   return (
     <div className="flex items-baseline gap-3 border-b border-border py-2">
       <span className="h-4 w-5 shrink-0 rounded bg-muted" />
       <span className="min-w-0 flex-1 space-y-1.5">
-        <span className={`block h-4 ${widths[i % widths.length]} rounded bg-muted`} />
+        <span
+          className={`block h-4 ${widths[i % widths.length]} rounded bg-muted`}
+        />
         <span className="block h-3 w-1/4 rounded bg-muted" />
       </span>
       <span className="hidden h-4 w-14 shrink-0 rounded bg-muted sm:block" />
@@ -76,9 +87,12 @@ function FeedSkeleton() {
         <div className="mb-2.5 h-5 w-24 rounded bg-muted" />
         <div className="grid gap-x-10 md:grid-cols-2">
           {[0, 1].map((col) => (
-            <div key={col} className="space-y-1.5">
-              {Array.from({ length: 6 }, (_, i) => (
-                <div key={i} className="h-3.5 w-full rounded bg-muted" />
+            <div key={col} className="space-y-2">
+              {Array.from({ length: 4 }, (_, i) => (
+                <div key={i} className="flex items-start gap-2">
+                  <span className="h-10 w-10 shrink-0 rounded-md bg-muted" />
+                  <span className="mt-2 h-3.5 w-full rounded bg-muted" />
+                </div>
               ))}
             </div>
           ))}
@@ -201,10 +215,12 @@ function IndexPage() {
   const bullets = displayTldrBullets(feed.tldr, lang);
 
   const topicByItemId = new Map<string, string>();
+  const imageByItemId = new Map<string, string>();
   for (const day of feed.days) {
     for (const item of day.items) {
       const topic = item.tags[0] ?? item.category;
       if (topic) topicByItemId.set(item.id, topic);
+      if (item.image_url) imageByItemId.set(item.id, item.image_url);
     }
   }
 
@@ -280,6 +296,7 @@ function IndexPage() {
             updatedAt={feed.updatedAt}
             lastFetchedAt={feed.lastFetchedAt}
             topicByItemId={topicByItemId}
+            imageByItemId={imageByItemId}
             snapshotDate={feed.tldr?.date}
           />
         )

--- a/apps/news/src/routes/index.tsx
+++ b/apps/news/src/routes/index.tsx
@@ -4,6 +4,7 @@ import { CategoryNav } from "../components/CategoryNav";
 import { DaySection } from "../components/DaySection";
 import { TldrSection } from "../components/TldrSection";
 import { TrendingChips } from "../components/TrendingChips";
+import { parseAidrLayout } from "../lib/aidr-layout";
 import { emptyFeedCopy, showFeedBrowseChrome } from "../lib/empty-feed";
 import { setCachedFeed } from "../lib/feed-cache";
 import { fetchFeed } from "../lib/feed-fn";
@@ -18,6 +19,8 @@ export interface IndexSearch {
   q?: string;
   tag?: string;
   category?: string;
+  /** QA-only AI;DR layout: a (default) | b | c. */
+  aidr?: "a" | "b" | "c";
 }
 
 export const Route = createFileRoute("/")({
@@ -27,6 +30,9 @@ export const Route = createFileRoute("/")({
     if (typeof search.tag === "string" && search.tag) out.tag = search.tag;
     if (typeof search.category === "string" && search.category) {
       out.category = search.category;
+    }
+    if (search.aidr === "a" || search.aidr === "b" || search.aidr === "c") {
+      out.aidr = search.aidr;
     }
     return out;
   },
@@ -90,8 +96,8 @@ function FeedSkeleton() {
             <div key={col} className="space-y-2">
               {Array.from({ length: 4 }, (_, i) => (
                 <div key={i} className="flex items-start gap-2">
-                  <span className="h-10 w-10 shrink-0 rounded-md bg-muted" />
                   <span className="mt-2 h-3.5 w-full rounded bg-muted" />
+                  <span className="h-10 w-10 shrink-0 rounded-md bg-muted" />
                 </div>
               ))}
             </div>
@@ -116,7 +122,7 @@ function FeedSkeleton() {
 }
 
 function IndexPage() {
-  const { q, tag, category } = Route.useSearch();
+  const { q, tag, category, aidr } = Route.useSearch();
   const lang = useLang();
   const { prefs } = usePrefs();
   const loaderFeed = Route.useLoaderData();
@@ -298,6 +304,8 @@ function IndexPage() {
             topicByItemId={topicByItemId}
             imageByItemId={imageByItemId}
             snapshotDate={feed.tldr?.date}
+            layout={parseAidrLayout(aidr)}
+            layoutLabeled={Boolean(aidr)}
           />
         )
       )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Homepage AI;DR was a text-only numbered list. Story images already live on `items.image_url` (og/thumbnail from ingest). This is a visual upgrade so each bullet gets the same compact thumb language as story cards — not a rewrite of the digest.

Rebased onto current `master` after `#1396` (`b83e54b`) and `#1398` (`058f0a9`). The `/api/public` commits are no longer in this branch; this PR is the AI;DR thumbnail work only. Leaves `#1362` `#1365` `#1282` `#1305` `#1300` alone.

## UI (Version A is the default)

Default homepage (`/` with no query): **number + category/summary on the left, 40–48px thumb on the RIGHT.** Number and thumb are never stacked on the same side.

- Thumb source: the linked story’s `image_url`.
- Missing/broken image: yellow **AI** site mark (`/favicon.svg`), never a broken-image icon.
- Mobile: `h-10 w-10` (40px). From `sm` up: `h-12 w-12` (48px). Same size language as story thumbs. Not a hero.
- Two columns, “Xem thêm”, counts, and snapshot date are unchanged.

## QA layout variants

No settings UI. Flip with `?aidr=` (also `data-aidr-layout` on the section):

| Version | URL | Layout |
| --- | --- | --- |
| **A (ship)** | `/` or `/?aidr=a` | Number + copy left, small thumb **right** |
| **B** | `/?aidr=b` | No list number; copy left, small thumb **right** |
| **C** | `/?aidr=c` | Copy left; thumb **right** with the list number overlaid bottom-left of the image |

When `?aidr=` is present, a tiny **Layout A/B/C** chip is shown so screenshots are labeled.

## Layout versions

Today’s live feed (`2026-08-28`, 16 VI bullets / 163 stories). 7 of the first 8 have story images; item 8 has none and shows the site mark.

### A — default (number left, thumb right)

![Layout A desktop ~1280](https://cursor.com/artifacts/c/art-d7062f9f-42f4-42c9-b611-c58153d59377)
![Layout A phone ~390](https://cursor.com/artifacts/c/art-ecf9367b-5338-4357-9af0-1a749d2be7ca)

### B — no list number

![Layout B desktop ~1280](https://cursor.com/artifacts/c/art-1bdc476a-6cdb-4f05-b17f-be88c819428f)
![Layout B phone ~390](https://cursor.com/artifacts/c/art-f5175968-ecdb-4bde-96e1-b2bf48f04c3d)

### C — number overlaid on the thumb

![Layout C desktop ~1280](https://cursor.com/artifacts/c/art-f9fbf11e-50ed-40a7-b8b1-bbbe2b52a5e4)
![Layout C phone ~390](https://cursor.com/artifacts/c/art-d839ab61-1e63-47df-9ed9-a0de3050a586)

## API (additive only)

`TldrBullet` may include `image_url` when the first linked story has one. Omitted when it doesn’t. Not persisted on `tldr_snapshots` (attached at read time).

```json
{ "text": "...", "item_ids": ["..."], "image_url": "https://..." }
```

- `/api/feed` attaches from the already-loaded items.
- `/api/public` attaches from top stories, then looks up remaining bullet `item_ids` (TL;DR can cite stories outside the top 8).

Existing fields are unchanged.

## Tests

- `apps/news/src/lib/tldr-images.test.ts`
- `apps/news/src/lib/aidr-layout.test.ts`
- `apps/news/src/lib/public-queries.test.ts` (bullet `image_url`, lookup outside top 8, omit when missing, field-size caps)

## CodeRabbit

Valid notes still in this PR after the rebase:

- Reset failed-image state when `src` changes (`failedSrc`).
- Explicit return types on `StoryThumb` / `ChangelogPage` / test `makeDb`.
- Cap public digest field sizes (bullet text, `item_ids`, story strings) before serialize / IN lookup.
- Document public `published_at` as epoch **seconds** vs millisecond `updatedAt`.

Skipped as no longer this PR’s surface (landed in `#1396`): rate-limit `/api/public`, `HandlerArgs` on `routes/api/public.ts`.

## Notes

- Do not squash-merge this PR from here. Leave open; do not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38e1f342-a9e0-4453-b54a-1e6b71d557f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38e1f342-a9e0-4453-b54a-1e6b71d557f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add responsive story thumbnails and read-time image metadata to homepage AI;DR bullets without changing the digest’s stored snapshot format.

New Features:
- Add compact story thumbnails to homepage AI;DR bullets, with a branded fallback for missing or failed images.
- Expose linked story image URLs as additive, read-time `image_url` fields in feed and public digest TL;DR data.
- Support QA-only selection of alternate AI;DR thumbnail layouts through the `?aidr=` query parameter.

Enhancements:
- Preserve existing AI;DR interactions and responsive two-column presentation while integrating thumbnail support.
- Harden public digest payloads by capping bullet and story field sizes and gracefully handling missing image columns or unavailable images.

Documentation:
- Update the news API README with the additive TL;DR bullet image field and payload notes.
- Add the AI;DR thumbnail upgrade to the user-facing changelog.

Tests:
- Add coverage for TL;DR image attachment, cross-language handling, missing images, and lookup of stories outside the public top-eight payload.
- Add coverage for AI;DR layout query parsing and public digest field limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added story thumbnails to AI;DR bullet points, with graceful fallback to the site icon when images are unavailable.
  * Added three validated AI;DR presentation layouts, including optional numbering and QA labels.
  * Added a public digest API with bilingual summaries, story images, bounded response fields, and resilient fallback behavior.
* **Documentation**
  * Updated API documentation to describe thumbnail availability and timestamp formats.
  * Added a changelog entry for AI;DR thumbnails and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->