### PR TITLE
fix(news): persist ingest workflow_runs at create()

### DIFF
--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -11,12 +11,15 @@ Both paths coalesce: a new instance is skipped if one started in the last
 45 minutes. `POST /api/admin/ingest?force=1` (workflow_dispatch) bypasses
 the window. LLM-heavy Workflow steps use `retries: 0` and a 4-minute
 timeout; a failed score/TL;DR call must not abort close-run. `open-run`
-upserts `workflow_runs` before fetch/LLM so `/api/system` `lastRun` moves
-even if a later step is terminated. Score and
+upserts `workflow_runs` at Workflow `create()` (the POST `{id}`) and again
+at `run()` start **before** `pruneLlmCalls` / fetch / LLM, so `/api/system`
+`lastRun` moves even when the instance is still queued or prune is slow.
+Do not wrap `open-run` in `safeStep`. Score and
 TL;DR hang-cap per model at 70s/90s (translate stays 25s). Do not treat
 GitHub Actions SUCCESS as a finished ingest — poll `GET /api/system`
-(no-store) until `lastRun.id` changes; do not invent a `:05/:20/:35/:50`
-schedule fire.
+(no-store) until `lastRun.id` matches the POST `id` (or at least is no
+longer the previous id) and `runsToday > 0`. Do not invent a
+`:05/:20/:35/:50` schedule fire.
 
 ## Pipeline (per hourly run)
 

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -55,8 +55,9 @@ coalesce if a run started in the last 45 minutes. Manual
 skip. Actions SUCCESS is only the POST; poll `GET /api/system` (no admin
 token, `Cache-Control: no-store`) until `lastRun.id` is no longer the
 previous id and `runsToday > 0`. The POST JSON `id` is the Cloudflare
-Workflow instance id and matches `workflow_runs.id` after `open-run`.
-Do not invent a scheduled `:05/:20/:35/:50` fire.
+Workflow instance id and is written to `workflow_runs` when `create()`
+returns (before `run()` / `open-run` may start). Do not invent a
+scheduled `:05/:20/:35/:50` fire.
 
 ## Admin API / MCP
 

--- a/apps/news/worker/__tests__/admin.test.ts
+++ b/apps/news/worker/__tests__/admin.test.ts
@@ -338,6 +338,39 @@ class FakeD1 {
       return { results: [] };
     }
 
+    if (sql.startsWith("INSERT INTO workflow_runs")) {
+      const [
+        id,
+        started_at,
+        finished_at,
+        items_fetched,
+        items_new,
+        error,
+        stats,
+      ] = args as [
+        string,
+        number,
+        number,
+        number,
+        number,
+        string | null,
+        string | null,
+      ];
+      const existing = this.workflowRuns.find((r) => r.id === id);
+      const row = {
+        id,
+        started_at,
+        finished_at,
+        items_fetched,
+        items_new,
+        error,
+        stats,
+      };
+      if (existing) Object.assign(existing, row);
+      else this.workflowRuns.push(row);
+      return { success: true };
+    }
+
     if (sql.startsWith("INSERT INTO admin_audit")) {
       return { success: true };
     }
@@ -821,6 +854,9 @@ describe("triggerIngest", () => {
     const result = await triggerIngest(env);
     expect(result).toEqual({ id: "wf-123", skipped: false });
     expect(env.NEWS_INGEST.create).toHaveBeenCalledOnce();
+    const runs = (env.DB as unknown as FakeD1).workflowRuns;
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe("wf-123");
   });
 
   it("returns a skipped tick from the scheduler without creating a workflow", async () => {
@@ -844,6 +880,7 @@ describe("triggerIngest", () => {
       reason: "ran recently",
     });
     expect(create).not.toHaveBeenCalled();
+    expect((env.DB as unknown as FakeD1).workflowRuns).toHaveLength(0);
   });
 
   it("passes force through to the scheduler tick", async () => {
@@ -860,6 +897,9 @@ describe("triggerIngest", () => {
     const result = await triggerIngest(env, { force: true });
     expect(result).toEqual({ id: "wf-forced", skipped: false });
     expect(tick).toHaveBeenCalledWith({ force: true });
+    const runs = (env.DB as unknown as FakeD1).workflowRuns;
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe("wf-forced");
   });
 });
 

--- a/apps/news/worker/__tests__/ingest-schedule.test.ts
+++ b/apps/news/worker/__tests__/ingest-schedule.test.ts
@@ -7,9 +7,11 @@ import {
   INGEST_MIN_INTERVAL_MS,
   INGEST_SCHEDULER_NAME,
   nextAlarmAt,
+  persistCreatedIngestRun,
   shouldSkipIngest,
   tickIngest,
 } from "../ingest-schedule.js";
