### PR TITLE
fix(news): replace stealth/ox-alpha with anyrouter/auto in LLM chains

### DIFF
--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -99,11 +99,12 @@ anyrouter's queue for long prompts), JSON mode, `max_tokens` 8192 (2048 on trans
 reasoning-model fallback (extracts JSON from `message.reasoning` when content
 is starved), comma-separated model fallback chains (`ANYROUTER_MODEL`), and
 per-task overrides (`ANYROUTER_TRANSLATE_MODEL` / `ANYROUTER_TLDR_MODEL` —
-stealth/ox-alpha first for score/TL;DR; translate leads with Gemma 4 /
-GLM-4.7 / Ling-3.0 / `anyrouter/auto` (native ids that finish a 3-item
-batch), then Gemma 4 31B, with stealth/ox-alpha last on every chain;
-BYOK-only ids such as SEA-LION and Gemini 3.6/3.7 are omitted, and all
-paid Gemini ids were replaced by stealth/ox-alpha). Translate
+`anyrouter/auto` first for score/TL;DR (AnyRouter's health-aware router
+over top stable platform models), then Gemma 4 / GLM-4.7 / Ling-3.0;
+translate leads with Gemma 4 / GLM-4.7 / Ling-3.0 / `anyrouter/auto`
+(native ids that finish a 3-item batch), then Gemma 4 31B;
+BYOK-only ids such as SEA-LION and Gemini 3.6/3.7 are omitted, and
+stealth/ox-alpha was removed after AnyRouter delisted it). Translate
 runs in batches of 3 (summaries clipped, title-only retry) and each
 backfill slice is its own Workflow step so a finished batch is written
 even if a later slice times out. A hang, empty sanitize, timeout, or 402 advances the chain

--- a/apps/news/worker/__tests__/llm.test.ts
+++ b/apps/news/worker/__tests__/llm.test.ts
@@ -714,6 +714,33 @@ describe("model fallback chain", () => {
     expect(results[0].category).toBe("Models");
   });
 
