### PR TITLE
fix(news): fail ingest POST unless lastRun can read persist

### DIFF
--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -11,12 +11,13 @@ Both paths coalesce: a new instance is skipped if one started in the last
 45 minutes. `POST /api/admin/ingest?force=1` (workflow_dispatch) bypasses
 the window. LLM-heavy Workflow steps use `retries: 0` and a 4-minute
 timeout; a failed score/TL;DR call must not abort close-run. HTTP
-`POST /api/admin/ingest` picks the instance uuid, **upserts and
-read-back-verifies** `workflow_runs` on the Worker D1 binding, then
-calls `NEWS_INGEST.create({ id })` (the Durable Object only gates the
-45-minute coalesce and performs create). Do not swallow that D1 write:
-#1409 upserted after `create()` and caught errors, so live POST
-`9a1002fa-…` never became `lastRun`. `run()` still upserts at start
+`POST /api/admin/ingest` picks the instance uuid, **upserts with
+RETURNING and lastRun-verifies** `workflow_runs` on the Worker D1
+binding (`first-primary` session), then `NEWS_INGEST.create({ id })`
+from that isolate. The Durable Object only gates the 45-minute
+coalesce and records last-started. A failed persist must fail the
+POST — #1411's WHERE-id SELECT still returned 2xx for
+`5419a68e-…` while lastRun stayed `42d830a9-…`. `run()` still upserts at start
 **before** `pruneLlmCalls` / fetch / LLM. Do not wrap `open-run` in
 `safeStep`. Score and
 TL;DR hang-cap per model at 70s/90s (translate stays 25s). Do not treat

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -56,7 +56,7 @@ skip. Actions SUCCESS is only the POST; poll `GET /api/system` (no admin
 token, `Cache-Control: no-store`) until `lastRun.id` is no longer the
 previous id and `runsToday > 0`. The POST JSON `id` is chosen before
 `NEWS_INGEST.create({ id })` and must be lastRun (`INSERT … RETURNING`
-plus `ORDER BY started_at DESC LIMIT 1`) before the POST returns.
+plus `ORDER BY started_at DESC, id DESC LIMIT 1`) before the POST returns.
 A persist miss fails the POST instead of returning a Workflow id.
 Do not invent a scheduled `:05/:20/:35/:50` fire.
 

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -55,8 +55,9 @@ coalesce if a run started in the last 45 minutes. Manual
 skip. Actions SUCCESS is only the POST; poll `GET /api/system` (no admin
 token, `Cache-Control: no-store`) until `lastRun.id` is no longer the
 previous id and `runsToday > 0`. The POST JSON `id` is chosen before
-`NEWS_INGEST.create({ id })` and is written (then SELECT-verified) to
-`workflow_runs` before the POST returns — not after ingest finishes.
+`NEWS_INGEST.create({ id })` and must be lastRun (`INSERT … RETURNING`
+plus `ORDER BY started_at DESC LIMIT 1`) before the POST returns.
+A persist miss fails the POST instead of returning a Workflow id.
 Do not invent a scheduled `:05/:20/:35/:50` fire.
 
 ## Admin API / MCP

--- a/apps/news/src/lib/system-queries.ts
+++ b/apps/news/src/lib/system-queries.ts
@@ -228,8 +228,8 @@ export async function loadSystemStats(
   ]);
 
   const runsQuery = hasRunStats
