### PR TITLE
fix(news): record ingest runs when score and tldr LLM steps fail

### DIFF
--- a/.github/workflows/news-ingest.yml
+++ b/.github/workflows/news-ingest.yml
@@ -26,8 +26,12 @@ jobs:
     steps:
       - name: Trigger news-ingest workflow
         run: |
+          url="https://news.duyet.net/api/admin/ingest"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            url="${url}?force=1"
+          fi
           code=$(curl -s -o /tmp/resp.json -w '%{http_code}' -X POST \
-            "https://news.duyet.net/api/admin/ingest" \
+            "$url" \
             -H "Authorization: Bearer ${{ secrets.NEWS_ADMIN_TOKEN }}")
           if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
             cat /tmp/resp.json

--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -8,7 +8,12 @@ alarm (not a Worker `[triggers]` cron — Free 5-cron cap — and not Workflow
 four independent crons at :05/:20/:35/:50) POSTs `/api/admin/ingest` as a
 watchdog because GitHub routinely delays or skips scheduled workflows.
 Both paths coalesce: a new instance is skipped if one started in the last
-45 minutes.
+45 minutes. `POST /api/admin/ingest?force=1` (workflow_dispatch) bypasses
+the window. LLM-heavy Workflow steps use `retries: 0` and a 4-minute
+timeout; a failed score/TL;DR call must not abort `record-run`. Score and
+TL;DR hang-cap per model at 70s/90s (translate stays 25s). Do not treat
+GitHub Actions SUCCESS as a finished ingest — wait for `/api/system`
+`lastRun` / `runsToday`.
 
 ## Pipeline (per hourly run)
 
@@ -18,7 +23,7 @@ Both paths coalesce: a new instance is skipped if one started in the last
 2. **Dedupe** — item id = `sha256(url)`; ids already in `items` are dropped.
 3. **Enrich** — missing summary/thumbnail filled from the article page
    (`og:description` / `og:image`), capped and failure-proof (`worker/enrich.ts`).
-4. **Score (LLM)** — batches of 15, fixed rubric → per item:
+   4. **Score (LLM)** — batches of 5, fixed rubric → per item:
    `relevance` 0–1, `importance` 0–10, `quality` 0–10, one `category` from a
    fixed 11-value enum, free-form `tags`.
    **Hide rule:** `relevance < 0.4` → status `rejected` (never shown).
@@ -111,7 +116,9 @@ BYOK-only ids such as SEA-LION and Gemini 3.6/3.7 are omitted, and
 stealth/ox-alpha was removed after AnyRouter delisted it). Translate
 runs in batches of 3 (summaries clipped, title-only retry) and each
 backfill slice is its own Workflow step so a finished batch is written
-even if a later slice times out. A hang, empty sanitize, timeout, or 402 advances the chain
+even if a later slice times out. Score batches of 5 with a 70s hang-cap;
+TL;DR uses a 90s hang-cap so bilingual JSON can finish (a 25s cap made
+every score/TL;DR model log 0 tokens). A hang, empty sanitize, timeout, or 402 advances the chain
 (`raceTimeout` aborts the fetch; leftover reserves a 20s floor for two
 fallbacks and hang-caps at 25s so leftover actually reaches them; 402
 retries the same id at the affordable token cap; the last failure lists

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -48,7 +48,10 @@ alarm (not a Worker cron) plus GitHub Actions
 (`.github/workflows/news-ingest.yml`, crons at :05/:20/:35/:50) via
 `POST /api/admin/ingest`. Do not add Worker `[triggers] crons` or
 Workflow `schedules` — both break Free-plan deploys. GitHub POSTs
-coalesce if a run started in the last 45 minutes.
+coalesce if a run started in the last 45 minutes. Manual
+`workflow_dispatch` sends `?force=1` so a hung coalesce window cannot
+skip. Actions SUCCESS is only the POST; `/api/system` `lastRun` is the
+finished ingest.
 
 ## Admin API / MCP
 

--- a/apps/news/src/routes/api/admin.$.ts
+++ b/apps/news/src/routes/api/admin.$.ts
@@ -169,7 +169,8 @@ async function handle(
   }
 
   if (method === "POST" && segments.length === 1 && segments[0] === "ingest") {
-    const result = await triggerIngest(env);
+    const force = new URL(request.url).searchParams.get("force") === "1";
+    const result = await triggerIngest(env, { force });
     return Response.json(result);
   }
 

--- a/apps/news/worker/__tests__/admin.test.ts
+++ b/apps/news/worker/__tests__/admin.test.ts
@@ -845,6 +845,22 @@ describe("triggerIngest", () => {
     });
     expect(create).not.toHaveBeenCalled();
   });