+import { UPSERT_WORKFLOW_RUN_SQL } from "../workflow-run.js";
 
 describe("shouldSkipIngest", () => {
   it("runs when there is no previous start", () => {
@@ -57,6 +59,24 @@ describe("tickIngest", () => {
     expect(result).toEqual({ id: "wf-1", skipped: false });
   });
 
+  it("writes workflow_runs with the create() id before returning", async () => {
+    const run = vi.fn().mockResolvedValue(undefined);
+    const bind = vi.fn().mockReturnValue({ run });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const create = vi.fn().mockResolvedValue({
+      id: "532028af-065f-422a-91a5-c342c5c84b85",
+    });
+    const result = await tickIngest({
+      DB: { prepare },
+      NEWS_INGEST: { create } as unknown as Workflow,
+    });
+    expect(result.id).toBe("532028af-065f-422a-91a5-c342c5c84b85");
+    expect(prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
+    expect(bind.mock.calls[0]?.[0]).toBe(
+      "532028af-065f-422a-91a5-c342c5c84b85"
+    );
+  });
+
   it("delegates to the Durable Object stub when bound", async () => {
     const tick = vi.fn().mockResolvedValue({
       id: "wf-2",
@@ -74,6 +94,17 @@ describe("tickIngest", () => {
     });
     expect(tick).toHaveBeenCalledWith({});
     expect(result).toEqual({ id: "wf-2", skipped: false });
+  });
+});
+
+describe("persistCreatedIngestRun", () => {
+  it("skips skipped ticks", async () => {
+    const prepare = vi.fn();
+    await persistCreatedIngestRun(
+      { prepare },
+      { id: null, skipped: true, reason: "ran recently" }
+    );
+    expect(prepare).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/news/worker/__tests__/schedule.test.ts
+++ b/apps/news/worker/__tests__/schedule.test.ts
@@ -186,4 +186,14 @@ describe("backfill-translate checkpoints", () => {
     expect(openIdx).toBeGreaterThan(0);
     expect(openIdx).toBeLessThan(fetchIdx);
   });
+
+  it("persists workflow_runs before pruneLlmCalls and without safeStep", () => {
+    const persistIdx = workflow.indexOf(
+      'persistOpenedWorkflowRun(this.env.DB, runId, startedAt, "open-run")'
+    );
+    const pruneIdx = workflow.indexOf("await pruneLlmCalls(this.env)");
+    expect(persistIdx).toBeGreaterThan(0);
+    expect(persistIdx).toBeLessThan(pruneIdx);
+    expect(workflow).not.toMatch(/safeStep\(\s*step,\s*"open-run"/);
+  });
 });

--- a/apps/news/worker/__tests__/workflow-run.test.ts
+++ b/apps/news/worker/__tests__/workflow-run.test.ts
@@ -3,6 +3,8 @@ import {
   ingestRunId,
   jsonMap,
   mapEntries,
+  openedWorkflowRun,
+  persistOpenedWorkflowRun,
   persistWorkflowRun,
   UPSERT_WORKFLOW_RUN_SQL,
 } from "../workflow-run.js";
@@ -78,5 +80,36 @@ describe("ingestRunId", () => {
     expect(id).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     );
+  });
+});
+
+describe("openedWorkflowRun", () => {
+  it("sets finished_at to started_at so runsToday counts the open row", () => {
+    const row = openedWorkflowRun("wf-1", 1_700_000_000, "create");
+    expect(row.id).toBe("wf-1");
+    expect(row.startedAt).toBe(1_700_000_000);
+    expect(row.finishedAt).toBe(1_700_000_000);
+    expect(row.itemsFetched).toBe(0);
+    expect(JSON.parse(row.statsJson).steps).toEqual([
+      { name: "create", action: "started" },
+    ]);
+  });
+});
+
+describe("persistOpenedWorkflowRun", () => {
+  it("no-ops without a db or id", async () => {
+    await persistOpenedWorkflowRun(undefined, "wf-1", 1, "create");
+    await persistOpenedWorkflowRun({ prepare: vi.fn() }, null, 1, "open-run");
+  });
+
+  it("swallows D1 failures so create() still returns the instance id", async () => {
+    const prepare = vi.fn().mockReturnValue({
+      bind: () => ({
+        run: () => Promise.reject(new Error("D1 unavailable")),
+      }),
+    });
+    await expect(
+      persistOpenedWorkflowRun({ prepare }, "wf-1", 1, "create")
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/news/worker/ingest-schedule.ts
+++ b/apps/news/worker/ingest-schedule.ts
@@ -1,3 +1,6 @@
+import { toEpochSeconds } from "./time.js";
+import { type D1Runner, persistOpenedWorkflowRun } from "./workflow-run.js";
+
 /** Coalescing rules for news ingest triggers (GitHub Actions, admin POST,
  * Durable Object alarm). Kept free of `cloudflare:workers` so node tests
  * can import them. */
@@ -32,6 +35,7 @@ export interface IngestSchedulerRpc {
 
 export async function tickIngest(
   env: {
+    DB?: D1Runner;
     NEWS_INGEST: Workflow;
     NEWS_INGEST_SCHEDULER?: DurableObjectNamespace;
   },
@@ -42,10 +46,31 @@ export async function tickIngest(
     const stub = ns.get(
       ns.idFromName(INGEST_SCHEDULER_NAME)
     ) as unknown as IngestSchedulerRpc;
-    return stub.tick(opts);
+    const result = await stub.tick(opts);
+    await persistCreatedIngestRun(env.DB, result);
+    return result;
   }
   const instance = await env.NEWS_INGEST.create();
-  return { id: instance.id, skipped: false };
+  const result: IngestTickResult = { id: instance.id, skipped: false };
+  await persistCreatedIngestRun(env.DB, result);
+  return result;
+}
+
+/** `create()` returns an id before `NewsIngestWorkflow.run()` (and
+ * `open-run`) may execute — instances can sit queued behind an in-flight
+ * ingest. Write `workflow_runs` here so lastRun.id matches the POST body
+ * as soon as the trigger returns. */
+export async function persistCreatedIngestRun(
+  db: D1Runner | undefined,
+  result: IngestTickResult
+): Promise<void> {
+  if (result.skipped || !result.id) return;
+  await persistOpenedWorkflowRun(
+    db,
+    result.id,
+    toEpochSeconds(Date.now()),
+    "create"
+  );
 }
 
 export async function ensureIngestAlarm(env: {

--- a/apps/news/worker/ingest-scheduler.ts
+++ b/apps/news/worker/ingest-scheduler.ts
@@ -3,6 +3,7 @@ import {
   armAlarmAt,
   type IngestTickResult,
   nextAlarmAt,
+  persistCreatedIngestRun,
   shouldSkipIngest,
 } from "./ingest-schedule.js";
 import type { Env } from "./types.js";
@@ -35,7 +36,12 @@ export class NewsIngestScheduler extends DurableObject<Env> {
     try {
       const instance = await this.env.NEWS_INGEST.create();
       await this.ctx.storage.put(LAST_STARTED_KEY, now);
-      return { id: instance.id, skipped: false };
+      const result: IngestTickResult = {
+        id: instance.id,
+        skipped: false,
+      };
+      await persistCreatedIngestRun(this.env.DB, result);
+      return result;
     } catch (error) {
       console.error("ingest scheduler create failed:", error);
       return {

--- a/apps/news/worker/workflow-run.ts
+++ b/apps/news/worker/workflow-run.ts
@@ -1,4 +1,5 @@
 import { nn } from "./d1-bind.js";
+import { buildRunStats, serializeRunStats } from "./run-stats.js";
 
 /** Upsert used by ingest open-run / close-run. ON CONFLICT so a Workflow
  * replay, a JS `finally`, and the durable `close-run` step can all write
@@ -44,6 +45,46 @@ export async function persistWorkflowRun(
       nn(row.statsJson)
     )
     .run();
+}
+
+export type OpenedRunStepName = "create" | "open-run";
+
+/** Row written at Workflow `create()` and again at `run()` start so
+ * `/api/system` lastRun.id matches the POST id before fetch/LLM. */
+export function openedWorkflowRun(
+  id: string,
+  startedAt: number,
+  stepName: OpenedRunStepName
+): WorkflowRunRecord {
+  return {
+    id,
+    startedAt,
+    finishedAt: startedAt,
+    itemsFetched: 0,
+    itemsNew: 0,
+    error: null,
+    statsJson: serializeRunStats(
+      buildRunStats({
+        steps: [{ name: stepName, action: "started" }],
+      })
+    ),
+  };
+}
+
+/** Best-effort upsert. Never throws — `create()` already succeeded, and
+ * ingest must continue even if this observability write fails. */
+export async function persistOpenedWorkflowRun(
+  db: D1Runner | undefined,
+  id: string | null | undefined,
+  startedAt: number,
+  stepName: OpenedRunStepName
+): Promise<void> {
+  if (!db || !id) return;
+  try {
+    await persistWorkflowRun(db, openedWorkflowRun(id, startedAt, stepName));
+  } catch (error) {
+    console.error(`${stepName} d1 failed:`, error);
+  }
 }
 
 /** Cloudflare Workflows JSON-serialize step returns. `Map` becomes `{}`,

--- a/apps/news/worker/workflow.ts
+++ b/apps/news/worker/workflow.ts
@@ -51,12 +51,6 @@ import {
   recordStep,
   serializeRunStats,
 } from "./run-stats.js";
-import {
-  ingestRunId,
-  jsonMap,
-  mapEntries,
-  persistWorkflowRun,
-} from "./workflow-run.js";
 import { fetchStoryDetailByUrl } from "./sources/huggingnews.js";
 import { adapters } from "./sources/registry.js";
 import type { FetchedItem, FetchedItemSource } from "./sources/types.js";
@@ -64,11 +58,18 @@ import { reviewPendingSubmissions } from "./submissions.js";
 import { sendDailyTldr } from "./subscribe/send.js";
 import { reviewPendingSuggestions } from "./suggestions.js";
 import { toEpochSeconds } from "./time.js";
-import { looksVietnamese } from "./tldr-lang.js";
 import { ensureDailyTldr } from "./tldr.js";
+import { looksVietnamese } from "./tldr-lang.js";
 import { MAX_MERGED_TOPICS, normalizeTopics, unionTopics } from "./topics.js";
 import { ratePendingTranslations } from "./translation-qa.js";
 import type { Env } from "./types.js";
+import {
+  ingestRunId,
+  jsonMap,
+  mapEntries,
+  persistOpenedWorkflowRun,
+  persistWorkflowRun,
+} from "./workflow-run.js";
 
 const RELEVANCE_THRESHOLD = 0.4;
 const RANK_RECOMPUTE_WINDOW_SEC = 72 * 60 * 60;
@@ -201,7 +202,7 @@ interface ItemRow {
 }
 
 export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
-  async run(_event: WorkflowEvent<unknown>, step: WorkflowStep) {
+  async run(event: WorkflowEvent<unknown>, step: WorkflowStep) {
     let itemsFetched = 0;
     let itemsNew = 0;
     let runError: string | null = null;
@@ -227,6 +228,17 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
     let notifyReason: Record<string, NotifyChannelReason> = {};
     const steps: RunStepInfo[] = [];
 
+    // POST /api/admin/ingest `{id}` is the Workflow instance id. Persist
+    // that row before prune/fetch/LLM and before any step.do: create() can
+    // return while run() is still queued, pruneLlmCalls can run for minutes
+    // on a large llm_calls table, and wrapping the first step.do in
+    // safeStep can return a fallback without executing the upsert.
+    const runId = ingestRunId(event);
+    const startedAt = toEpochSeconds(
+      event.timestamp instanceof Date ? event.timestamp.getTime() : Date.now()
+    );
+    await persistOpenedWorkflowRun(this.env.DB, runId, startedAt, "open-run");
+
     // Installs the D1-backed llm_calls logger so every scoreItems/
     // translateItems/generateTldr call below (and everything else that
     // routes through callAnyrouter) gets an observability row. Plain code,
@@ -234,39 +246,15 @@ export class NewsIngestWorkflow extends WorkflowEntrypoint<Env> {
     // reinstalls the same closure and re-runs an idempotent DELETE), and
     // it must never affect run-error tracking below.
     setLlmCallLogger(createD1LlmCallLogger(this.env));
-    await pruneLlmCalls(this.env);
 
-    // Insert workflow_runs before any LLM/fetch step. A later engine-level
-    // step failure skips remaining step.do (including close-run in finally);
-    // this row still moves /api/system lastRun.id and runsToday.
-    const opened = await safeStep(
-      step,
-      "open-run",
-      {
-        id: ingestRunId(_event as { instanceId?: string }),
-        startedAt: toEpochSeconds(Date.now()),
-      },
-      async () => {
-        const id = ingestRunId(_event as { instanceId?: string });
-        const startedAt = toEpochSeconds(Date.now());
-        await persistWorkflowRun(this.env.DB, {
-          id,
-          startedAt,
-          finishedAt: startedAt,
-          itemsFetched: 0,
-          itemsNew: 0,
-          error: null,
-          statsJson: serializeRunStats(
-            buildRunStats({
-              steps: [{ name: "open-run", action: "started" }],
-            })
-          ),
-        });
-        return { id, startedAt };
-      }
-    );
-    const runId = opened.id;
-    const startedAt = opened.startedAt;
+    // Durable duplicate of the open-run upsert. Do not wrap in safeStep:
+    // a caught engine yield would skip the callback and look like success.
+    await step.do("open-run", async () => {
+      await persistOpenedWorkflowRun(this.env.DB, runId, startedAt, "open-run");
+      return { id: runId, startedAt };
+    });
+
+    await pruneLlmCalls(this.env);
 
     try {
       const sources = await safeStep(step, "load-sources", [], async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes leftover https://github.com/duyet/monorepo/issues/1408 after #1405.

## What I found (not a schedule fire)

Live `GET https://news.duyet.net/api/system` still showed `lastRun.id` `42d830a9-689c-4e9a-9e91-98e812016b97` (finished 2026-08-26 ICT), `runsToday` 0, `Cache-Control: no-store` (so the #1405 cache fix is live). Same D1 in that payload: `itemsPerDay` for 2026-08-28 is 15, `latestTldrDate` 2026-08-28, `llmCallsPerDay` translate still climbing (~1952 / fail ~1930 when I fetched). `532028af-…` is not in `runs[]`.

Confirmed, not invented:

- Force News Ingest [33156341919](https://github.com/duyet/monorepo/actions/runs/33156341919) POSTed `{id: 532028af-…, skipped: false}`. That is Cloudflare Workflow `create()`, not a `workflow_runs` row.
- Recert ~2 minutes later still had lastRun `42d830a9`. Translate counts at dispatch were already ~1726 — that work is a long-running instance, not two minutes of a new run.
- `duyet-news` `modified_on` 2026-08-28T08:40:42Z (after #1405 merge 08:39:07Z). The fetch Worker is the new deploy (`no-store`). Last real **schedule** News Ingest remains 2026-08-27 23:38 UTC on `5a771c1a`. No `:05/:20/:35/:50` fire is claimed.

`lastRun` is `ORDER BY started_at DESC LIMIT 30` with no `finished_at` filter — an open row would show. Same `/api/system` D1 as `llm_calls` / `items`. Discarded: hidden open row; different D1 than lastRun.

#1405 only upserted inside `safeStep(step.do("open-run"))` **after** `await pruneLlmCalls()`, and the matching HTTP persist was only in `finally` after fetch/LLM. That is too late when:

1. `create()` returns while `run()` is still **queued** behind an in-flight ingest (force bypasses the 45-minute coalesce).
2. `pruneLlmCalls` is an unbounded `DELETE` on a large `llm_calls` table **before** the first upsert.
3. Wrapping the first `step.do` in `safeStep` can return the fallback `{id, startedAt}` without running the upsert, then continue into fetch/LLM.

## Fix

- `tickIngest` / `NewsIngestScheduler.tick` upsert `workflow_runs` with the `create()` id before the POST returns.
- `run()` upserts again immediately (direct D1, then `step.do("open-run")` **not** wrapped in `safeStep`) **before** `pruneLlmCalls` / fetch / LLM.
- `close-run` upsert unchanged. No Worker cron. No Workflow `schedules`. Does not touch #1362, #1365, or #1407.

## Verify (do not wait for or invent a cron fire)

1. Deploy `duyet-news` from this PR.
2. Manual **News Ingest** `workflow_dispatch` (yml POSTs `?force=1`). Treat Actions SUCCESS as POST 2xx only. Note the JSON `id`.
3. Poll `GET https://news.duyet.net/api/system` (no admin token): `lastRun.id` must leave `42d830a9-…` and should match the POST `id`. `runsToday > 0`. `finished_at` is today (set on create/open, updated on close). This should be visible as soon as the POST returns, not after ingest finishes.
4. Do **not** treat a `:05/:20/:35/:50` schedule as having fired unless GitHub Actions shows a `schedule` run.

Closes #1408.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17ce1d43-2167-45f8-94d3-c8ffcb7a58a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17ce1d43-2167-45f8-94d3-c8ffcb7a58a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Persist news ingest workflow runs at creation and execution start so monitoring reflects newly triggered runs without waiting for processing to begin.

Bug Fixes:
- Persist news ingest workflow runs as soon as a workflow is created, ensuring system status reflects queued and active runs immediately.

Enhancements:
- Record the workflow run again at execution start before maintenance or ingest processing, while keeping the existing close-run updates intact.

Documentation:
- Update news ingest documentation with the earlier workflow-run persistence and verification behavior.

Tests:
- Add coverage for create-time run persistence, skipped ingests, D1 failures, and ordering before pruning and ingest work.