### PR TITLE
fix(news): persist workflow_runs before Workflow create()

### DIFF
--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -10,11 +10,15 @@ watchdog because GitHub routinely delays or skips scheduled workflows.
 Both paths coalesce: a new instance is skipped if one started in the last
 45 minutes. `POST /api/admin/ingest?force=1` (workflow_dispatch) bypasses
 the window. LLM-heavy Workflow steps use `retries: 0` and a 4-minute
-timeout; a failed score/TL;DR call must not abort close-run. `open-run`
-upserts `workflow_runs` at Workflow `create()` (the POST `{id}`) and again
-at `run()` start **before** `pruneLlmCalls` / fetch / LLM, so `/api/system`
-`lastRun` moves even when the instance is still queued or prune is slow.
-Do not wrap `open-run` in `safeStep`. Score and
+timeout; a failed score/TL;DR call must not abort close-run. HTTP
+`POST /api/admin/ingest` picks the instance uuid, **upserts and
+read-back-verifies** `workflow_runs` on the Worker D1 binding, then
+calls `NEWS_INGEST.create({ id })` (the Durable Object only gates the
+45-minute coalesce and performs create). Do not swallow that D1 write:
+#1409 upserted after `create()` and caught errors, so live POST
+`9a1002fa-…` never became `lastRun`. `run()` still upserts at start
+**before** `pruneLlmCalls` / fetch / LLM. Do not wrap `open-run` in
+`safeStep`. Score and
 TL;DR hang-cap per model at 70s/90s (translate stays 25s). Do not treat
 GitHub Actions SUCCESS as a finished ingest — poll `GET /api/system`
 (no-store) until `lastRun.id` matches the POST `id` (or at least is no

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -54,10 +54,10 @@ coalesce if a run started in the last 45 minutes. Manual
 `workflow_dispatch` sends `?force=1` so a hung coalesce window cannot
 skip. Actions SUCCESS is only the POST; poll `GET /api/system` (no admin
 token, `Cache-Control: no-store`) until `lastRun.id` is no longer the
-previous id and `runsToday > 0`. The POST JSON `id` is the Cloudflare
-Workflow instance id and is written to `workflow_runs` when `create()`
-returns (before `run()` / `open-run` may start). Do not invent a
-scheduled `:05/:20/:35/:50` fire.
+previous id and `runsToday > 0`. The POST JSON `id` is chosen before
+`NEWS_INGEST.create({ id })` and is written (then SELECT-verified) to
+`workflow_runs` before the POST returns — not after ingest finishes.
+Do not invent a scheduled `:05/:20/:35/:50` fire.
 
 ## Admin API / MCP
 

--- a/apps/news/worker/__tests__/admin.test.ts
+++ b/apps/news/worker/__tests__/admin.test.ts
@@ -55,6 +55,12 @@ class FakeD1 {
   }
 
   private exec(sql: string, args: unknown[]): unknown {
+    if (sql.startsWith("SELECT id FROM workflow_runs WHERE id = ?")) {
+      const [id] = args as [string];
+      const row = this.workflowRuns.find((r) => r.id === id);
+      return row ? { id: row.id } : null;
+    }
+
     if (sql.startsWith("SELECT id FROM items WHERE id = ?")) {
       const [id] = args as [string];
       const row = this.items.get(id);
@@ -852,25 +858,34 @@ describe("triggerIngest", () => {
   it("creates a workflow instance when no scheduler is bound", async () => {
     const env = makeEnv();
     const result = await triggerIngest(env);
-    expect(result).toEqual({ id: "wf-123", skipped: false });
-    expect(env.NEWS_INGEST.create).toHaveBeenCalledOnce();
+    expect(result.skipped).toBe(false);
+    expect(result.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+    expect(env.NEWS_INGEST.create).toHaveBeenCalledWith({ id: result.id });
     const runs = (env.DB as unknown as FakeD1).workflowRuns;
     expect(runs).toHaveLength(1);
-    expect(runs[0]?.id).toBe("wf-123");
+    expect(runs[0]?.id).toBe(result.id);
   });
 
   it("returns a skipped tick from the scheduler without creating a workflow", async () => {
     const create = vi.fn();
-    const tick = vi.fn().mockResolvedValue({
+    const canStart = vi.fn().mockResolvedValue({
       id: null,
       skipped: true,
       reason: "ran recently",
     });
+    const startInstance = vi.fn();
     const env = makeEnv({
       NEWS_INGEST: { create } as unknown as Workflow,
       NEWS_INGEST_SCHEDULER: {
         idFromName: () => "id",
-        get: () => ({ tick, ensureArmed: vi.fn() }),
+        get: () => ({
+          tick: vi.fn(),
+          canStart,
+          startInstance,
+          ensureArmed: vi.fn(),
+        }),
       } as unknown as DurableObjectNamespace,
     });
     const result = await triggerIngest(env);
@@ -880,26 +895,37 @@ describe("triggerIngest", () => {
       reason: "ran recently",
     });
     expect(create).not.toHaveBeenCalled();
+    expect(startInstance).not.toHaveBeenCalled();
     expect((env.DB as unknown as FakeD1).workflowRuns).toHaveLength(0);
   });
 
-  it("passes force through to the scheduler tick", async () => {
-    const tick = vi.fn().mockResolvedValue({
-      id: "wf-forced",
+  it("persists workflow_runs before startInstance when force is set", async () => {
+    const canStart = vi.fn().mockResolvedValue({
+      id: null,
       skipped: false,
     });
+    const startInstance = vi.fn(async (id: string) => ({
+      id,
+      skipped: false,
+    }));
     const env = makeEnv({
       NEWS_INGEST_SCHEDULER: {
         idFromName: () => "id",
-        get: () => ({ tick, ensureArmed: vi.fn() }),
+        get: () => ({
+          tick: vi.fn(),
+          canStart,
+          startInstance,
+          ensureArmed: vi.fn(),
+        }),
       } as unknown as DurableObjectNamespace,
     });
     const result = await triggerIngest(env, { force: true });
-    expect(result).toEqual({ id: "wf-forced", skipped: false });
-    expect(tick).toHaveBeenCalledWith({ force: true });
+    expect(canStart).toHaveBeenCalledWith({ force: true });
+    expect(result.skipped).toBe(false);
+    expect(startInstance).toHaveBeenCalledWith(result.id);
     const runs = (env.DB as unknown as FakeD1).workflowRuns;
     expect(runs).toHaveLength(1);
-    expect(runs[0]?.id).toBe("wf-forced");
+    expect(runs[0]?.id).toBe(result.id);
   });
 });
 

--- a/apps/news/worker/__tests__/ingest-schedule.test.ts
+++ b/apps/news/worker/__tests__/ingest-schedule.test.ts
@@ -8,10 +8,28 @@ import {
   INGEST_SCHEDULER_NAME,
   nextAlarmAt,
   persistCreatedIngestRun,
+  persistCreatedIngestRunVerified,
   shouldSkipIngest,
   tickIngest,
 } from "../ingest-schedule.js";
-import { UPSERT_WORKFLOW_RUN_SQL } from "../workflow-run.js";
+import {
+  type D1Runner,
+  SELECT_WORKFLOW_RUN_ID_SQL,
+  UPSERT_WORKFLOW_RUN_SQL,
+} from "../workflow-run.js";
+
+function trackingDb(order: string[]): D1Runner {
+  const prepare = vi.fn((sql: string) => {
+    order.push(sql.startsWith("INSERT") ? "persist" : "verify");
+    return {
+      bind: (...args: unknown[]) => ({
+        run: async () => ({ success: true }),
+        first: async <T>() => ({ id: args[0] as string }) as T,
+      }),
+    };
+  });
+  return { prepare };
+}
 
 describe("shouldSkipIngest", () => {
   it("runs when there is no previous start", () => {
@@ -50,50 +68,100 @@ describe("alarm timestamps", () => {
 });
 
 describe("tickIngest", () => {
-  it("falls back to NEWS_INGEST.create when no scheduler is bound", async () => {
+  it("falls back to NEWS_INGEST.create({ id }) when no scheduler is bound", async () => {
     const create = vi.fn().mockResolvedValue({ id: "wf-1" });
     const result = await tickIngest({
       NEWS_INGEST: { create } as unknown as Workflow,
     });
-    expect(create).toHaveBeenCalledOnce();
-    expect(result).toEqual({ id: "wf-1", skipped: false });
+    expect(result.skipped).toBe(false);
+    expect(create).toHaveBeenCalledWith({ id: result.id });
   });
 
-  it("writes workflow_runs with the create() id before returning", async () => {
-    const run = vi.fn().mockResolvedValue(undefined);
-    const bind = vi.fn().mockReturnValue({ run });
-    const prepare = vi.fn().mockReturnValue({ bind });
-    const create = vi.fn().mockResolvedValue({
-      id: "532028af-065f-422a-91a5-c342c5c84b85",
+  it("writes and verifies workflow_runs before create()", async () => {
+    const order: string[] = [];
+    const db = trackingDb(order);
+    const create = vi.fn(async (opts?: { id?: string }) => {
+      order.push("create");
+      return { id: opts?.id };
     });
+    const result = await tickIngest({
+      DB: db,
+      NEWS_INGEST: { create } as unknown as Workflow,
+    });
+    expect(result.skipped).toBe(false);
+    expect(order).toEqual(["persist", "verify", "create"]);
+    expect(create).toHaveBeenCalledWith({ id: result.id });
+    expect(db.prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
+    expect(db.prepare).toHaveBeenCalledWith(SELECT_WORKFLOW_RUN_ID_SQL);
+  });
+
+  it("persists on the Worker DB before startInstance when the scheduler is bound", async () => {
+    const order: string[] = [];
+    const db = trackingDb(order);
+    const canStart = vi.fn(async () => {
+      order.push("gate");
+      return { id: null, skipped: false };
+    });
+    const startInstance = vi.fn(async (id: string) => {
+      order.push("create");
+      return { id, skipped: false };
+    });
+    const create = vi.fn();
+    const result = await tickIngest(
+      {
+        DB: db,
+        NEWS_INGEST: { create } as unknown as Workflow,
+        NEWS_INGEST_SCHEDULER: {
+          idFromName: (name: string) => {
+            expect(name).toBe(INGEST_SCHEDULER_NAME);
+            return "id";
+          },
+          get: () => ({
+            tick: vi.fn(),
+            canStart,
+            startInstance,
+            ensureArmed: vi.fn(),
+          }),
+        } as unknown as DurableObjectNamespace,
+      },
+      { force: true }
+    );
+    expect(canStart).toHaveBeenCalledWith({ force: true });
+    expect(create).not.toHaveBeenCalled();
+    expect(startInstance).toHaveBeenCalledWith(result.id);
+    expect(order).toEqual(["gate", "persist", "verify", "create"]);
+    expect(db.prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
+  });
+
+  it("does not persist or create when the scheduler skips", async () => {
+    const prepare = vi.fn();
+    const startInstance = vi.fn();
+    const create = vi.fn();
     const result = await tickIngest({
       DB: { prepare },
       NEWS_INGEST: { create } as unknown as Workflow,
-    });
-    expect(result.id).toBe("532028af-065f-422a-91a5-c342c5c84b85");
-    expect(prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
-    expect(bind.mock.calls[0]?.[0]).toBe(
-      "532028af-065f-422a-91a5-c342c5c84b85"
-    );
-  });
-
-  it("delegates to the Durable Object stub when bound", async () => {
-    const tick = vi.fn().mockResolvedValue({
-      id: "wf-2",
-      skipped: false,
-    });
-    const result = await tickIngest({
-      NEWS_INGEST: { create: vi.fn() } as unknown as Workflow,
       NEWS_INGEST_SCHEDULER: {
-        idFromName: (name: string) => {
-          expect(name).toBe(INGEST_SCHEDULER_NAME);
-          return "id";
-        },
-        get: () => ({ tick, ensureArmed: vi.fn() }),
+        idFromName: () => "id",
+        get: () => ({
+          tick: vi.fn(),
+          canStart: vi.fn().mockResolvedValue({
+            id: null,
+            skipped: true,
+            reason: "ran recently",
+          }),
+          startInstance,
+          ensureArmed: vi.fn(),
+        }),
       } as unknown as DurableObjectNamespace,
     });
-    expect(tick).toHaveBeenCalledWith({});
-    expect(result).toEqual({ id: "wf-2", skipped: false });
+    expect(result).toEqual({
+      id: null,
+      skipped: true,
+      reason: "ran recently",
+    });
+    expect(prepare).not.toHaveBeenCalled();
+    expect(startInstance).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
   });
 });
 
@@ -108,6 +176,23 @@ describe("persistCreatedIngestRun", () => {
   });
 });
 
+describe("persistCreatedIngestRunVerified", () => {
+  it("throws when D1 does not read back the row", async () => {
+    const prepare = vi.fn().mockReturnValue({
+      bind: () => ({
+        run: async () => ({ success: true }),
+        first: async () => null,
+      }),
+    });
+    await expect(
+      persistCreatedIngestRunVerified(
+        { prepare },
+        { id: "wf-missing", skipped: false }
+      )
+    ).rejects.toThrow(/verify missed wf-missing/);
+  });
+});
+
 describe("ensureIngestAlarm", () => {
   it("is a no-op without a scheduler binding", async () => {
     await expect(ensureIngestAlarm({})).resolves.toBeUndefined();
@@ -118,7 +203,12 @@ describe("ensureIngestAlarm", () => {
     await ensureIngestAlarm({
       NEWS_INGEST_SCHEDULER: {
         idFromName: () => "id",
-        get: () => ({ tick: vi.fn(), ensureArmed }),
+        get: () => ({
+          tick: vi.fn(),
+          canStart: vi.fn(),
+          startInstance: vi.fn(),
+          ensureArmed,
+        }),
       } as unknown as DurableObjectNamespace,
     });
     expect(ensureArmed).toHaveBeenCalledOnce();

--- a/apps/news/worker/__tests__/schedule.test.ts
+++ b/apps/news/worker/__tests__/schedule.test.ts
@@ -197,3 +197,19 @@ describe("backfill-translate checkpoints", () => {
     expect(workflow).not.toMatch(/safeStep\(\s*step,\s*"open-run"/);
   });
 });
+
+describe("create-path workflow_runs persist", () => {
+  const ingestSchedule = readFileSync(
+    path.join(newsRoot, "worker/ingest-schedule.ts"),
+    "utf-8"
+  );
+
+  it("verifies D1 before NEWS_INGEST.create({ id })", () => {
+    const persistIdx = ingestSchedule.indexOf(
+      "persistCreatedIngestRunVerified"
+    );
+    const createIdx = ingestSchedule.indexOf("NEWS_INGEST.create({ id })");
+    expect(persistIdx).toBeGreaterThan(0);
+    expect(createIdx).toBeGreaterThan(persistIdx);
+  });
+});

--- a/apps/news/worker/__tests__/workflow-run.test.ts
+++ b/apps/news/worker/__tests__/workflow-run.test.ts
@@ -5,7 +5,9 @@ import {
   mapEntries,
   openedWorkflowRun,
   persistOpenedWorkflowRun,
+  persistOpenedWorkflowRunVerified,
   persistWorkflowRun,
+  SELECT_WORKFLOW_RUN_ID_SQL,
   UPSERT_WORKFLOW_RUN_SQL,
 } from "../workflow-run.js";
 
@@ -22,8 +24,9 @@ describe("UPSERT_WORKFLOW_RUN_SQL", () => {
 
 describe("persistWorkflowRun", () => {
   it("binds the row onto the upsert statement", async () => {
-    const run = vi.fn().mockResolvedValue(undefined);
-    const bind = vi.fn().mockReturnValue({ run });
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const first = vi.fn();
+    const bind = vi.fn().mockReturnValue({ run, first });
     const prepare = vi.fn().mockReturnValue({ bind });
     await persistWorkflowRun(
       { prepare },
@@ -106,10 +109,38 @@ describe("persistOpenedWorkflowRun", () => {
     const prepare = vi.fn().mockReturnValue({
       bind: () => ({
         run: () => Promise.reject(new Error("D1 unavailable")),
+        first: () => Promise.resolve(null),
       }),
     });
     await expect(
       persistOpenedWorkflowRun({ prepare }, "wf-1", 1, "create")
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("persistOpenedWorkflowRunVerified", () => {
+  it("upserts then reads the same id back", async () => {
+    const run = vi.fn().mockResolvedValue({ success: true });
+    const first = vi.fn().mockResolvedValue({ id: "wf-1" });
+    const bind = vi.fn().mockReturnValue({ run, first });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    await persistOpenedWorkflowRunVerified({ prepare }, "wf-1", 1, "create");
+    expect(prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
+    expect(prepare).toHaveBeenCalledWith(SELECT_WORKFLOW_RUN_ID_SQL);
+    expect(run).toHaveBeenCalledOnce();
+    expect(first).toHaveBeenCalledOnce();
+  });
+
+  it("throws after retries when verify misses", async () => {
+    const prepare = vi.fn().mockReturnValue({
+      bind: () => ({
+        run: async () => ({ success: true }),
+        first: async () => null,
+      }),
+    });
+    await expect(
+      persistOpenedWorkflowRunVerified({ prepare }, "wf-1", 1, "create")
+    ).rejects.toThrow(/verify missed wf-1/);
+    expect(prepare).toHaveBeenCalledTimes(6);
   });
 });

--- a/apps/news/worker/ingest-schedule.ts
+++ b/apps/news/worker/ingest-schedule.ts
@@ -1,5 +1,9 @@
 import { toEpochSeconds } from "./time.js";
-import { type D1Runner, persistOpenedWorkflowRun } from "./workflow-run.js";
+import {
+  type D1Runner,
+  persistOpenedWorkflowRun,
+  persistOpenedWorkflowRunVerified,
+} from "./workflow-run.js";
 
 /** Coalescing rules for news ingest triggers (GitHub Actions, admin POST,
  * Durable Object alarm). Kept free of `cloudflare:workers` so node tests
@@ -26,11 +30,28 @@ export interface IngestTickResult {
   reason?: string;
 }
 
+export interface IngestTickOpts {
+  force?: boolean;
+}
+
 /** RPC surface of `NewsIngestScheduler`. Declared here so admin handlers
- * can call it without importing `cloudflare:workers`. */
+ * can call it without importing `cloudflare:workers`.
+ *
+ * HTTP ingest must persist `workflow_runs` on the Worker D1 binding
+ * **before** `NEWS_INGEST.create()`: #1409 upserted after create() (and
+ * swallowed D1 errors), and live POST `9a1002fa-…` never appeared in
+ * `/api/system`. Split gate/start so the Worker can write+verify first. */
 export interface IngestSchedulerRpc {
-  tick(opts?: { force?: boolean }): Promise<IngestTickResult>;
+  tick(opts?: IngestTickOpts): Promise<IngestTickResult>;
+  canStart(opts?: IngestTickOpts): Promise<IngestTickResult>;
+  startInstance(id: string): Promise<IngestTickResult>;
   ensureArmed(): Promise<void>;
+}
+
+function schedulerStub(ns: DurableObjectNamespace): IngestSchedulerRpc {
+  return ns.get(
+    ns.idFromName(INGEST_SCHEDULER_NAME)
+  ) as unknown as IngestSchedulerRpc;
 }
 
 export async function tickIngest(
@@ -39,27 +60,44 @@ export async function tickIngest(
     NEWS_INGEST: Workflow;
     NEWS_INGEST_SCHEDULER?: DurableObjectNamespace;
   },
-  opts: { force?: boolean } = {}
+  opts: IngestTickOpts = {}
 ): Promise<IngestTickResult> {
   if (env.NEWS_INGEST_SCHEDULER) {
-    const ns = env.NEWS_INGEST_SCHEDULER;
-    const stub = ns.get(
-      ns.idFromName(INGEST_SCHEDULER_NAME)
-    ) as unknown as IngestSchedulerRpc;
-    const result = await stub.tick(opts);
-    await persistCreatedIngestRun(env.DB, result);
-    return result;
+    const stub = schedulerStub(env.NEWS_INGEST_SCHEDULER);
+    const gate = await stub.canStart(opts);
+    if (gate.skipped) return gate;
+    return startCreatedIngest(env, stub);
   }
-  const instance = await env.NEWS_INGEST.create();
-  const result: IngestTickResult = { id: instance.id, skipped: false };
-  await persistCreatedIngestRun(env.DB, result);
+  return startCreatedIngest(env);
+}
+
+/** Choose the instance id, persist+verify `workflow_runs`, then
+ * `create({ id })`. POST `{id}` is this uuid, not whatever create()
+ * would mint after a D1 write that may never commit. */
+async function startCreatedIngest(
+  env: {
+    DB?: D1Runner;
+    NEWS_INGEST: Workflow;
+  },
+  stub?: Pick<IngestSchedulerRpc, "startInstance">
+): Promise<IngestTickResult> {
+  const id = crypto.randomUUID();
+  const result: IngestTickResult = { id, skipped: false };
+  await persistCreatedIngestRunVerified(env.DB, result);
+  if (stub) {
+    const started = await stub.startInstance(id);
+    return {
+      id,
+      skipped: false,
+      reason: started.reason,
+    };
+  }
+  await env.NEWS_INGEST.create({ id });
   return result;
 }
 
-/** `create()` returns an id before `NewsIngestWorkflow.run()` (and
- * `open-run`) may execute — instances can sit queued behind an in-flight
- * ingest. Write `workflow_runs` here so lastRun.id matches the POST body
- * as soon as the trigger returns. */
+/** Best-effort upsert after the Durable Object alarm `create()`. HTTP
+ * ingest uses `persistCreatedIngestRunVerified` instead. */
 export async function persistCreatedIngestRun(
   db: D1Runner | undefined,
   result: IngestTickResult
@@ -73,21 +111,32 @@ export async function persistCreatedIngestRun(
   );
 }
 
+/** Must succeed before `create()` / POST 2xx. Throws if D1 does not
+ * read back the row. No-ops when DB is unbound (unit tests). */
+export async function persistCreatedIngestRunVerified(
+  db: D1Runner | undefined,
+  result: IngestTickResult
+): Promise<void> {
+  if (result.skipped || !result.id || !db) return;
+  await persistOpenedWorkflowRunVerified(
+    db,
+    result.id,
+    toEpochSeconds(Date.now()),
+    "create"
+  );
+}
+
 export async function ensureIngestAlarm(env: {
   NEWS_INGEST_SCHEDULER?: DurableObjectNamespace;
 }): Promise<void> {
   if (!env.NEWS_INGEST_SCHEDULER) return;
-  const ns = env.NEWS_INGEST_SCHEDULER;
-  const stub = ns.get(
-    ns.idFromName(INGEST_SCHEDULER_NAME)
-  ) as unknown as IngestSchedulerRpc;
-  await stub.ensureArmed();
+  await schedulerStub(env.NEWS_INGEST_SCHEDULER).ensureArmed();
 }
 
 export function shouldSkipIngest(
   lastStartedAt: number | null | undefined,
   now: number,
-  opts: { force?: boolean } = {}
+  opts: IngestTickOpts = {}
 ): boolean {
   if (opts.force) return false;
   if (lastStartedAt == null) return false;

--- a/apps/news/worker/ingest-scheduler.ts
+++ b/apps/news/worker/ingest-scheduler.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from "cloudflare:workers";
 import {
   armAlarmAt,
+  type IngestTickOpts,
   type IngestTickResult,
   nextAlarmAt,
   persistCreatedIngestRun,
@@ -14,13 +15,17 @@ const LAST_STARTED_KEY = "last_started_at";
  * Singleton Durable Object that fires hourly ingest without a Worker cron
  * trigger (Free accounts are capped at 5 crons). GitHub Actions remains a
  * watchdog; both paths call `tick()` so overlapping POSTs coalesce.
+ *
+ * HTTP `POST /api/admin/ingest` uses `canStart` + Worker D1 persist +
+ * `startInstance` so `workflow_runs` is committed on the same binding
+ * `/api/system` reads **before** `NEWS_INGEST.create()`.
  */
 export class NewsIngestScheduler extends DurableObject<Env> {
   async alarm(): Promise<void> {
     await this.tick();
   }
 
-  async tick(opts: { force?: boolean } = {}): Promise<IngestTickResult> {
+  async canStart(opts: IngestTickOpts = {}): Promise<IngestTickResult> {
     const now = Date.now();
     const lastStartedAt = await this.ctx.storage.get<number>(LAST_STARTED_KEY);
     await this.ctx.storage.setAlarm(nextAlarmAt(now));
@@ -32,24 +37,34 @@ export class NewsIngestScheduler extends DurableObject<Env> {
         reason: "ran recently",
       };
     }
+    return { id: null, skipped: false };
+  }
 
+  async startInstance(id: string): Promise<IngestTickResult> {
+    const now = Date.now();
     try {
-      const instance = await this.env.NEWS_INGEST.create();
+      await this.env.NEWS_INGEST.create({ id });
       await this.ctx.storage.put(LAST_STARTED_KEY, now);
-      const result: IngestTickResult = {
-        id: instance.id,
-        skipped: false,
-      };
-      await persistCreatedIngestRun(this.env.DB, result);
-      return result;
+      await this.ctx.storage.setAlarm(nextAlarmAt(now));
+      return { id, skipped: false };
     } catch (error) {
       console.error("ingest scheduler create failed:", error);
       return {
-        id: null,
+        id,
         skipped: false,
         reason: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  async tick(opts: IngestTickOpts = {}): Promise<IngestTickResult> {
+    const gate = await this.canStart(opts);
+    if (gate.skipped) return gate;
+
+    const id = crypto.randomUUID();
+    const result: IngestTickResult = { id, skipped: false };
+    await persistCreatedIngestRun(this.env.DB, result);
+    return this.startInstance(id);
   }
 
   async ensureArmed(): Promise<void> {

--- a/apps/news/worker/workflow-run.ts
+++ b/apps/news/worker/workflow-run.ts
@@ -13,6 +13,13 @@ ON CONFLICT(id) DO UPDATE SET
   error = excluded.error,
   stats = excluded.stats`;
 
+/** Read-your-writes check after the HTTP create-path upsert so POST does
+ * not return an id that `/api/system` cannot see. */
+export const SELECT_WORKFLOW_RUN_ID_SQL =
+  "SELECT id FROM workflow_runs WHERE id = ?";
+
+const PERSIST_ATTEMPTS = 3;
+
 export interface WorkflowRunRecord {
   id: string;
   startedAt: number;
@@ -23,17 +30,31 @@ export interface WorkflowRunRecord {
   statsJson: string;
 }
 
+export interface D1BoundStatement {
+  run: () => Promise<unknown>;
+  first: <T>() => Promise<T | null>;
+}
+
 export interface D1Runner {
   prepare: (sql: string) => {
-    bind: (...args: unknown[]) => { run: () => Promise<unknown> };
+    bind: (...args: unknown[]) => D1BoundStatement;
   };
+}
+
+function d1RunFailed(result: unknown): boolean {
+  return (
+    !!result &&
+    typeof result === "object" &&
+    "success" in result &&
+    (result as { success: unknown }).success === false
+  );
 }
 
 export async function persistWorkflowRun(
   db: D1Runner,
   row: WorkflowRunRecord
 ): Promise<void> {
-  await db
+  const result = await db
     .prepare(UPSERT_WORKFLOW_RUN_SQL)
     .bind(
       nn(row.id),
@@ -45,6 +66,9 @@ export async function persistWorkflowRun(
       nn(row.statsJson)
     )
     .run();
+  if (d1RunFailed(result)) {
+    throw new Error("workflow_runs upsert returned success=false");
+  }
 }
 
 export type OpenedRunStepName = "create" | "open-run";
@@ -71,8 +95,9 @@ export function openedWorkflowRun(
   };
 }
 
-/** Best-effort upsert. Never throws — `create()` already succeeded, and
- * ingest must continue even if this observability write fails. */
+/** Best-effort upsert. Never throws — Workflow `run()` must continue even
+ * if this observability write fails. HTTP create-path uses
+ * `persistOpenedWorkflowRunVerified` instead. */
 export async function persistOpenedWorkflowRun(
   db: D1Runner | undefined,
   id: string | null | undefined,
@@ -85,6 +110,42 @@ export async function persistOpenedWorkflowRun(
   } catch (error) {
     console.error(`${stepName} d1 failed:`, error);
   }
+}
+
+async function verifyWorkflowRunRow(db: D1Runner, id: string): Promise<void> {
+  const seen = await db
+    .prepare(SELECT_WORKFLOW_RUN_ID_SQL)
+    .bind(id)
+    .first<{ id: string }>();
+  if (seen?.id !== id) {
+    throw new Error(`workflow_runs verify missed ${id}`);
+  }
+}
+
+/** Upsert that must stick before POST /api/admin/ingest returns. Throws
+ * after retries if D1 does not read back the same id — swallowing here
+ * is what left lastRun on 42d830a9 after #1409. */
+export async function persistOpenedWorkflowRunVerified(
+  db: D1Runner,
+  id: string,
+  startedAt: number,
+  stepName: OpenedRunStepName
+): Promise<void> {
+  const row = openedWorkflowRun(id, startedAt, stepName);
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= PERSIST_ATTEMPTS; attempt++) {
+    try {
+      await persistWorkflowRun(db, row);
+      await verifyWorkflowRunRow(db, id);
+      return;
+    } catch (error) {
+      lastError = error;
+      console.error(`${stepName} d1 failed (attempt ${attempt}):`, error);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`${stepName} d1 failed`);
 }
 
 /** Cloudflare Workflows JSON-serialize step returns. `Map` becomes `{}`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes leftover https://github.com/duyet/monorepo/issues/1410 after #1409.

## What I found (not a schedule fire)

Live `GET https://news.duyet.net/api/system` still showed `lastRun.id` `42d830a9-689c-4e9a-9e91-98e812016b97` (finished 2026-08-26 ICT), `runsToday` 0, `Cache-Control: no-store`. Same payload: `itemsPerDay` 2026-08-28 is 23, `latestTldrDate` 2026-08-28, `llmCallsPerDay` translate still climbing (~2255 / fail ~2230). `9a1002fa-…` is not in `runs[]`.

Confirmed, not invented:

- Force News Ingest [33158333160](https://github.com/duyet/monorepo/actions/runs/33158333160) @ `5ea5aa3a` POSTed `{id: 9a1002fa-…, skipped: false}`. That is Cloudflare Workflow `create()`, not a `workflow_runs` row.
- Polled `/api/system` for 1+ minute after POST: lastRun still `42d830a9`. Translate work is a long-running instance, not one minute of a new run.
- `duyet-news` `modified_on` 2026-08-28T09:09:08Z (after #1409 merge 09:07:39Z). The live Worker bundle **does** include `persistCreatedIngestRun` after `create()`. Last real **schedule** News Ingest remains 2026-08-27 23:38 UTC on `5a771c1a`. No `:05/:20/:35/:50` fire is claimed.

#1409 upserted `workflow_runs` **after** `NEWS_INGEST.create()` (inside the Durable Object, then again in the Worker) and **swallowed** D1 errors so POST still returned 2xx with the Workflow id. Tests only asserted persist on the no-scheduler fallback — production always has `NEWS_INGEST_SCHEDULER`. Live ingest is writing `items` / `llm_calls` from an in-flight instance; new `create()` ids never land in `workflow_runs`.

Discarded: hidden open row (lastRun has no `finished_at` filter); different D1 than lastRun (same `/api/system` payload as items/llm_calls); deploy missed the files (bundle contains the #1409 upsert).

## Fix

- HTTP `tickIngest` asks the Durable Object only to **gate** the 45-minute coalesce (`canStart`), then picks the instance uuid, **upserts + SELECT-verifies** `workflow_runs` on the Worker `DB` binding `/api/system` reads, **then** `startInstance` → `NEWS_INGEST.create({ id })`.
- That D1 write throws after 3 attempts if the row is not readable. POST no longer returns an id that lastRun cannot show.
- Alarm `tick()` still best-effort persists (swallow) then `create({ id })`. `run()` open-run / close-run unchanged.
- No Worker cron. No Workflow `schedules`. Does not touch #1362, #1365, or #1407.

## Verify (do not wait for or invent a cron fire)

1. Deploy `duyet-news` from this PR.
2. Manual **News Ingest** `workflow_dispatch` (yml POSTs `?force=1`). Treat Actions SUCCESS as POST 2xx only. Note the JSON `id`.
3. As soon as the POST returns — not after ingest finishes — `GET https://news.duyet.net/api/system` (no admin token): `lastRun.id` must leave `42d830a9-…` and should match the POST `id`. `runsToday > 0`. `finished_at` is today (set on create/open, updated on close).
4. If persist cannot stick, the POST should fail (Actions red) instead of returning a phantom Workflow id.
5. Do **not** treat a `:05/:20/:35/:50` schedule as having fired unless GitHub Actions shows a `schedule` run.

Closes #1410.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce15c2f7-01ed-420c-9f1c-3569b3486a79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce15c2f7-01ed-420c-9f1c-3569b3486a79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Ensure news ingest workflow runs are visible to system reporting before workflow creation and prevent phantom successful triggers when persistence fails.

Bug Fixes:
- Persist news ingest workflow runs before starting the workflow and fail the ingest request if the row cannot be verified.
- Preserve best-effort workflow run persistence for alarm-triggered ingests while keeping workflow execution resilient to observability failures.

Enhancements:
- Separate ingest coalescing from workflow startup so the Worker can persist and verify the run on the D1 binding used by system reporting.
- Add retrying read-after-write verification for workflow run records and update scheduler and ingest documentation accordingly.

Documentation:
- Update news ingest documentation to describe pre-creation workflow run persistence and verification.

Tests:
- Add coverage for persistence ordering, scheduler gating, read-back verification, skipped ingests, and failure retries.