+
+  it("passes force through to the scheduler tick", async () => {
+    const tick = vi.fn().mockResolvedValue({
+      id: "wf-forced",
+      skipped: false,
+    });
+    const env = makeEnv({
+      NEWS_INGEST_SCHEDULER: {
+        idFromName: () => "id",
+        get: () => ({ tick, ensureArmed: vi.fn() }),
+      } as unknown as DurableObjectNamespace,
+    });
+    const result = await triggerIngest(env, { force: true });
+    expect(result).toEqual({ id: "wf-forced", skipped: false });
+    expect(tick).toHaveBeenCalledWith({ force: true });
+  });
 });
 
 describe("MCP server", () => {

--- a/apps/news/worker/__tests__/dedupe.test.ts
+++ b/apps/news/worker/__tests__/dedupe.test.ts
@@ -137,6 +137,22 @@ describe("clusterSimilar", () => {
     expect(clusters).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("sends only the first id when ANYROUTER_MODEL is a fallback chain", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(chatResponse(JSON.stringify({ clusters: [] })));
+    vi.stubGlobal("fetch", fetchMock);
+    await clusterSimilar(
+      { ...env, ANYROUTER_MODEL: "anyrouter/auto,google/gemma-4-26b-a4b-it" },
+      [{ i: 0, title: "A" }],
+      []
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+      model: string;
+    };
+    expect(body.model).toBe("anyrouter/auto");
+  });
 });
 
 describe("title similarity dedupe", () => {

--- a/apps/news/worker/__tests__/llm.test.ts
+++ b/apps/news/worker/__tests__/llm.test.ts
@@ -1539,6 +1539,11 @@ describe("modelAttemptTimeoutMs", () => {
     expect(modelAttemptTimeoutMs(0, 3)).toBe(0);
     expect(modelAttemptTimeoutMs(-5, 3)).toBe(0);
   });
+
+  it("honors a longer per-task hang-cap for score/tldr JSON", () => {
+    expect(modelAttemptTimeoutMs(240_000, 4, 90_000)).toBe(90_000);
+    expect(modelAttemptTimeoutMs(70_000, 3, 70_000)).toBe(30_000);
+  });
 });
 
 describe("normalizeTag", () => {

--- a/apps/news/worker/__tests__/schedule.test.ts
+++ b/apps/news/worker/__tests__/schedule.test.ts
@@ -141,9 +141,13 @@ describe("translate batch size", () => {
     expect(algorithm).toMatch(/batches of 3/);
   });
 
-  it("caps each model attempt at 25s so leftover reaches fallbacks", () => {
+  it("caps translate attempts at 25s so leftover reaches fallbacks", () => {
     expect(llm).toMatch(/MODEL_SLICE_MAX_MS = 25_000/);
+    expect(llm).toMatch(/SCORE_SLICE_MAX_MS = 70_000/);
+    expect(llm).toMatch(/TLDR_SLICE_MAX_MS = 90_000/);
     expect(llm).toMatch(/FALLBACK_FLOOR_MS = 20_000/);
+    expect(llm).toMatch(/SCORE_BATCH_SIZE = 5/);
+    expect(algorithm).toMatch(/batches of 5/);
   });
 });
 
@@ -158,7 +162,17 @@ describe("backfill-translate checkpoints", () => {
     expect(workflow).toMatch(/backfill-translate-\$\{offset\}/);
     expect(workflow).toContain("TRANSLATE_BATCH_SIZE");
     expect(workflow).toContain("BACKFILL_TRANSLATE_STEP");
+    expect(workflow).toContain("LLM_STEP");
     expect(workflow).toMatch(/retries:\s*\{\s*limit:\s*0/);
+    expect(workflow).toContain('step.do("score", LLM_STEP');
+    expect(workflow).toContain('step.do("translate", LLM_STEP');
+    expect(workflow).toContain('step.do("tldr", LLM_STEP');
+    expect(workflow).toContain('step.do("record-run", LLM_STEP');
     expect(workflow).toContain("if (!row || !result.title) continue");
+  });
+
+  it("does not rethrow after setting runError so record-run can insert", () => {
+    expect(workflow).toContain("ingest run failed:");
+    expect(workflow).not.toMatch(/runError[\s\S]{0,80}throw error/);
   });
 });

--- a/apps/news/worker/admin/handlers.ts
+++ b/apps/news/worker/admin/handlers.ts
@@ -254,8 +254,11 @@ export async function deleteSource(
   return { ok: true, id };
 }
 
-export async function triggerIngest(env: Env) {
-  const result = await tickIngest(env);
+export async function triggerIngest(
+  env: Env,
+  opts: { force?: boolean } = {}
+) {
+  const result = await tickIngest(env, opts);
   await writeAudit(
     env,
     "ingest.trigger",

--- a/apps/news/worker/dedupe.ts
+++ b/apps/news/worker/dedupe.ts
@@ -40,7 +40,9 @@ async function callAnyrouterForClustering(
       Authorization: `Bearer ${env.ANYROUTER_API_KEY}`,
     },
     body: JSON.stringify({
-      model: env.ANYROUTER_MODEL,
+      model:
+        (env.ANYROUTER_MODEL ?? "").split(",")[0]?.trim() ||
+        env.ANYROUTER_MODEL,
       messages: [{ role: "user", content: prompt }],
       temperature: 0,
       max_tokens: MAX_TOKENS,

--- a/apps/news/worker/llm.ts
+++ b/apps/news/worker/llm.ts
@@ -2,7 +2,9 @@ import { looksVietnamese } from "./tldr-lang.js";
 import type { Env } from "./types.js";
 import { mapWithConcurrency } from "./concurrency.js";
 
-const BATCH_SIZE = 15;
+/** 15-item score JSON routinely misses a 25s hang-cap (0 tokens, 100%
+ *  fail). 5 titles still fill a batch and finish inside SCORE_SLICE_MAX. */
+const SCORE_BATCH_SIZE = 5;
 /** 15-item translate JSON + VI_STYLE routinely times out native Gemma 4
  *  at the 90s attempt cap; 3 titles still fill a homepage row and finish. */
 export const TRANSLATE_BATCH_SIZE = 3;
@@ -323,10 +325,12 @@ async function streamCompletion(
   throw new Error("anyrouter response missing content");
 }
 
-/** Hang-cap. 90s equaled a 90s batch budget so leftover never reached
- *  fallbacks after one native hang. 25s still finishes a 3-item title
- *  batch and leaves a 20s floor for two more ids. */
+/** Hang-cap for translate (3-item JSON). Score/TL;DR use a longer slice. */
 export const MODEL_SLICE_MAX_MS = 25_000;
+/** 15-item score / 16-bullet TL;DR JSON cannot finish in 25s; every
+ *  model then logs 0 tokens and the chain looks 100% dead. */
+export const SCORE_SLICE_MAX_MS = 70_000;
+export const TLDR_SLICE_MAX_MS = 90_000;
 const FALLBACK_FLOOR_MS = 20_000;
 
 /**
@@ -384,6 +388,7 @@ async function callAnyrouter(
     task?: LlmTask;
     timeoutMs?: number;
     maxTokens?: number;
+    maxSliceMs?: number;
     /** A 200 with content that fails this check is a model failure so
      *  the next id in the chain can run (e.g. empty sanitize). */
     accept?: (content: string) => boolean;
@@ -408,7 +413,8 @@ async function callAnyrouter(
     const model = models[i];
     const timeoutMs = modelAttemptTimeoutMs(
       deadline - Date.now(),
-      models.length - i
+      models.length - i,
+      opts.maxSliceMs ?? MODEL_SLICE_MAX_MS
     );
     if (timeoutMs <= 0) {
       failures.push(`${model}: leftover budget too small`);
@@ -429,7 +435,19 @@ async function callAnyrouter(
         abort
       );
       if (opts.accept && !opts.accept(result.content)) {
-        throw new Error("anyrouter response failed accept check");
+        logLlmCall({
+          ts: attemptStartedAt,
+          task,
+          model,
+          ok: false,
+          tokens: result.tokens,
+          durationMs: Date.now() - attemptStartedAt,
+          error: "anyrouter response failed accept check",
+          promptChars,
+          responseSnippet: result.content.slice(0, 2000),
+        });
+        failures.push(`${model}: anyrouter response failed accept check`);
+        continue;
       }
       console.log(`anyrouter completion served by ${model}`);
       logLlmCall({
@@ -641,7 +659,7 @@ export async function scoreItems(
   env: Env,
   items: ScoreInput[]
 ): Promise<ScoreResult[]> {
-  const batches = chunk(items, BATCH_SIZE);
+  const batches = chunk(items, SCORE_BATCH_SIZE);
   // Token spend unchanged; wall-clock divided (~3× at SCORE_CONCURRENCY).
   const SCORE_CONCURRENCY = 3;
   const batchResults = await mapWithConcurrency(
@@ -671,7 +689,11 @@ Respond with strict JSON only: {"results":[{"i":0,"relevance":0.9,"importance":7
         const { content: raw, tokens } = await callAnyrouter(
           env,
           [{ role: "user", content: prompt }],
-          { json: true, task: "score" }
+          {
+            json: true,
+            task: "score",
+            maxSliceMs: SCORE_SLICE_MAX_MS,
+          }
         );
         const parsed = parseJson<{ results?: unknown } | unknown[]>(raw);
         const rows = Array.isArray(parsed) ? parsed : parsed.results;
@@ -845,7 +867,11 @@ export async function translateItems(
   ): Promise<TranslateResult[]> => {
     const remaining = deadline - Date.now();
     if (remaining <= 0) {
-      logTranslateBatchFailed("translate deadline exhausted", batch, titlesOnly);
+      logTranslateBatchFailed(
+        "translate deadline exhausted",
+        batch,
+        titlesOnly
+      );
       return [];
     }
     try {
@@ -1055,6 +1081,7 @@ export async function generateTldr(
           modelSpec: env.ANYROUTER_TLDR_MODEL,
           task: "tldr",
           timeoutMs: TLDR_TIMEOUT_MS,
+          maxSliceMs: TLDR_SLICE_MAX_MS,
           // Bilingual attempt: EN-only JSON is a miss so the next model
           // can still produce bullets_vi. EN-only is accepted on retry.
           accept: (content) => {

--- a/apps/news/worker/workflow.ts
+++ b/apps/news/worker/workflow.ts
@@ -81,6 +81,19 @@ const BACKFILL_TRANSLATE_STEP = {
   timeout: "2 minutes",
 } as const;
 
+/** Score / translate / merge / TL;DR / backfill-score. Same retry trap as
+ * backfill-translate: a timed-out or exhausted LLM step must not retry for
+ * ~50 minutes, or `record-run` never writes `workflow_runs`. */
+const LLM_STEP = {
+  retries: { limit: 0, delay: 0 },
+  timeout: "4 minutes",
+} as const;
+
+const EMPTY_MERGE_PLAN: MergePlan = {
+  merged: new Map(),
+  canonicalUpdates: new Map(),
+};
+
 interface SourceRow {
   id: string;
   type: string;
@@ -311,27 +324,32 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
         };
       });
 
-      const scored = await step.do("score", async () => {
-        if (newRows.length === 0)
-          return new Map<
-            string,
-            Awaited<ReturnType<typeof scoreItems>>[number]
-          >();
-        const results = await scoreItems(
-          this.env,
-          newRows.map((row, i) => ({
-            i,
-            title: row.item.title,
-            summary: row.item.summary,
-            source: row.source.id,
-          }))
-        );
-        const map = new Map<string, (typeof results)[number]>();
-        for (const result of results) {
-          const row = newRows[result.i];
-          if (row) map.set(row.id, result);
+      const scored = await step.do("score", LLM_STEP, async () => {
+        const empty = new Map<
+          string,
+          Awaited<ReturnType<typeof scoreItems>>[number]
+        >();
+        if (newRows.length === 0) return empty;
+        try {
+          const results = await scoreItems(
+            this.env,
+            newRows.map((row, i) => ({
+              i,
+              title: row.item.title,
+              summary: row.item.summary,
+              source: row.source.id,
+            }))
+          );
+          const map = new Map<string, (typeof results)[number]>();
+          for (const result of results) {
+            const row = newRows[result.i];
+            if (row) map.set(row.id, result);
+          }
+          return map;
+        } catch (error) {
+          console.error("score step failed:", error);
+          return empty;
         }
-        return map;
       });
       recordStep(
         steps,
@@ -349,93 +367,99 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
       // dedupe against.
       const canonicalTagsByItem = await step.do(
         "normalize-topics",
+        LLM_STEP,
         async () => {
           if (newRows.length === 0) return new Map<string, string[]>();
-          const rawTagsByItem = new Map<string, string[]>(
-            newRows.map((row) => [row.id, scored.get(row.id)?.tags ?? []])
-          );
-          return normalizeTopics(this.env, rawTagsByItem, now);
+          try {
+            const rawTagsByItem = new Map<string, string[]>(
+              newRows.map((row) => [row.id, scored.get(row.id)?.tags ?? []])
+            );
+            return await normalizeTopics(this.env, rawTagsByItem, now);
+          } catch (error) {
+            console.error("normalize-topics step failed:", error);
+            return new Map<string, string[]>();
+          }
         }
       );
 
-      const mergePlan = await step.do("merge-similar", async () => {
-        const empty: MergePlan = {
-          merged: new Map(),
-          canonicalUpdates: new Map(),
-        };
-        if (newRows.length === 0) return empty;
-
-        const { results: recentForClustering } = await this.env.DB.prepare(
-          `SELECT id, title, points, comments FROM items
+      const mergePlan = await step.do("merge-similar", LLM_STEP, async () => {
+        if (newRows.length === 0) return EMPTY_MERGE_PLAN;
+        try {
+          const { results: recentForClustering } = await this.env.DB.prepare(
+            `SELECT id, title, points, comments FROM items
            WHERE status = 'published' AND published_at >= ?
            ORDER BY published_at DESC
            LIMIT ${MERGE_CANDIDATE_LIMIT}`
-        )
-          .bind(toEpochSeconds(now) - MERGE_LOOKBACK_SEC)
-          .all<{
-            id: string;
-            title: string;
-            points: number;
-            comments: number;
-          }>();
+          )
+            .bind(toEpochSeconds(now) - MERGE_LOOKBACK_SEC)
+            .all<{
+              id: string;
+              title: string;
+              points: number;
+              comments: number;
+            }>();
 
-        const newForCluster = newRows.map((row, i) => ({
-          i,
-          title: row.item.title,
-        }));
-        const existingForCluster = (recentForClustering ?? []).map((r) => ({
-          id: r.id,
-          title: r.title,
-        }));
-        const llmClusters = await clusterSimilar(
-          this.env,
-          newForCluster,
-          existingForCluster
-        );
-        const titleClusters = clusterByTitleSimilarity(
-          newForCluster,
-          existingForCluster
-        );
-        const clusters = mergeClusters([llmClusters, titleClusters]);
-        if (clusters.length === 0) return empty;
-
-        const candidates: MergeCandidate[] = newRows.map((row, i) => {
-          const score = scored.get(row.id);
-          const rank = rankScore({
-            importance: score?.importance ?? 5,
-            quality: score?.quality ?? 5,
-            points: row.item.points ?? 0,
-            comments: row.item.comments ?? 0,
-            publishedAt: row.item.publishedAt * 1000,
-            now,
-          });
-          return {
+          const newForCluster = newRows.map((row, i) => ({
             i,
-            id: row.id,
-            url: row.item.url,
-            sourceId: row.source.id,
-            sources: row.item.sources,
-            topics: canonicalTagsByItem.get(row.id),
-            points: row.item.points ?? 0,
-            comments: row.item.comments ?? 0,
-            rank,
-          };
-        });
+            title: row.item.title,
+          }));
+          const existingForCluster = (recentForClustering ?? []).map((r) => ({
+            id: r.id,
+            title: r.title,
+          }));
+          const llmClusters = await clusterSimilar(
+            this.env,
+            newForCluster,
+            existingForCluster
+          );
+          const titleClusters = clusterByTitleSimilarity(
+            newForCluster,
+            existingForCluster
+          );
+          const clusters = mergeClusters([llmClusters, titleClusters]);
+          if (clusters.length === 0) return EMPTY_MERGE_PLAN;
 
-        const existingById = new Map<string, ExistingCandidate>(
-          (recentForClustering ?? []).map((r) => [
-            r.id,
-            { points: r.points, comments: r.comments },
-          ])
-        );
+          const candidates: MergeCandidate[] = newRows.map((row, i) => {
+            const score = scored.get(row.id);
+            const rank = rankScore({
+              importance: score?.importance ?? 5,
+              quality: score?.quality ?? 5,
+              points: row.item.points ?? 0,
+              comments: row.item.comments ?? 0,
+              publishedAt: row.item.publishedAt * 1000,
+              now,
+            });
+            return {
+              i,
+              id: row.id,
+              url: row.item.url,
+              sourceId: row.source.id,
+              sources: row.item.sources,
+              topics: canonicalTagsByItem.get(row.id),
+              points: row.item.points ?? 0,
+              comments: row.item.comments ?? 0,
+              rank,
+            };
+          });
 
-        return buildMergePlan(
-          clusters,
-          candidates,
-          existingById,
-          MAX_SOURCES_PER_ITEM,
-          MAX_MERGED_TOPICS
-        );
+          const existingById = new Map<string, ExistingCandidate>(
+            (recentForClustering ?? []).map((r) => [
+              r.id,
+              { points: r.points, comments: r.comments },
+            ])
+          );
+
+          return buildMergePlan(
+            clusters,
+            candidates,
+            existingById,
+            MAX_SOURCES_PER_ITEM,
+            MAX_MERGED_TOPICS
+          );
+        } catch (error) {
+          console.error("merge-similar step failed:", error);
+          return EMPTY_MERGE_PLAN;
+        }
       });
 
       const newRowById = new Map(newRows.map((row) => [row.id, row]));
@@ -446,26 +470,31 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
         return !score || score.relevance >= RELEVANCE_THRESHOLD;
       });
 
-      const translated = await step.do("translate", async () => {
-        if (publishedRows.length === 0)
-          return new Map<
-            string,
-            Awaited<ReturnType<typeof translateItems>>[number]
-          >();
-        const results = await translateItems(
-          this.env,
-          publishedRows.map((row, i) => ({
-            i,
-            title: row.item.title,
-            summary: row.item.summary,
-          }))
-        );
-        const map = new Map<string, (typeof results)[number]>();
-        for (const result of results) {
-          const row = publishedRows[result.i];
-          if (row) map.set(row.id, result);
+      const translated = await step.do("translate", LLM_STEP, async () => {
+        const empty = new Map<
+          string,
+          Awaited<ReturnType<typeof translateItems>>[number]
+        >();
+        if (publishedRows.length === 0) return empty;
+        try {
+          const results = await translateItems(
+            this.env,
+            publishedRows.map((row, i) => ({
+              i,
+              title: row.item.title,
+              summary: row.item.summary,
+            }))
+          );
+          const map = new Map<string, (typeof results)[number]>();
+          for (const result of results) {
+            const row = publishedRows[result.i];
+            if (row) map.set(row.id, result);
+          }
+          return map;
+        } catch (error) {
+          console.error("translate step failed:", error);
+          return empty;
         }
-        return map;
       });
       recordStep(
         steps,
@@ -985,80 +1014,84 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
           : undefined
       );
 
-      const backfillScoreResult = await step.do("backfill-score", async () => {
-        let scoredCount = 0;
-        let tokens = 0;
-        try {
-          const { results } = await this.env.DB.prepare(
-            buildUnscoredItemsQuery(BACKFILL_SCORE_CAP)
-          ).all<{
-            id: string;
-            title: string;
-            summary: string | null;
-            source_id: string;
-            points: number;
-            comments: number;
-            published_at: number;
-          }>();
-          const rows = results ?? [];
-          if (rows.length === 0) return { scoredCount, tokens };
+      const backfillScoreResult = await step.do(
+        "backfill-score",
+        LLM_STEP,
+        async () => {
+          let scoredCount = 0;
+          let tokens = 0;
+          try {
+            const { results } = await this.env.DB.prepare(
+              buildUnscoredItemsQuery(BACKFILL_SCORE_CAP)
+            ).all<{
+              id: string;
+              title: string;
+              summary: string | null;
+              source_id: string;
+              points: number;
+              comments: number;
+              published_at: number;
+            }>();
+            const rows = results ?? [];
+            if (rows.length === 0) return { scoredCount, tokens };
 
-          const scoredRows = await scoreItems(
-            this.env,
-            rows.map((row, i) => ({
-              i,
-              title: row.title,
-              summary: row.summary ?? undefined,
-              source: row.source_id,
-            }))
-          );
-          const rawTagsByItem = new Map<string, string[]>();
-          for (const result of scoredRows) {
-            tokens += result.tokens;
-            const row = rows[result.i];
-            if (row) rawTagsByItem.set(row.id, result.tags);
-          }
-          const canonical = await normalizeTopics(
-            this.env,
-            rawTagsByItem,
-            Date.now()
-          );
-          const now = Date.now();
-          for (const result of scoredRows) {
-            const row = rows[result.i];
-            if (!row) continue;
-            const tags = canonical.get(row.id) ?? result.tags;
-            const rank = rankScore({
-              importance: result.importance,
-              quality: result.quality,
-              points: row.points ?? 0,
-              comments: row.comments ?? 0,
-              publishedAt: row.published_at * 1000,
-              now,
-            });
-            await this.env.DB.prepare(
-              `UPDATE items SET
+            const scoredRows = await scoreItems(
+              this.env,
+              rows.map((row, i) => ({
+                i,
+                title: row.title,
+                summary: row.summary ?? undefined,
+                source: row.source_id,
+              }))
+            );
+            const rawTagsByItem = new Map<string, string[]>();
+            for (const result of scoredRows) {
+              tokens += result.tokens;
+              const row = rows[result.i];
+              if (row) rawTagsByItem.set(row.id, result.tags);
+            }
+            const canonical = await normalizeTopics(
+              this.env,
+              rawTagsByItem,
+              Date.now()
+            );
+            const now = Date.now();
+            for (const result of scoredRows) {
+              const row = rows[result.i];
+              if (!row) continue;
+              const tags = canonical.get(row.id) ?? result.tags;
+              const rank = rankScore({
+                importance: result.importance,
+                quality: result.quality,
+                points: row.points ?? 0,
+                comments: row.comments ?? 0,
+                publishedAt: row.published_at * 1000,
+                now,
+              });
+              await this.env.DB.prepare(
+                `UPDATE items SET
                  llm_relevance = ?, llm_importance = ?, llm_quality = ?,
                  category = ?, tags = ?, rank_score = ?
                WHERE id = ?`
-            )
-              .bind(
-                result.relevance,
-                result.importance,
-                result.quality,
-                result.category,
-                JSON.stringify(tags),
-                rank,
-                row.id
               )
-              .run();
-            scoredCount++;
+                .bind(
+                  result.relevance,
+                  result.importance,
+                  result.quality,
+                  result.category,
+                  JSON.stringify(tags),
+                  rank,
+                  row.id
+                )
+                .run();
+              scoredCount++;
+            }
+          } catch (error) {
+            console.error("backfill-score step failed:", error);
           }
-        } catch (error) {
-          console.error("backfill-score step failed:", error);
+          return { scoredCount, tokens };
         }
-        return { scoredCount, tokens };
-      });
+      );
       scoreAndTranslateTokens += backfillScoreResult.tokens;
       recordStep(
         steps,
@@ -1068,7 +1101,7 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
           : `scored ${backfillScoreResult.scoredCount} items`
       );
 
-      const qaStats = await step.do("qa-translations", async () => {
+      const qaStats = await step.do("qa-translations", LLM_STEP, async () => {
         try {
           return await ratePendingTranslations(this.env);
         } catch (error) {
@@ -1123,7 +1156,7 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
           : `reviewed ${submissionsReviewed} submissions`
       );
 
-      const tldrStats = await step.do("tldr", async () => {
+      const tldrStats = await step.do("tldr", LLM_STEP, async () => {
         try {
           return await ensureDailyTldr(this.env);
         } catch (error) {
@@ -1185,8 +1218,12 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
         JSON.stringify(notifyReason)
       );
     } catch (error) {
+      // Do not rethrow. Cloudflare Workflows retry a thrown `run()` (and
+      // skip later steps, including `record-run` in this finally). A
+      // finished ingest must always insert a workflow_runs row so
+      // /api/system lastRun/runsToday move.
       runError = error instanceof Error ? error.message : String(error);
-      throw error;
+      console.error("ingest run failed:", error);
     } finally {
       const stats = buildRunStats({
         bySource,
@@ -1214,22 +1251,26 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
         notifyReason,
       });
 
-      await step.do("record-run", async () => {
-        await this.env.DB.prepare(
-          `INSERT INTO workflow_runs (id, started_at, finished_at, items_fetched, items_new, error, stats)
+      try {
+        await step.do("record-run", LLM_STEP, async () => {
+          await this.env.DB.prepare(
+            `INSERT INTO workflow_runs (id, started_at, finished_at, items_fetched, items_new, error, stats)
            VALUES (?, ?, ?, ?, ?, ?, ?)`
-        )
-          .bind(
-            nn(runId),
-            nn(startedAt),
-            nn(toEpochSeconds(Date.now())),
-            nn(itemsFetched),
-            nn(itemsNew),
-            nn(runError),
-            nn(serializeRunStats(stats))
           )
-          .run();
-      });
+            .bind(
+              nn(runId),
+              nn(startedAt),
+              nn(toEpochSeconds(Date.now())),
+              nn(itemsFetched),
+              nn(itemsNew),
+              nn(runError),
+              nn(serializeRunStats(stats))
+            )
+            .run();
+        });
+      } catch (error) {
+        console.error("record-run failed:", error);
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes leftover https://github.com/duyet/monorepo/issues/1401 after #1400.

## What I found (not a schedule fire)

Live `GET https://news.duyet.net/api/system` still showed `lastRun` `42d830a9-…` (finished 2026-08-26 ICT), `runsToday` 0, while 2026-08-28 had 15 published items, `latestTldrDate` 2026-08-28, and `llm_calls` with translate 1177/1170 fail (some tokens) and **score 20/20 fail / 0 tokens**, **tldr 16/16 fail / 0 tokens**.

Confirmed facts, not invented:

- Watchdog yml is on `master` (`e4f00c70`). GitHub **News Ingest** `workflow_dispatch` 33149718138 @ e4f00c70 returned POST 2xx. That is **not** a `workflow_runs` row.
- Last real **schedule** News Ingest was 2026-08-27 23:38 UTC on `5a771c1a`. No `:05/:20/:35/:50` cron fire is claimed here.
- `duyet-news` was deployed 2026-08-28T06:56:04Z (#1400).
- `workflow_runs` is only inserted in the `record-run` step. Mid-run writes (items, `llm_calls`, title-fallback TL;DR) can land without that row.

#1400 only set `retries: 0` on **backfill-translate** slices. Score, translate, merge, and TL;DR still used default Workflow retries, and `run()` **rethrow** after setting `runError`, so Cloudflare Workflows never executed `record-run`.

Separately, the **25s** `MODEL_SLICE_MAX_MS` hang-cap (sized for 3-item translate) timed out 15-item score JSON and bilingual 16-bullet TL;DR before any model emitted tokens — which matches score/tldr 100% fail / 0 tokens while Gemma-led translate still scored some tokens.

Clustering sent the whole comma-separated `ANYROUTER_MODEL` string as a single model id.

## Fix

- `LLM_STEP`: `retries: 0`, 4-minute timeout on score / translate / merge / tldr / backfill-score / record-run; catch failures and **do not rethrow** so `finally` always inserts `workflow_runs`.
- Score batches of 5 with a **70s** hang-cap; TL;DR **90s** hang-cap; translate stays 25s.
- Clustering uses the first chain id.
- `workflow_dispatch` POSTs `?force=1` so a 45-minute coalesce window cannot skip a manual unstick. Scheduled watchdog POSTs stay coalesced.

No Worker cron. No Workflow `schedules`. Does not touch #1362, #1365, #1399.

## Verify (do not wait for or invent a cron fire)

1. Deploy `duyet-news` from this PR.
2. Manual **News Ingest** `workflow_dispatch` (this yml now POSTs `?force=1`). Treat Actions SUCCESS as POST 2xx only.
3. Poll `GET https://news.duyet.net/api/system` (no admin token): `lastRun.id` must change from `42d830a9-…`, `lastRun.finished_at` today, `runsToday > 0`. `lastRun.stats.steps` should include `score` / `tldr` (success, skip, or caught failure) and not omit `record-run`.
4. Same payload: score/tldr `llmCallsPerDay` for today must not stay 100% fail / 0 tokens after the run. Translate may still be partial.
5. Do **not** treat a `:05/:20/:35/:50` schedule as having fired unless GitHub Actions shows a `schedule` run. The DO alarm is independent of that.

Closes #1401.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-936baaf6-aab5-46c1-9cce-483a73571f1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-936baaf6-aab5-46c1-9cce-483a73571f1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Ensure failed LLM processing does not prevent ingest runs from being recorded while improving execution reliability and manual recovery.

Bug Fixes:
- Ensure every ingest attempt records a completed workflow run even when LLM processing steps fail.
- Prevent score and TL;DR processing from timing out before models can respond, and correctly handle fallback model chains for clustering.
- Allow manually dispatched ingest workflows to bypass the scheduler coalescing window.

Enhancements:
- Make LLM-heavy workflow steps failure-tolerant so later processing and run reporting can continue.

Documentation:
- Document forced manual ingest behavior, LLM timeout limits, batch sizing, and verification through the system status API.

Tests:
- Add coverage for forced ingest propagation, fallback-chain model selection, and task-specific LLM timeout and batch settings.