+  it("advances past 404, 429, and 402 so a delisted primary cannot stall the chain", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("model not found", { status: 404 }))
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+      .mockResolvedValueOnce(
+        new Response("insufficient credits", { status: 402 })
+      )
+      .mockResolvedValueOnce(completion(scorePayload));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const results = await scoreItems(
+      {
+        ...env,
+        ANYROUTER_MODEL: "gone/model,busy/model,broke/model,ok/model",
+      },
+      scoreInput
+    );
+    expect(modelsOf(fetchMock)).toEqual([
+      "gone/model",
+      "busy/model",
+      "broke/model",
+      "ok/model",
+    ]);
+    expect(results[0].category).toBe("Models");
+  });
+
   it("advances when a model streams an empty completion", async () => {
     const fetchMock = vi
       .fn()

--- a/apps/news/worker/__tests__/schedule.test.ts
+++ b/apps/news/worker/__tests__/schedule.test.ts
@@ -47,26 +47,41 @@ describe("live AnyRouter model chains", () => {
     return match![1].split(",").map((s) => s.trim());
   }
 
-  it("uses stealth/ox-alpha on every live chain", () => {
+  it("keeps a real fallback chain on every live task (no single-model setup)", () => {
     for (const name of [
       "ANYROUTER_MODEL",
       "ANYROUTER_TRANSLATE_MODEL",
       "ANYROUTER_TLDR_MODEL",
     ]) {
-      expect(idsOf(name), name).toContain("stealth/ox-alpha");
+      expect(idsOf(name).length, name).toBeGreaterThanOrEqual(2);
     }
   });
 
-  it("leads score/tldr with ox-alpha and translate with Gemma 4", () => {
-    expect(idsOf("ANYROUTER_MODEL")[0]).toBe("stealth/ox-alpha");
-    expect(idsOf("ANYROUTER_TLDR_MODEL")[0]).toBe("stealth/ox-alpha");
+  it("leads score/tldr with anyrouter/auto and translate with Gemma 4", () => {
+    expect(idsOf("ANYROUTER_MODEL")[0]).toBe("anyrouter/auto");
+    expect(idsOf("ANYROUTER_TLDR_MODEL")[0]).toBe("anyrouter/auto");
     expect(idsOf("ANYROUTER_TRANSLATE_MODEL")[0]).toBe(
       "google/gemma-4-26b-a4b-it"
     );
+    expect(idsOf("ANYROUTER_TRANSLATE_MODEL")).toContain("anyrouter/auto");
   });
 
-  it("omits known BYOK-only and paid gemini ids from every live chain", () => {
+  it("reports three scoring fallbacks so /data can show (+3 fallback)", () => {
+    expect(idsOf("ANYROUTER_MODEL")).toEqual([
+      "anyrouter/auto",
+      "google/gemma-4-26b-a4b-it",
+      "z-ai/glm-4.7-flash",
+      "inclusionai/ling-3.0-flash",
+    ]);
+    expect(idsOf("ANYROUTER_TLDR_MODEL")).toEqual(idsOf("ANYROUTER_MODEL"));
+  });
+
+  it("omits delisted, BYOK-only, paid gemini, and rejected replacement ids", () => {
     const blocked = [
+      "stealth/ox-alpha",
+      "poolside/laguna-s-2.1",
+      "deepseek/DeepSeek-V4-Flash",
+      "stepfun-ai/step-3.7-flash",
       "aisingapore/gemma-sea-lion-v4-27b-it",
       "google/gemini-2.5-flash-lite",
       "google/gemini-2.5-flash",

--- a/apps/news/wrangler.toml
+++ b/apps/news/wrangler.toml
@@ -31,17 +31,19 @@ database_id = "8e692ccf-ec38-4e41-b011-50adbc891322"
 
 [vars]
 ANYROUTER_BASE_URL = "https://anyrouter.dev/api/v1"
-# Live model chains on stealth/ox-alpha (replaced every paid google/gemini-*
-# id). Score/TL;DR lead with ox-alpha and fall back to the cheap native ids
-# (non-BYOK); translate still leads with Gemma 4 (completes a 3-item JSON
-# batch fast) and keeps ox-alpha as the final fallback. No BYOK-only ids
-# (SEA-LION, gemini-3.6/3.7, qwen3.7) — a hang/401 on the first id used to
-# eat the whole budget before reaching a model that can write title_vi.
-ANYROUTER_MODEL = "stealth/ox-alpha,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash"
-ANYROUTER_TRANSLATE_MODEL = "google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,anyrouter/auto,google/gemma-4-31b,stealth/ox-alpha"
+# Live model chains: score/TL;DR lead with anyrouter/auto (AnyRouter's
+# health-aware router over top stable platform models) and fall back to
+# cheap native ids (non-BYOK). Translate still leads with Gemma 4
+# (completes a 3-item JSON batch fast) and keeps anyrouter/auto mid-chain.
+# stealth/ox-alpha was delisted (404s) — do not restore it. No BYOK-only
+# ids (SEA-LION, gemini-3.6/3.7, qwen3.7) — a hang/401 on the first id
+# used to eat the whole budget before reaching a model that can write
+# title_vi.
+ANYROUTER_MODEL = "anyrouter/auto,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash"
+ANYROUTER_TRANSLATE_MODEL = "google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash,anyrouter/auto,google/gemma-4-31b"
 # Bilingual TL;DR used to fall through to a reasoning-first chain and time
 # out both attempts, leaving English bullets on the VI homepage.
-ANYROUTER_TLDR_MODEL = "stealth/ox-alpha,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash"
+ANYROUTER_TLDR_MODEL = "anyrouter/auto,google/gemma-4-26b-a4b-it,z-ai/glm-4.7-flash,inclusionai/ling-3.0-flash"
 # Derived from VITE_CLERK_PUBLISHABLE_KEY's base64 domain suffix (see
 # apps/news/.env.production): pk_live_Y2xlcmsuZHV5ZXQubmV0JA -> clerk.duyet.net
 CLERK_ISSUER = "https://clerk.duyet.net"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
ox-alpha was delisted from AnyRouter. Live `/data` (2026-08-28) still listed it as the scoring/TL;DR primary while fallbacks carried the load (3789 LLM calls / 3360 failures over 14 days).

This PR only rewrites the live model lists. The pipeline, prompts, and `callAnyrouter` fallback loop are unchanged.

## Routing

| Task | Before | After |
| --- | --- | --- |
| Scoring | `stealth/ox-alpha` → gemma-4-26b → glm-4.7-flash → ling-3.0-flash | **`anyrouter/auto`** → gemma-4-26b → glm-4.7-flash → ling-3.0-flash |
| TL;DR | same as scoring | same as scoring |
| Translation | gemma-4-26b → glm-4.7 → ling-3.0 → auto → gemma-4-31b → **ox-alpha** | gemma-4-26b → glm-4.7 → ling-3.0 → **auto** → gemma-4-31b |

- Primary id is exactly `anyrouter/auto` (AnyRouter health-aware router).
- Every task still has a real fallback chain (not a single-model setup).
- Rejected replacements left out: `poolside/laguna-s-2.1`, `deepseek/DeepSeek-V4-Flash`, `stepfun-ai/step-3.7-flash`.
- `/data` reads these vars, so scoring will show `anyrouter/auto (+3 fallback)`.

## Fallback

`callAnyrouter` already advances on transport errors, non-200s, timeouts, and empty/unusable completions. 402 with an afford-cap retries the same id at a cheaper token budget; otherwise 402/429/404/5xx hop to the next model. Tests now cover 404 → 429 → 402 → success.

## Out of scope

Does not touch #1362, #1365, #1282, #1305, #1300, #1396, or #1397.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9d0d86e-1aca-48e9-b50b-cea0b6290d35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9d0d86e-1aca-48e9-b50b-cea0b6290d35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Replace the delisted ox-alpha model with AnyRouter auto routing while retaining reliable fallback chains across news-processing tasks.

Bug Fixes:
- Replace the delisted ox-alpha model with AnyRouter’s health-aware auto router in the scoring and TL;DR chains.
- Remove ox-alpha from the translation fallback chain to prevent failures caused by delisted model IDs.
- Ensure model fallback handling advances through 404, 429, and 402 responses instead of stalling on unavailable models.

Enhancements:
- Preserve multi-model fallback coverage across all live news-processing tasks.
- Document the updated live model routing and excluded model IDs.

Deployment:
- Update production AnyRouter model chains for scoring, TL;DR generation, and translation.

Documentation:
- Update the news algorithm documentation to reflect the new model routing and removal of ox-alpha.

Tests:
- Add coverage for fallback progression across 404, 429, and 402 responses.
- Update schedule tests to verify AnyRouter auto routing, fallback chains, and exclusion of delisted or rejected models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated AI model routing for scoring, summaries, and translations.
  - Added automatic fallback handling when a model is unavailable or rate-limited.
  - Removed the unavailable `stealth/ox-alpha` model from supported routing chains.
- **Documentation**
  - Updated model-chain documentation to reflect the current routing order and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->