-    ? "SELECT id, started_at, finished_at, items_fetched, items_new, error, stats FROM workflow_runs ORDER BY started_at DESC LIMIT 30"
-    : "SELECT id, started_at, finished_at, items_fetched, items_new, error FROM workflow_runs ORDER BY started_at DESC LIMIT 30";
+    ? "SELECT id, started_at, finished_at, items_fetched, items_new, error, stats FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 30"
+    : "SELECT id, started_at, finished_at, items_fetched, items_new, error FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 30";
 
   const [
     itemsTotal,

--- a/apps/news/src/routes/api/admin.$.ts
+++ b/apps/news/src/routes/api/admin.$.ts
@@ -170,8 +170,20 @@ async function handle(
 
   if (method === "POST" && segments.length === 1 && segments[0] === "ingest") {
     const force = new URL(request.url).searchParams.get("force") === "1";
-    const result = await triggerIngest(env, { force });
-    return Response.json(result);
+    try {
+      const result = await triggerIngest(env, { force });
+      return Response.json(result);
+    } catch (error) {
+      // Persist / create / canStart / markStarted must not become Actions
+      // SUCCESS with a phantom Workflow id (Sourcery on #1413).
+      console.error("ingest trigger failed:", error);
+      return Response.json(
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        { status: 500 }
+      );
+    }
   }
 
   if (method === "GET" && segments.length === 1 && segments[0] === "status") {

--- a/apps/news/src/routes/api/system.ts
+++ b/apps/news/src/routes/api/system.ts
@@ -25,7 +25,11 @@ export const Route = createFileRoute("/api/system")({
         }
 
         try {
-          const stats = await loadSystemStats(db, env);
+          const session =
+            typeof db.withSession === "function"
+              ? db.withSession("first-primary")
+              : db;
+          const stats = await loadSystemStats(session as D1Database, env);
           return Response.json(stats, {
             headers: {
               // Operational: lastRun/runsToday must not sit behind the 5-minute

--- a/apps/news/worker/__tests__/admin.test.ts
+++ b/apps/news/worker/__tests__/admin.test.ts
@@ -61,6 +61,17 @@ class FakeD1 {
       return row ? { id: row.id } : null;
     }
 
+    if (
+      sql.startsWith(
+        "SELECT id FROM workflow_runs ORDER BY started_at DESC LIMIT 1"
+      )
+    ) {
+      const rows = [...this.workflowRuns].sort(
+        (a, b) => Number(b.started_at ?? 0) - Number(a.started_at ?? 0)
+      );
+      return rows[0] ? { id: rows[0].id } : null;
+    }
+
     if (sql.startsWith("SELECT id FROM items WHERE id = ?")) {
       const [id] = args as [string];
       const row = this.items.get(id);
@@ -374,7 +385,13 @@ class FakeD1 {
       };
       if (existing) Object.assign(existing, row);
       else this.workflowRuns.push(row);
-      return { success: true };
+      return {
+        success: true,
+        id,
+        started_at,
+        results: [{ id, started_at }],
+        meta: { changes: 1, rows_written: 1 },
+      };
     }
 
     if (sql.startsWith("INSERT INTO admin_audit")) {
@@ -884,6 +901,7 @@ describe("triggerIngest", () => {
           tick: vi.fn(),
           canStart,
           startInstance,
+          markStarted: vi.fn(),
           ensureArmed: vi.fn(),
         }),
       } as unknown as DurableObjectNamespace,
@@ -899,22 +917,25 @@ describe("triggerIngest", () => {
     expect((env.DB as unknown as FakeD1).workflowRuns).toHaveLength(0);
   });
 
-  it("persists workflow_runs before startInstance when force is set", async () => {
+  it("persists workflow_runs before Worker create({ id }) when force is set", async () => {
     const canStart = vi.fn().mockResolvedValue({
       id: null,
       skipped: false,
     });
-    const startInstance = vi.fn(async (id: string) => ({
-      id,
-      skipped: false,
+    const startInstance = vi.fn();
+    const markStarted = vi.fn();
+    const create = vi.fn(async (opts?: { id?: string }) => ({
+      id: opts?.id,
     }));
     const env = makeEnv({
+      NEWS_INGEST: { create } as unknown as Workflow,
       NEWS_INGEST_SCHEDULER: {
         idFromName: () => "id",
         get: () => ({
           tick: vi.fn(),
           canStart,
           startInstance,
+          markStarted,
           ensureArmed: vi.fn(),
         }),
       } as unknown as DurableObjectNamespace,
@@ -922,7 +943,9 @@ describe("triggerIngest", () => {
     const result = await triggerIngest(env, { force: true });
     expect(canStart).toHaveBeenCalledWith({ force: true });
     expect(result.skipped).toBe(false);
-    expect(startInstance).toHaveBeenCalledWith(result.id);
+    expect(startInstance).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledWith({ id: result.id });
+    expect(markStarted).toHaveBeenCalledWith(result.id);
     const runs = (env.DB as unknown as FakeD1).workflowRuns;
     expect(runs).toHaveLength(1);
     expect(runs[0]?.id).toBe(result.id);

--- a/apps/news/worker/__tests__/admin.test.ts
+++ b/apps/news/worker/__tests__/admin.test.ts
@@ -63,11 +63,16 @@ class FakeD1 {
 
     if (
       sql.startsWith(
-        "SELECT id FROM workflow_runs ORDER BY started_at DESC LIMIT 1"
+        "SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 1"
       )
     ) {
       const rows = [...this.workflowRuns].sort(
-        (a, b) => Number(b.started_at ?? 0) - Number(a.started_at ?? 0)
+        (a: Record<string, unknown>, b: Record<string, unknown>): number => {
+          const byStarted =
+            Number(b.started_at ?? 0) - Number(a.started_at ?? 0);
+          if (byStarted !== 0) return byStarted;
+          return String(b.id ?? "").localeCompare(String(a.id ?? ""));
+        }
       );
       return rows[0] ? { id: rows[0].id } : null;
     }

--- a/apps/news/worker/__tests__/ingest-schedule.test.ts
+++ b/apps/news/worker/__tests__/ingest-schedule.test.ts
@@ -14,18 +14,33 @@ import {
 } from "../ingest-schedule.js";
 import {
   type D1Runner,
+  SELECT_LATEST_WORKFLOW_RUN_ID_SQL,
   SELECT_WORKFLOW_RUN_ID_SQL,
   UPSERT_WORKFLOW_RUN_SQL,
 } from "../workflow-run.js";
 
-function trackingDb(order: string[]): D1Runner {
+function trackingDb(order: string[], lastRunId?: { current: string }): D1Runner {
   const prepare = vi.fn((sql: string) => {
-    order.push(sql.startsWith("INSERT") ? "persist" : "verify");
+    if (sql.startsWith("INSERT")) order.push("persist");
+    else if (sql.includes("ORDER BY")) order.push("verify-last");
+    else order.push("verify");
     return {
-      bind: (...args: unknown[]) => ({
-        run: async () => ({ success: true }),
-        first: async <T>() => ({ id: args[0] as string }) as T,
-      }),
+      bind: (...args: unknown[]) => {
+        if (typeof args[0] === "string" && lastRunId) {
+          lastRunId.current = args[0];
+        }
+        const id = (args[0] as string | undefined) ?? lastRunId?.current;
+        return {
+          run: async () => ({
+            success: true,
+            meta: { changes: 1, rows_written: 1 },
+            results: [{ id, started_at: 1 }],
+          }),
+          first: async <T>() => ({ id, started_at: 1 }) as T,
+        };
+      },
+      first: async <T>() =>
+        ({ id: lastRunId?.current, started_at: 1 }) as T,
     };
   });
   return { prepare };
@@ -68,18 +83,35 @@ describe("alarm timestamps", () => {
 });
 
 describe("tickIngest", () => {
+  it("fails closed when DB is unbound so POST cannot return a phantom id", async () => {
+    const create = vi.fn();
+    await expect(
+      tickIngest({
+        NEWS_INGEST: { create } as unknown as Workflow,
+      })
+    ).rejects.toThrow(/requires DB/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
   it("falls back to NEWS_INGEST.create({ id }) when no scheduler is bound", async () => {
-    const create = vi.fn().mockResolvedValue({ id: "wf-1" });
+    const order: string[] = [];
+    const lastRunId = { current: "" };
+    const create = vi.fn(async (opts?: { id?: string }) => {
+      order.push("create");
+      return { id: opts?.id };
+    });
     const result = await tickIngest({
+      DB: trackingDb(order, lastRunId),
       NEWS_INGEST: { create } as unknown as Workflow,
     });
     expect(result.skipped).toBe(false);
     expect(create).toHaveBeenCalledWith({ id: result.id });
   });
 
-  it("writes and verifies workflow_runs before create()", async () => {
+  it("writes and lastRun-verifies workflow_runs before create()", async () => {
     const order: string[] = [];
-    const db = trackingDb(order);
+    const lastRunId = { current: "" };
+    const db = trackingDb(order, lastRunId);
     const create = vi.fn(async (opts?: { id?: string }) => {
       order.push("create");
       return { id: opts?.id };
@@ -89,24 +121,29 @@ describe("tickIngest", () => {
       NEWS_INGEST: { create } as unknown as Workflow,
     });
     expect(result.skipped).toBe(false);
-    expect(order).toEqual(["persist", "verify", "create"]);
+    expect(order).toEqual(["persist", "verify", "verify-last", "create"]);
     expect(create).toHaveBeenCalledWith({ id: result.id });
     expect(db.prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
     expect(db.prepare).toHaveBeenCalledWith(SELECT_WORKFLOW_RUN_ID_SQL);
+    expect(db.prepare).toHaveBeenCalledWith(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
   });
 
-  it("persists on the Worker DB before startInstance when the scheduler is bound", async () => {
+  it("persists on the Worker DB then create({ id }) when the scheduler is bound", async () => {
     const order: string[] = [];
-    const db = trackingDb(order);
+    const lastRunId = { current: "" };
+    const db = trackingDb(order, lastRunId);
     const canStart = vi.fn(async () => {
       order.push("gate");
       return { id: null, skipped: false };
     });
-    const startInstance = vi.fn(async (id: string) => {
-      order.push("create");
-      return { id, skipped: false };
+    const startInstance = vi.fn();
+    const markStarted = vi.fn(async () => {
+      order.push("mark");
     });
-    const create = vi.fn();
+    const create = vi.fn(async (opts?: { id?: string }) => {
+      order.push("create");
+      return { id: opts?.id };
+    });
     const result = await tickIngest(
       {
         DB: db,
@@ -120,6 +157,7 @@ describe("tickIngest", () => {
             tick: vi.fn(),
             canStart,
             startInstance,
+            markStarted,
             ensureArmed: vi.fn(),
           }),
         } as unknown as DurableObjectNamespace,
@@ -127,9 +165,17 @@ describe("tickIngest", () => {
       { force: true }
     );
     expect(canStart).toHaveBeenCalledWith({ force: true });
-    expect(create).not.toHaveBeenCalled();
-    expect(startInstance).toHaveBeenCalledWith(result.id);
-    expect(order).toEqual(["gate", "persist", "verify", "create"]);
+    expect(startInstance).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledWith({ id: result.id });
+    expect(markStarted).toHaveBeenCalledWith(result.id);
+    expect(order).toEqual([
+      "gate",
+      "persist",
+      "verify",
+      "verify-last",
+      "create",
+      "mark",
+    ]);
     expect(db.prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
   });
 
@@ -150,6 +196,7 @@ describe("tickIngest", () => {
             reason: "ran recently",
           }),
           startInstance,
+          markStarted: vi.fn(),
           ensureArmed: vi.fn(),
         }),
       } as unknown as DurableObjectNamespace,
@@ -177,19 +224,29 @@ describe("persistCreatedIngestRun", () => {
 });
 
 describe("persistCreatedIngestRunVerified", () => {
-  it("throws when D1 does not read back the row", async () => {
+  it("throws when DB is unbound", async () => {
+    await expect(
+      persistCreatedIngestRunVerified(undefined, {
+        id: "wf-missing",
+        skipped: false,
+      })
+    ).rejects.toThrow(/requires DB/);
+  });
+
+  it("throws when D1 does not RETURN the row", async () => {
     const prepare = vi.fn().mockReturnValue({
       bind: () => ({
         run: async () => ({ success: true }),
         first: async () => null,
       }),
+      first: async () => null,
     });
     await expect(
       persistCreatedIngestRunVerified(
         { prepare },
         { id: "wf-missing", skipped: false }
       )
-    ).rejects.toThrow(/verify missed wf-missing/);
+    ).rejects.toThrow(/RETURNING missed wf-missing/);
   });
 });
 
@@ -207,6 +264,7 @@ describe("ensureIngestAlarm", () => {
           tick: vi.fn(),
           canStart: vi.fn(),
           startInstance: vi.fn(),
+          markStarted: vi.fn(),
           ensureArmed,
         }),
       } as unknown as DurableObjectNamespace,

--- a/apps/news/worker/__tests__/ingest-schedule.test.ts
+++ b/apps/news/worker/__tests__/ingest-schedule.test.ts
@@ -210,6 +210,87 @@ describe("tickIngest", () => {
     expect(startInstance).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
   });
+
+  it("rethrows canStart failures instead of proceeding as skipped:false", async () => {
+    const prepare = vi.fn();
+    const create = vi.fn();
+    await expect(
+      tickIngest({
+        DB: { prepare },
+        NEWS_INGEST: { create } as unknown as Workflow,
+        NEWS_INGEST_SCHEDULER: {
+          idFromName: () => "id",
+          get: () => ({
+            tick: vi.fn(),
+            canStart: vi.fn().mockRejectedValue(new Error("DO unavailable")),
+            startInstance: vi.fn(),
+            markStarted: vi.fn(),
+            ensureArmed: vi.fn(),
+          }),
+        } as unknown as DurableObjectNamespace,
+      })
+    ).rejects.toThrow(/DO unavailable/);
+    expect(prepare).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("rethrows NEWS_INGEST.create failures after persist (no 2xx phantom)", async () => {
+    const order: string[] = [];
+    const lastRunId = { current: "" };
+    const create = vi.fn(async () => {
+      order.push("create");
+      throw new Error("workflow create rejected");
+    });
+    const markStarted = vi.fn();
+    await expect(
+      tickIngest({
+        DB: trackingDb(order, lastRunId),
+        NEWS_INGEST: { create } as unknown as Workflow,
+        NEWS_INGEST_SCHEDULER: {
+          idFromName: () => "id",
+          get: () => ({
+            tick: vi.fn(),
+            canStart: vi.fn().mockResolvedValue({ id: null, skipped: false }),
+            startInstance: vi.fn(),
+            markStarted,
+            ensureArmed: vi.fn(),
+          }),
+        } as unknown as DurableObjectNamespace,
+      })
+    ).rejects.toThrow(/workflow create rejected/);
+    expect(order).toEqual(["persist", "verify", "verify-last", "create"]);
+    expect(markStarted).not.toHaveBeenCalled();
+  });
+
+  it("rethrows markStarted failures after create so POST is not SUCCESS", async () => {
+    const order: string[] = [];
+    const lastRunId = { current: "" };
+    const create = vi.fn(async (opts?: { id?: string }) => {
+      order.push("create");
+      return { id: opts?.id };
+    });
+    const markStarted = vi
+      .fn()
+      .mockRejectedValue(new Error("markStarted storage failed"));
+    await expect(
+      tickIngest({
+        DB: trackingDb(order, lastRunId),
+        NEWS_INGEST: { create } as unknown as Workflow,
+        NEWS_INGEST_SCHEDULER: {
+          idFromName: () => "id",
+          get: () => ({
+            tick: vi.fn(),
+            canStart: vi.fn().mockResolvedValue({ id: null, skipped: false }),
+            startInstance: vi.fn(),
+            markStarted,
+            ensureArmed: vi.fn(),
+          }),
+        } as unknown as DurableObjectNamespace,
+      })
+    ).rejects.toThrow(/markStarted storage failed/);
+    expect(create).toHaveBeenCalledOnce();
+    expect(markStarted).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe("persistCreatedIngestRun", () => {

--- a/apps/news/worker/__tests__/schedule.test.ts
+++ b/apps/news/worker/__tests__/schedule.test.ts
@@ -205,10 +205,11 @@ describe("create-path workflow_runs persist", () => {
   );
 
   it("verifies D1 before NEWS_INGEST.create({ id })", () => {
-    const persistIdx = ingestSchedule.indexOf(
-      "persistCreatedIngestRunVerified"
+    const startFn = ingestSchedule.slice(
+      ingestSchedule.indexOf("async function startCreatedIngest")
     );
-    const createIdx = ingestSchedule.indexOf("NEWS_INGEST.create({ id })");
+    const persistIdx = startFn.indexOf("persistCreatedIngestRunVerified");
+    const createIdx = startFn.indexOf("NEWS_INGEST.create({ id })");
     expect(persistIdx).toBeGreaterThan(0);
     expect(createIdx).toBeGreaterThan(persistIdx);
   });

--- a/apps/news/worker/__tests__/workflow-run.test.ts
+++ b/apps/news/worker/__tests__/workflow-run.test.ts
@@ -7,6 +7,8 @@ import {
   persistOpenedWorkflowRun,
   persistOpenedWorkflowRunVerified,
   persistWorkflowRun,
+  type D1Runner,
+  SELECT_LATEST_WORKFLOW_RUN_ID_SQL,
   SELECT_WORKFLOW_RUN_ID_SQL,
   UPSERT_WORKFLOW_RUN_SQL,
 } from "../workflow-run.js";
@@ -19,6 +21,10 @@ describe("UPSERT_WORKFLOW_RUN_SQL", () => {
       "finished_at = excluded.finished_at"
     );
     expect(UPSERT_WORKFLOW_RUN_SQL).toContain("stats = excluded.stats");
+    expect(UPSERT_WORKFLOW_RUN_SQL).toContain(
+      "started_at = excluded.started_at"
+    );
+    expect(UPSERT_WORKFLOW_RUN_SQL).toContain("RETURNING id, started_at");
   });
 });
 
@@ -119,28 +125,54 @@ describe("persistOpenedWorkflowRun", () => {
 });
 
 describe("persistOpenedWorkflowRunVerified", () => {
-  it("upserts then reads the same id back", async () => {
+  it("upserts via RETURNING then confirms lastRun", async () => {
     const run = vi.fn().mockResolvedValue({ success: true });
-    const first = vi.fn().mockResolvedValue({ id: "wf-1" });
+    const first = vi.fn().mockResolvedValue({ id: "wf-1", started_at: 1 });
     const bind = vi.fn().mockReturnValue({ run, first });
-    const prepare = vi.fn().mockReturnValue({ bind });
-    await persistOpenedWorkflowRunVerified({ prepare }, "wf-1", 1, "create");
+    const prepare = vi.fn().mockReturnValue({ bind, first });
+    await persistOpenedWorkflowRunVerified(
+      { prepare } as D1Runner,
+      "wf-1",
+      1,
+      "create"
+    );
     expect(prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
     expect(prepare).toHaveBeenCalledWith(SELECT_WORKFLOW_RUN_ID_SQL);
-    expect(run).toHaveBeenCalledOnce();
-    expect(first).toHaveBeenCalledOnce();
+    expect(prepare).toHaveBeenCalledWith(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
+    expect(first).toHaveBeenCalled();
   });
 
-  it("throws after retries when verify misses", async () => {
+  it("throws after retries when RETURNING misses", async () => {
     const prepare = vi.fn().mockReturnValue({
       bind: () => ({
         run: async () => ({ success: true }),
         first: async () => null,
       }),
+      first: async () => null,
     });
     await expect(
-      persistOpenedWorkflowRunVerified({ prepare }, "wf-1", 1, "create")
-    ).rejects.toThrow(/verify missed wf-1/);
-    expect(prepare).toHaveBeenCalledTimes(6);
+      persistOpenedWorkflowRunVerified({ prepare } as D1Runner, "wf-1", 1, "create")
+    ).rejects.toThrow(/RETURNING missed wf-1/);
+    expect(prepare).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws when RETURNING echoes the id but lastRun is still another row", async () => {
+    const prepare = vi.fn((sql: string) => ({
+      bind: () => ({
+        run: async () => ({ success: true }),
+        first: async () =>
+          sql.includes("ORDER BY")
+            ? { id: "42d830a9-689c-4e9a-9e91-98e812016b97" }
+            : { id: "wf-1", started_at: 1 },
+      }),
+      first: async () =>
+        sql.includes("ORDER BY")
+          ? { id: "42d830a9-689c-4e9a-9e91-98e812016b97" }
+          : { id: "wf-1", started_at: 1 },
+    }));
+    await expect(
+      persistOpenedWorkflowRunVerified({ prepare } as D1Runner, "wf-1", 1, "create")
+    ).rejects.toThrow(/lastRun is 42d830a9/);
+    expect(prepare).toHaveBeenCalled();
   });
 });

--- a/apps/news/worker/__tests__/workflow-run.test.ts
+++ b/apps/news/worker/__tests__/workflow-run.test.ts
@@ -105,6 +105,14 @@ describe("openedWorkflowRun", () => {
   });
 });
 
+describe("SELECT_LATEST_WORKFLOW_RUN_ID_SQL", () => {
+  it("breaks started_at ties with id DESC so lastRun is deterministic", () => {
+    expect(SELECT_LATEST_WORKFLOW_RUN_ID_SQL).toContain(
+      "ORDER BY started_at DESC, id DESC"
+    );
+  });
+});
+
 describe("persistOpenedWorkflowRun", () => {
   it("no-ops without a db or id", async () => {
     await persistOpenedWorkflowRun(undefined, "wf-1", 1, "create");

--- a/apps/news/worker/ingest-schedule.ts
+++ b/apps/news/worker/ingest-schedule.ts
@@ -24,6 +24,8 @@ export const INGEST_ALARM_ARM_DELAY_MS = 15_000;
 
 export const INGEST_SCHEDULER_NAME = "default";
 
+const MARK_STARTED_ATTEMPTS = 3;
+
 export interface IngestTickResult {
   id: string | null;
   skipped: boolean;
@@ -66,30 +68,20 @@ export async function tickIngest(
 ): Promise<IngestTickResult> {
   if (env.NEWS_INGEST_SCHEDULER) {
     const stub = schedulerStub(env.NEWS_INGEST_SCHEDULER);
-    const gate = await gateIngest(stub, opts);
+    // Fail closed on gate errors — do not swallow into skipped:false
+    // (that would bypass the 45-minute coalesce during a DO outage).
+    const gate = await stub.canStart(opts);
     if (gate.skipped) return gate;
     return startCreatedIngest(env, stub);
   }
   return startCreatedIngest(env);
 }
 
-async function gateIngest(
-  stub: IngestSchedulerRpc,
-  opts: IngestTickOpts
-): Promise<IngestTickResult> {
-  try {
-    return await stub.canStart(opts);
-  } catch (error) {
-    // Old DO isolate without canStart. Force still has to persist+create
-    // on the Worker; non-force also proceeds rather than calling tick()
-    // (that would create() without a lastRun row).
-    console.error("ingest scheduler canStart failed:", error);
-    return { id: null, skipped: false, reason: "gate-unavailable" };
-  }
-}
-
 /** Choose the instance id, persist+verify `workflow_runs` as lastRun,
- * then `create({ id })` from this Worker. POST `{id}` is this uuid. */
+ * then `create({ id })` from this Worker. POST `{id}` is this uuid.
+ * create() / markStarted failures throw so the admin route is non-2xx —
+ * never return a persisted id as HTTP 200 when the Workflow did not
+ * start or the coalesce clock was not updated. */
 async function startCreatedIngest(
   env: {
     DB?: D1Runner;
@@ -100,20 +92,33 @@ async function startCreatedIngest(
   const id = crypto.randomUUID();
   const result: IngestTickResult = { id, skipped: false };
   await persistCreatedIngestRunVerified(env.DB, result);
-  try {
-    await env.NEWS_INGEST.create({ id });
-  } catch (error) {
-    console.error("NEWS_INGEST.create failed after persist:", error);
-    result.reason = error instanceof Error ? error.message : String(error);
-  }
+  await env.NEWS_INGEST.create({ id });
   if (stub) {
-    try {
-      await stub.markStarted(id);
-    } catch (error) {
-      console.error("ingest scheduler markStarted failed:", error);
-    }
+    await markStartedOrThrow(stub, id);
   }
   return result;
+}
+
+async function markStartedOrThrow(
+  stub: Pick<IngestSchedulerRpc, "markStarted">,
+  id: string
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MARK_STARTED_ATTEMPTS; attempt++) {
+    try {
+      await stub.markStarted(id);
+      return;
+    } catch (error) {
+      lastError = error;
+      console.error(
+        `ingest scheduler markStarted failed (attempt ${attempt}):`,
+        error
+      );
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("ingest scheduler markStarted failed");
 }
 
 /** Best-effort upsert after the Durable Object alarm `create()`. HTTP

--- a/apps/news/worker/ingest-schedule.ts
+++ b/apps/news/worker/ingest-schedule.ts
@@ -37,14 +37,16 @@ export interface IngestTickOpts {
 /** RPC surface of `NewsIngestScheduler`. Declared here so admin handlers
  * can call it without importing `cloudflare:workers`.
  *
- * HTTP ingest must persist `workflow_runs` on the Worker D1 binding
- * **before** `NEWS_INGEST.create()`: #1409 upserted after create() (and
- * swallowed D1 errors), and live POST `9a1002fa-…` never appeared in
- * `/api/system`. Split gate/start so the Worker can write+verify first. */
+ * HTTP ingest persists `workflow_runs` on the Worker D1 binding (the one
+ * `/api/system` reads) **before** `NEWS_INGEST.create({ id })` in this
+ * isolate. The Durable Object only gates the 45-minute coalesce and
+ * records last-started — it must not be the create() path, because a
+ * Workflow id is not a `workflow_runs` row. */
 export interface IngestSchedulerRpc {
   tick(opts?: IngestTickOpts): Promise<IngestTickResult>;
   canStart(opts?: IngestTickOpts): Promise<IngestTickResult>;
   startInstance(id: string): Promise<IngestTickResult>;
+  markStarted(id: string): Promise<void>;
   ensureArmed(): Promise<void>;
 }
 
@@ -64,35 +66,53 @@ export async function tickIngest(
 ): Promise<IngestTickResult> {
   if (env.NEWS_INGEST_SCHEDULER) {
     const stub = schedulerStub(env.NEWS_INGEST_SCHEDULER);
-    const gate = await stub.canStart(opts);
+    const gate = await gateIngest(stub, opts);
     if (gate.skipped) return gate;
     return startCreatedIngest(env, stub);
   }
   return startCreatedIngest(env);
 }
 
-/** Choose the instance id, persist+verify `workflow_runs`, then
- * `create({ id })`. POST `{id}` is this uuid, not whatever create()
- * would mint after a D1 write that may never commit. */
+async function gateIngest(
+  stub: IngestSchedulerRpc,
+  opts: IngestTickOpts
+): Promise<IngestTickResult> {
+  try {
+    return await stub.canStart(opts);
+  } catch (error) {
+    // Old DO isolate without canStart. Force still has to persist+create
+    // on the Worker; non-force also proceeds rather than calling tick()
+    // (that would create() without a lastRun row).
+    console.error("ingest scheduler canStart failed:", error);
+    return { id: null, skipped: false, reason: "gate-unavailable" };
+  }
+}
+
+/** Choose the instance id, persist+verify `workflow_runs` as lastRun,
+ * then `create({ id })` from this Worker. POST `{id}` is this uuid. */
 async function startCreatedIngest(
   env: {
     DB?: D1Runner;
     NEWS_INGEST: Workflow;
   },
-  stub?: Pick<IngestSchedulerRpc, "startInstance">
+  stub?: Pick<IngestSchedulerRpc, "markStarted">
 ): Promise<IngestTickResult> {
   const id = crypto.randomUUID();
   const result: IngestTickResult = { id, skipped: false };
   await persistCreatedIngestRunVerified(env.DB, result);
-  if (stub) {
-    const started = await stub.startInstance(id);
-    return {
-      id,
-      skipped: false,
-      reason: started.reason,
-    };
+  try {
+    await env.NEWS_INGEST.create({ id });
+  } catch (error) {
+    console.error("NEWS_INGEST.create failed after persist:", error);
+    result.reason = error instanceof Error ? error.message : String(error);
   }
-  await env.NEWS_INGEST.create({ id });
+  if (stub) {
+    try {
+      await stub.markStarted(id);
+    } catch (error) {
+      console.error("ingest scheduler markStarted failed:", error);
+    }
+  }
   return result;
 }
 
@@ -111,13 +131,16 @@ export async function persistCreatedIngestRun(
   );
 }
 
-/** Must succeed before `create()` / POST 2xx. Throws if D1 does not
- * read back the row. No-ops when DB is unbound (unit tests). */
+/** Must succeed before `create()` / POST 2xx. Throws if D1 is unbound or
+ * does not read back the row as lastRun. */
 export async function persistCreatedIngestRunVerified(
   db: D1Runner | undefined,
   result: IngestTickResult
 ): Promise<void> {
-  if (result.skipped || !result.id || !db) return;
+  if (result.skipped || !result.id) return;
+  if (!db) {
+    throw new Error("workflow_runs persist requires DB");
+  }
   await persistOpenedWorkflowRunVerified(
     db,
     result.id,

--- a/apps/news/worker/ingest-scheduler.ts
+++ b/apps/news/worker/ingest-scheduler.ts
@@ -17,12 +17,18 @@ const LAST_STARTED_KEY = "last_started_at";
  * watchdog; both paths call `tick()` so overlapping POSTs coalesce.
  *
  * HTTP `POST /api/admin/ingest` uses `canStart` + Worker D1 persist +
- * `startInstance` so `workflow_runs` is committed on the same binding
- * `/api/system` reads **before** `NEWS_INGEST.create()`.
+ * Worker `NEWS_INGEST.create({ id })` + `markStarted`. Alarm `tick()`
+ * still creates from this isolate (best-effort persist).
  */
 export class NewsIngestScheduler extends DurableObject<Env> {
   async alarm(): Promise<void> {
     await this.tick();
+  }
+
+  async markStarted(_id: string): Promise<void> {
+    const now = Date.now();
+    await this.ctx.storage.put(LAST_STARTED_KEY, now);
+    await this.ctx.storage.setAlarm(nextAlarmAt(now));
   }
 
   async canStart(opts: IngestTickOpts = {}): Promise<IngestTickResult> {

--- a/apps/news/worker/workflow-run.ts
+++ b/apps/news/worker/workflow-run.ts
@@ -24,10 +24,11 @@ RETURNING id, started_at`;
 export const SELECT_WORKFLOW_RUN_ID_SQL =
   "SELECT id FROM workflow_runs WHERE id = ?";
 
-/** Same ordering `/api/system` uses for lastRun. A WHERE-id hit that is
- * not this row is still a phantom as far as recert is concerned. */
+/** Same ordering `/api/system` uses for lastRun. `id DESC` breaks ties when
+ * two rows share a second-precision `started_at` (concurrent force/alarm).
+ * A WHERE-id hit that is not this row is still a phantom for recert. */
 export const SELECT_LATEST_WORKFLOW_RUN_ID_SQL =
-  "SELECT id FROM workflow_runs ORDER BY started_at DESC LIMIT 1";
+  "SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 1";
 
 const PERSIST_ATTEMPTS = 3;
 

--- a/apps/news/worker/workflow-run.ts
+++ b/apps/news/worker/workflow-run.ts
@@ -3,20 +3,31 @@ import { buildRunStats, serializeRunStats } from "./run-stats.js";
 
 /** Upsert used by ingest open-run / close-run. ON CONFLICT so a Workflow
  * replay, a JS `finally`, and the durable `close-run` step can all write
- * the same `workflow_runs.id` without failing the instance. */
+ * the same `workflow_runs.id` without failing the instance.
+ * `started_at` is updated on conflict so lastRun ORDER BY cannot keep an
+ * older row on top. RETURNING is the write-path proof #1411's separate
+ * `WHERE id = ?` SELECT did not provide (live POST `5419a68e-…` was 2xx
+ * with no lastRun row). */
 export const UPSERT_WORKFLOW_RUN_SQL = `INSERT INTO workflow_runs (id, started_at, finished_at, items_fetched, items_new, error, stats)
 VALUES (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
+  started_at = excluded.started_at,
   finished_at = excluded.finished_at,
   items_fetched = excluded.items_fetched,
   items_new = excluded.items_new,
   error = excluded.error,
-  stats = excluded.stats`;
+  stats = excluded.stats
+RETURNING id, started_at`;
 
 /** Read-your-writes check after the HTTP create-path upsert so POST does
  * not return an id that `/api/system` cannot see. */
 export const SELECT_WORKFLOW_RUN_ID_SQL =
   "SELECT id FROM workflow_runs WHERE id = ?";
+
+/** Same ordering `/api/system` uses for lastRun. A WHERE-id hit that is
+ * not this row is still a phantom as far as recert is concerned. */
+export const SELECT_LATEST_WORKFLOW_RUN_ID_SQL =
+  "SELECT id FROM workflow_runs ORDER BY started_at DESC LIMIT 1";
 
 const PERSIST_ATTEMPTS = 3;
 
@@ -33,12 +44,17 @@ export interface WorkflowRunRecord {
 export interface D1BoundStatement {
   run: () => Promise<unknown>;
   first: <T>() => Promise<T | null>;
+  all?: () => Promise<{ results?: unknown[] } | unknown>;
+}
+
+export interface D1PreparedStatement {
+  bind: (...args: unknown[]) => D1BoundStatement;
+  first?: <T>() => Promise<T | null>;
 }
 
 export interface D1Runner {
-  prepare: (sql: string) => {
-    bind: (...args: unknown[]) => D1BoundStatement;
-  };
+  prepare: (sql: string) => D1PreparedStatement;
+  withSession?: (constraint: string) => D1Runner;
 }
 
 function d1RunFailed(result: unknown): boolean {
@@ -48,6 +64,40 @@ function d1RunFailed(result: unknown): boolean {
     "success" in result &&
     (result as { success: unknown }).success === false
   );
+}
+
+function d1DidNotWrite(result: unknown): boolean {
+  if (!result || typeof result !== "object") return false;
+  const meta = (result as { meta?: { changes?: unknown; rows_written?: unknown } })
+    .meta;
+  if (!meta) return false;
+  const written =
+    typeof meta.changes === "number"
+      ? meta.changes
+      : typeof meta.rows_written === "number"
+        ? meta.rows_written
+        : null;
+  return written !== null && written < 1;
+}
+
+/** D1 `.first()`, `.all().results[0]`, or a row-shaped object. */
+export function d1RowId(result: unknown): string | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const rec = result as { id?: unknown; results?: unknown[] };
+  if (typeof rec.id === "string" && rec.id.length > 0) return rec.id;
+  const row = Array.isArray(rec.results) ? rec.results[0] : undefined;
+  if (row && typeof row === "object" && typeof (row as { id?: unknown }).id === "string") {
+    const id = (row as { id: string }).id;
+    if (id.length > 0) return id;
+  }
+  return undefined;
+}
+
+export function d1Session(db: D1Runner): D1Runner {
+  if (typeof db.withSession === "function") {
+    return db.withSession("first-primary");
+  }
+  return db;
 }
 
 export async function persistWorkflowRun(
@@ -68,6 +118,9 @@ export async function persistWorkflowRun(
     .run();
   if (d1RunFailed(result)) {
     throw new Error("workflow_runs upsert returned success=false");
+  }
+  if (d1DidNotWrite(result)) {
+    throw new Error("workflow_runs upsert wrote 0 rows");
   }
 }
 
@@ -112,19 +165,53 @@ export async function persistOpenedWorkflowRun(
   }
 }
 
-async function verifyWorkflowRunRow(db: D1Runner, id: string): Promise<void> {
-  const seen = await db
+async function returningWorkflowRunRow(
+  db: D1Runner,
+  row: WorkflowRunRecord
+): Promise<void> {
+  const bound = db
+    .prepare(UPSERT_WORKFLOW_RUN_SQL)
+    .bind(
+      nn(row.id),
+      nn(row.startedAt),
+      nn(row.finishedAt),
+      nn(row.itemsFetched),
+      nn(row.itemsNew),
+      nn(row.error),
+      nn(row.statsJson)
+    );
+  const written = await bound.first<{ id: string; started_at?: number }>();
+  if (d1RowId(written) !== row.id) {
+    throw new Error(`workflow_runs RETURNING missed ${row.id}`);
+  }
+}
+
+async function verifyWorkflowRunIsLastRun(
+  db: D1Runner,
+  id: string
+): Promise<void> {
+  const byId = await db
     .prepare(SELECT_WORKFLOW_RUN_ID_SQL)
     .bind(id)
     .first<{ id: string }>();
-  if (seen?.id !== id) {
+  if (d1RowId(byId) !== id) {
     throw new Error(`workflow_runs verify missed ${id}`);
+  }
+  const latestStmt = db.prepare(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
+  const latest = latestStmt.first
+    ? await latestStmt.first<{ id: string }>()
+    : await latestStmt.bind().first<{ id: string }>();
+  if (d1RowId(latest) !== id) {
+    throw new Error(
+      `workflow_runs lastRun is ${d1RowId(latest) ?? "null"} after persist ${id}`
+    );
   }
 }
 
 /** Upsert that must stick before POST /api/admin/ingest returns. Throws
- * after retries if D1 does not read back the same id — swallowing here
- * is what left lastRun on 42d830a9 after #1409. */
+ * after retries if D1 does not RETURN the id and show it as lastRun —
+ * #1411's WHERE-id SELECT still let live POST `5419a68e-…` return 2xx
+ * while `/api/system` lastRun stayed `42d830a9-…`. */
 export async function persistOpenedWorkflowRunVerified(
   db: D1Runner,
   id: string,
@@ -132,11 +219,12 @@ export async function persistOpenedWorkflowRunVerified(
   stepName: OpenedRunStepName
 ): Promise<void> {
   const row = openedWorkflowRun(id, startedAt, stepName);
+  const session = d1Session(db);
   let lastError: unknown;
   for (let attempt = 1; attempt <= PERSIST_ATTEMPTS; attempt++) {
     try {
-      await persistWorkflowRun(db, row);
-      await verifyWorkflowRunRow(db, id);
+      await returningWorkflowRunRow(session, row);
+      await verifyWorkflowRunIsLastRun(session, id);
       return;
     } catch (error) {
       lastError = error;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes leftover https://github.com/duyet/monorepo/issues/1412 after #1411.

## What I found (not a schedule fire)

Live `GET https://news.duyet.net/api/system` still shows `lastRun.id` `42d830a9-689c-4e9a-9e91-98e812016b97` (finished 2026-08-26 23:20 ICT), `runsToday` 0, `Cache-Control: no-store`. `5419a68e` is not in `runs[]`.

Confirmed, not invented:

- #1411 squash-merged as `4a8fff8f`. Deploy Cloudflare Workers 33218323707 succeeded; Deploy duyet-news Worker finished 2026-08-28T22:52:28Z.
- Force News Ingest 33218451660 @ `4a8fff8f` POSTed `{id: 5419a68e-425b-4f82-b929-c65fd8575150, skipped: false}` in ~2s. That is Cloudflare Workflow `create()`, not a `workflow_runs` row `/api/system` can read.
- Polled `/api/system` immediately after POST and again ~1 minute later: lastRun still `42d830a9`, runsToday 0.
- Last confirmed **schedule** News Ingest is 33211353909 at 2026-08-28T21:09:50Z on `5ea5aa3a`. Do not invent a `:05/:20/:35/:50` fire.

#1411 promised upsert + SELECT-verify **before** `NEWS_INGEST.create({ id })`. What shipped still allowed a 2xx phantom id:

1. Verify was only `SELECT id FROM workflow_runs WHERE id = ?`. That is not the lastRun query (`ORDER BY started_at DESC LIMIT 1`). A WHERE-id hit (or a bind echo) does not mean `/api/system` will show the row.
2. `persistCreatedIngestRunVerified` **no-op’d when DB was unbound**, then still called `create()` and returned the uuid.
3. HTTP `create({ id })` was delegated to the Durable Object `startInstance`. A Workflow instance id is not a `workflow_runs` row the Worker GET can read.

Discarded as the whole story: replica lag hiding `workflow_runs` while `llm_calls`/items from the in-flight instance stay visible (same D1 WAL). The POST never produced a lastRun-shaped row.

## Fix

- Persist with `INSERT … RETURNING id, started_at` (write-path proof, not a later WHERE-id SELECT).
- Require `SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 1` to equal the POST id (same ordering as lastRun; `id DESC` breaks second-precision ties).
- Throw if D1 is unbound. POST cannot return a Workflow id that lastRun cannot show.
- HTTP path: Worker `NEWS_INGEST.create({ id })` after persist; DO only `canStart` + `markStarted`. Alarm `tick()` still best-effort persists then `startInstance`.
- Fail closed on create / canStart / markStarted (rethrow; admin route → HTTP 500). No soft `result.reason` 2xx phantoms for Actions SUCCESS.
- `markStarted` retries 3× then throws. `GET /api/system` reads through `withSession("first-primary")`.
- No Worker cron. No Workflow `schedules`. Does not touch #1362, #1365, or #1407.

## Review follow-up (`1d7f776b`)

Addresses Sourcery blocking findings on create/canStart/markStarted soft-success, plus CodeRabbit lastRun tie-break (`id DESC`).

## Verify (do not wait for or invent a cron fire)

1. Deploy `duyet-news` from this PR.
2. Manual **News Ingest** `workflow_dispatch` (yml POSTs `?force=1`). Treat Actions SUCCESS as POST 2xx only. Note the JSON `id`.
3. As soon as the POST returns — not after ingest finishes — `GET https://news.duyet.net/api/system`: `lastRun.id` must leave `42d830a9-…` and should match the POST `id`. `runsToday > 0`.
4. If persist / create / gate / markStarted cannot stick, the POST should fail (Actions red) instead of returning a phantom Workflow id.

Closes #1412.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6c1c44c-516c-4ff9-a0d1-5fb62df186aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6c1c44c-516c-4ff9-a0d1-5fb62df186aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Ensure news ingest POSTs succeed only when the run is durably persisted and visible as the latest system run before Workflow creation.

Bug Fixes:
- Prevent news ingest requests from returning phantom Workflow IDs when the corresponding run cannot be persisted or exposed as the latest system run.
- Fail ingest requests with an HTTP error when persistence, Workflow creation, scheduler gating, or start-state recording fails.

Enhancements:
- Align run persistence and system statistics with deterministic latest-run ordering and primary-session reads.
- Move HTTP Workflow creation into the Worker path while retaining Durable Object coalescing and alarm scheduling responsibilities.

Documentation:
- Update news ingest documentation and algorithm guidance to describe last-run verification and failure behavior.

Tests:
- Expand ingest, workflow-run, and admin coverage for persistence proofs, latest-run verification, failure propagation, and Worker-side Workflow creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved news ingestion reliability by verifying run records before confirming success.
  * Ensured newly created workflow runs are tracked consistently as the latest run.
  * Added safer failure handling for unavailable scheduling checks and ingestion errors.
  * Improved system statistics consistency and deterministic run ordering.
  * Ingestion failures now return a clear server error instead of appearing successful.

* **Documentation**
  * Clarified ingestion run creation, verification, and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->