### PR TITLE
fix(news): persist ingest lastRun with D1 .run()/batch()

### DIFF
--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -11,13 +11,16 @@ Both paths coalesce: a new instance is skipped if one started in the last
 45 minutes. `POST /api/admin/ingest?force=1` (workflow_dispatch) bypasses
 the window. LLM-heavy Workflow steps use `retries: 0` and a 4-minute
 timeout; a failed score/TL;DR call must not abort close-run. HTTP
-`POST /api/admin/ingest` picks the instance uuid, **upserts with
-RETURNING and lastRun-verifies** `workflow_runs` on the Worker D1
-binding (`first-primary` session), then `NEWS_INGEST.create({ id })`
-from that isolate. The Durable Object only gates the 45-minute
-coalesce and records last-started. A failed persist must fail the
-POST — #1411's WHERE-id SELECT still returned 2xx for
-`5419a68e-…` while lastRun stayed `42d830a9-…`. `run()` still upserts at start
+`POST /api/admin/ingest` picks the instance uuid, **upserts `workflow_runs`
+with `.run()` / `batch()` (D1 writes do not populate `.first()` / `.results`)
+then lastRun-verifies** on the Worker D1 binding (`first-primary` session,
+`ORDER BY started_at DESC, id DESC LIMIT 1` — same query `/api/system`
+uses). A 2xx POST cannot happen unless that SELECT returns the POST id.
+Then `NEWS_INGEST.create({ id })` from that isolate. The Durable Object
+only gates the 45-minute coalesce and records last-started. #1413's
+INSERT…RETURNING `.first()` 500'd the live force POST; #1411's WHERE-id
+SELECT was 2xx for `5419a68e-…` while lastRun stayed `42d830a9-…`.
+`run()` still upserts at start
 **before** `pruneLlmCalls` / fetch / LLM. Do not wrap `open-run` in
 `safeStep`. Score and
 TL;DR hang-cap per model at 70s/90s (translate stays 25s). Do not treat

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -55,9 +55,11 @@ coalesce if a run started in the last 45 minutes. Manual
 skip. Actions SUCCESS is only the POST; poll `GET /api/system` (no admin
 token, `Cache-Control: no-store`) until `lastRun.id` is no longer the
 previous id and `runsToday > 0`. The POST JSON `id` is chosen before
-`NEWS_INGEST.create({ id })` and must be lastRun (`INSERT … RETURNING`
-plus `ORDER BY started_at DESC, id DESC LIMIT 1`) before the POST returns.
-A persist miss fails the POST instead of returning a Workflow id.
+`NEWS_INGEST.create({ id })` and must be lastRun: D1 `.run()`/`batch()`
+upsert, then `SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC
+LIMIT 1` (the same query `/api/system` uses for `lastRun`). A persist miss
+fails the POST instead of returning a Workflow id. INSERT RETURNING +
+`.first()` is not that proof — D1 write results are empty.
 Do not invent a scheduled `:05/:20/:35/:50` fire.
 
 ## Admin API / MCP

--- a/apps/news/worker/__tests__/ingest-schedule.test.ts
+++ b/apps/news/worker/__tests__/ingest-schedule.test.ts
@@ -15,32 +15,40 @@ import {
 import {
   type D1Runner,
   SELECT_LATEST_WORKFLOW_RUN_ID_SQL,
-  SELECT_WORKFLOW_RUN_ID_SQL,
   UPSERT_WORKFLOW_RUN_SQL,
 } from "../workflow-run.js";
 
-function trackingDb(order: string[], lastRunId?: { current: string }): D1Runner {
+function trackingDb(
+  order: string[],
+  lastRunId?: { current: string }
+): D1Runner {
   const prepare = vi.fn((sql: string) => {
     if (sql.startsWith("INSERT")) order.push("persist");
     else if (sql.includes("ORDER BY")) order.push("verify-last");
     else order.push("verify");
+    const row = () => {
+      const id = lastRunId?.current;
+      return {
+        success: true,
+        meta: { changes: 1, rows_written: 1 },
+        results: [{ id, started_at: 1 }],
+        id,
+        started_at: 1,
+      };
+    };
     return {
       bind: (...args: unknown[]) => {
         if (typeof args[0] === "string" && lastRunId) {
           lastRunId.current = args[0];
         }
-        const id = (args[0] as string | undefined) ?? lastRunId?.current;
         return {
-          run: async () => ({
-            success: true,
-            meta: { changes: 1, rows_written: 1 },
-            results: [{ id, started_at: 1 }],
-          }),
-          first: async <T>() => ({ id, started_at: 1 }) as T,
+          run: async () => row(),
+          first: async <T>() =>
+            ({ id: lastRunId?.current, started_at: 1 }) as T,
         };
       },
-      first: async <T>() =>
-        ({ id: lastRunId?.current, started_at: 1 }) as T,
+      first: async <T>() => ({ id: lastRunId?.current, started_at: 1 }) as T,
+      run: async () => row(),
     };
   });
   return { prepare };
@@ -121,10 +129,9 @@ describe("tickIngest", () => {
       NEWS_INGEST: { create } as unknown as Workflow,
     });
     expect(result.skipped).toBe(false);
-    expect(order).toEqual(["persist", "verify", "verify-last", "create"]);
+    expect(order).toEqual(["persist", "verify-last", "create"]);
     expect(create).toHaveBeenCalledWith({ id: result.id });
     expect(db.prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
-    expect(db.prepare).toHaveBeenCalledWith(SELECT_WORKFLOW_RUN_ID_SQL);
     expect(db.prepare).toHaveBeenCalledWith(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
   });
 
@@ -168,14 +175,7 @@ describe("tickIngest", () => {
     expect(startInstance).not.toHaveBeenCalled();
     expect(create).toHaveBeenCalledWith({ id: result.id });
     expect(markStarted).toHaveBeenCalledWith(result.id);
-    expect(order).toEqual([
-      "gate",
-      "persist",
-      "verify",
-      "verify-last",
-      "create",
-      "mark",
-    ]);
+    expect(order).toEqual(["gate", "persist", "verify-last", "create", "mark"]);
     expect(db.prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
   });
 
@@ -258,7 +258,7 @@ describe("tickIngest", () => {
         } as unknown as DurableObjectNamespace,
       })
     ).rejects.toThrow(/workflow create rejected/);
-    expect(order).toEqual(["persist", "verify", "verify-last", "create"]);
+    expect(order).toEqual(["persist", "verify-last", "create"]);
     expect(markStarted).not.toHaveBeenCalled();
   });
 
@@ -314,20 +314,21 @@ describe("persistCreatedIngestRunVerified", () => {
     ).rejects.toThrow(/requires DB/);
   });
 
-  it("throws when D1 does not RETURN the row", async () => {
+  it("throws when lastRun SELECT does not return the persisted id", async () => {
     const prepare = vi.fn().mockReturnValue({
       bind: () => ({
-        run: async () => ({ success: true }),
+        run: async () => ({ success: true, meta: { changes: 1 } }),
         first: async () => null,
       }),
       first: async () => null,
+      run: async () => ({ results: [] }),
     });
     await expect(
       persistCreatedIngestRunVerified(
         { prepare },
         { id: "wf-missing", skipped: false }
       )
-    ).rejects.toThrow(/RETURNING missed wf-missing/);
+    ).rejects.toThrow(/lastRun is null after persist wf-missing/);
   });
 });
 

--- a/apps/news/worker/__tests__/workflow-run.test.ts
+++ b/apps/news/worker/__tests__/workflow-run.test.ts
@@ -27,6 +27,13 @@ describe("UPSERT_WORKFLOW_RUN_SQL", () => {
   });
 });
 
+describe("D1Runner", () => {
+  it("accepts D1Database so Env.DB assigns at tickIngest/persist", () => {
+    const use = (_db: D1Runner): void => undefined;
+    use({} as D1Database);
+  });
+});
+
 describe("persistWorkflowRun", () => {
   it("binds the row onto the upsert statement", async () => {
     const run = vi.fn().mockResolvedValue({ success: true });

--- a/apps/news/worker/__tests__/workflow-run.test.ts
+++ b/apps/news/worker/__tests__/workflow-run.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  type D1Runner,
   ingestRunId,
   jsonMap,
   mapEntries,
@@ -7,9 +8,7 @@ import {
   persistOpenedWorkflowRun,
   persistOpenedWorkflowRunVerified,
   persistWorkflowRun,
-  type D1Runner,
   SELECT_LATEST_WORKFLOW_RUN_ID_SQL,
-  SELECT_WORKFLOW_RUN_ID_SQL,
   UPSERT_WORKFLOW_RUN_SQL,
 } from "../workflow-run.js";
 
@@ -24,7 +23,7 @@ describe("UPSERT_WORKFLOW_RUN_SQL", () => {
     expect(UPSERT_WORKFLOW_RUN_SQL).toContain(
       "started_at = excluded.started_at"
     );
-    expect(UPSERT_WORKFLOW_RUN_SQL).toContain("RETURNING id, started_at");
+    expect(UPSERT_WORKFLOW_RUN_SQL).not.toContain("RETURNING");
   });
 });
 
@@ -133,11 +132,23 @@ describe("persistOpenedWorkflowRun", () => {
 });
 
 describe("persistOpenedWorkflowRunVerified", () => {
-  it("upserts via RETURNING then confirms lastRun", async () => {
-    const run = vi.fn().mockResolvedValue({ success: true });
+  it("upserts via .run() then confirms lastRun (not INSERT RETURNING)", async () => {
+    const run = vi.fn().mockResolvedValue({
+      success: true,
+      meta: { changes: 1 },
+      results: [],
+    });
     const first = vi.fn().mockResolvedValue({ id: "wf-1", started_at: 1 });
     const bind = vi.fn().mockReturnValue({ run, first });
-    const prepare = vi.fn().mockReturnValue({ bind, first });
+    const prepare = vi.fn((sql: string) => ({
+      bind,
+      first: sql.includes("ORDER BY")
+        ? async () => ({ id: "wf-1", started_at: 1 })
+        : first,
+      run: sql.includes("ORDER BY")
+        ? async () => ({ results: [{ id: "wf-1" }] })
+        : run,
+    }));
     await persistOpenedWorkflowRunVerified(
       { prepare } as D1Runner,
       "wf-1",
@@ -145,29 +156,67 @@ describe("persistOpenedWorkflowRunVerified", () => {
       "create"
     );
     expect(prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
-    expect(prepare).toHaveBeenCalledWith(SELECT_WORKFLOW_RUN_ID_SQL);
     expect(prepare).toHaveBeenCalledWith(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
-    expect(first).toHaveBeenCalled();
+    expect(run).toHaveBeenCalled();
+    expect(first).not.toHaveBeenCalled();
   });
 
-  it("throws after retries when RETURNING misses", async () => {
+  it("uses batch write+lastRun SELECT when batch is bound", async () => {
+    const bind = vi.fn().mockReturnValue({
+      run: async () => ({ success: true, meta: { changes: 1 }, results: [] }),
+    });
+    const prepare = vi.fn((sql: string) => ({
+      bind,
+      run: async () =>
+        sql.includes("ORDER BY")
+          ? { results: [{ id: "wf-batch" }] }
+          : { success: true, meta: { changes: 1 }, results: [] },
+    }));
+    const batch = vi.fn(async (stmts: { run: () => Promise<unknown> }[]) => {
+      const results = [];
+      for (const stmt of stmts) results.push(await stmt.run());
+      return results;
+    });
+    await persistOpenedWorkflowRunVerified(
+      { prepare, batch } as D1Runner,
+      "wf-batch",
+      1,
+      "create"
+    );
+    expect(batch).toHaveBeenCalledOnce();
+    expect(prepare).toHaveBeenCalledWith(UPSERT_WORKFLOW_RUN_SQL);
+    expect(prepare).toHaveBeenCalledWith(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
+    expect(bind).toHaveBeenCalled();
+  });
+
+  it("throws after retries when lastRun SELECT misses", async () => {
     const prepare = vi.fn().mockReturnValue({
       bind: () => ({
-        run: async () => ({ success: true }),
+        run: async () => ({ success: true, meta: { changes: 1 } }),
         first: async () => null,
       }),
       first: async () => null,
+      run: async () => ({ results: [] }),
     });
     await expect(
-      persistOpenedWorkflowRunVerified({ prepare } as D1Runner, "wf-1", 1, "create")
-    ).rejects.toThrow(/RETURNING missed wf-1/);
-    expect(prepare).toHaveBeenCalledTimes(3);
+      persistOpenedWorkflowRunVerified(
+        { prepare } as D1Runner,
+        "wf-1",
+        1,
+        "create"
+      )
+    ).rejects.toThrow(/lastRun is null after persist wf-1/);
+    expect(prepare).toHaveBeenCalled();
   });
 
-  it("throws when RETURNING echoes the id but lastRun is still another row", async () => {
+  it("throws when the write reports success but lastRun is still another row", async () => {
     const prepare = vi.fn((sql: string) => ({
       bind: () => ({
-        run: async () => ({ success: true }),
+        run: async () => ({
+          success: true,
+          meta: { changes: 1 },
+          results: [{ id: "wf-1" }],
+        }),
         first: async () =>
           sql.includes("ORDER BY")
             ? { id: "42d830a9-689c-4e9a-9e91-98e812016b97" }
@@ -177,9 +226,18 @@ describe("persistOpenedWorkflowRunVerified", () => {
         sql.includes("ORDER BY")
           ? { id: "42d830a9-689c-4e9a-9e91-98e812016b97" }
           : { id: "wf-1", started_at: 1 },
+      run: async () =>
+        sql.includes("ORDER BY")
+          ? { results: [{ id: "42d830a9-689c-4e9a-9e91-98e812016b97" }] }
+          : { success: true, meta: { changes: 1 }, results: [{ id: "wf-1" }] },
     }));
     await expect(
-      persistOpenedWorkflowRunVerified({ prepare } as D1Runner, "wf-1", 1, "create")
+      persistOpenedWorkflowRunVerified(
+        { prepare } as D1Runner,
+        "wf-1",
+        1,
+        "create"
+      )
     ).rejects.toThrow(/lastRun is 42d830a9/);
     expect(prepare).toHaveBeenCalled();
   });

--- a/apps/news/worker/ingest-schedule.ts
+++ b/apps/news/worker/ingest-schedule.ts
@@ -137,7 +137,7 @@ export async function persistCreatedIngestRun(
 }
 
 /** Must succeed before `create()` / POST 2xx. Throws if D1 is unbound or
- * does not read back the row as lastRun. */
+ * lastRun (`ORDER BY started_at DESC, id DESC LIMIT 1`) is not this id. */
 export async function persistCreatedIngestRunVerified(
   db: D1Runner | undefined,
   result: IngestTickResult

--- a/apps/news/worker/workflow-run.ts
+++ b/apps/news/worker/workflow-run.ts
@@ -5,9 +5,12 @@ import { buildRunStats, serializeRunStats } from "./run-stats.js";
  * replay, a JS `finally`, and the durable `close-run` step can all write
  * the same `workflow_runs.id` without failing the instance.
  * `started_at` is updated on conflict so lastRun ORDER BY cannot keep an
- * older row on top. RETURNING is the write-path proof #1411's separate
- * `WHERE id = ?` SELECT did not provide (live POST `5419a68e-…` was 2xx
- * with no lastRun row). */
+ * older row on top.
+ *
+ * No RETURNING: D1 `.first()` / `.run().results` are empty for INSERT
+ * (`results` is empty for writes). #1413 used INSERT…RETURNING + `.first()`
+ * as write-path proof; live force POST then HTTP 500'd (`RETURNING missed`)
+ * and lastRun stayed `42d830a9-…`. Writes go through `.run()` / `batch()`. */
 export const UPSERT_WORKFLOW_RUN_SQL = `INSERT INTO workflow_runs (id, started_at, finished_at, items_fetched, items_new, error, stats)
 VALUES (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
@@ -16,17 +19,12 @@ ON CONFLICT(id) DO UPDATE SET
   items_fetched = excluded.items_fetched,
   items_new = excluded.items_new,
   error = excluded.error,
-  stats = excluded.stats
-RETURNING id, started_at`;
-
-/** Read-your-writes check after the HTTP create-path upsert so POST does
- * not return an id that `/api/system` cannot see. */
-export const SELECT_WORKFLOW_RUN_ID_SQL =
-  "SELECT id FROM workflow_runs WHERE id = ?";
+  stats = excluded.stats`;
 
 /** Same ordering `/api/system` uses for lastRun. `id DESC` breaks ties when
  * two rows share a second-precision `started_at` (concurrent force/alarm).
- * A WHERE-id hit that is not this row is still a phantom for recert. */
+ * This SELECT — not WHERE-id and not INSERT RETURNING — is the 2xx gate:
+ * a bind-echo or write-shaped `{id}` is not lastRun. */
 export const SELECT_LATEST_WORKFLOW_RUN_ID_SQL =
   "SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 1";
 
@@ -51,11 +49,15 @@ export interface D1BoundStatement {
 export interface D1PreparedStatement {
   bind: (...args: unknown[]) => D1BoundStatement;
   first?: <T>() => Promise<T | null>;
+  run?: () => Promise<unknown>;
 }
 
 export interface D1Runner {
   prepare: (sql: string) => D1PreparedStatement;
   withSession?: (constraint: string) => D1Runner;
+  batch?: (
+    statements: Array<D1BoundStatement | D1PreparedStatement>
+  ) => Promise<unknown[]>;
 }
 
 function d1RunFailed(result: unknown): boolean {
@@ -69,8 +71,9 @@ function d1RunFailed(result: unknown): boolean {
 
 function d1DidNotWrite(result: unknown): boolean {
   if (!result || typeof result !== "object") return false;
-  const meta = (result as { meta?: { changes?: unknown; rows_written?: unknown } })
-    .meta;
+  const meta = (
+    result as { meta?: { changes?: unknown; rows_written?: unknown } }
+  ).meta;
   if (!meta) return false;
   const written =
     typeof meta.changes === "number"
@@ -87,7 +90,11 @@ export function d1RowId(result: unknown): string | undefined {
   const rec = result as { id?: unknown; results?: unknown[] };
   if (typeof rec.id === "string" && rec.id.length > 0) return rec.id;
   const row = Array.isArray(rec.results) ? rec.results[0] : undefined;
-  if (row && typeof row === "object" && typeof (row as { id?: unknown }).id === "string") {
+  if (
+    row &&
+    typeof row === "object" &&
+    typeof (row as { id?: unknown }).id === "string"
+  ) {
     const id = (row as { id: string }).id;
     if (id.length > 0) return id;
   }
@@ -105,24 +112,8 @@ export async function persistWorkflowRun(
   db: D1Runner,
   row: WorkflowRunRecord
 ): Promise<void> {
-  const result = await db
-    .prepare(UPSERT_WORKFLOW_RUN_SQL)
-    .bind(
-      nn(row.id),
-      nn(row.startedAt),
-      nn(row.finishedAt),
-      nn(row.itemsFetched),
-      nn(row.itemsNew),
-      nn(row.error),
-      nn(row.statsJson)
-    )
-    .run();
-  if (d1RunFailed(result)) {
-    throw new Error("workflow_runs upsert returned success=false");
-  }
-  if (d1DidNotWrite(result)) {
-    throw new Error("workflow_runs upsert wrote 0 rows");
-  }
+  const result = await boundUpsert(db, row).run();
+  assertWriteOk(result);
 }
 
 export type OpenedRunStepName = "create" | "open-run";
@@ -166,11 +157,8 @@ export async function persistOpenedWorkflowRun(
   }
 }
 
-async function returningWorkflowRunRow(
-  db: D1Runner,
-  row: WorkflowRunRecord
-): Promise<void> {
-  const bound = db
+function boundUpsert(db: D1Runner, row: WorkflowRunRecord): D1BoundStatement {
+  return db
     .prepare(UPSERT_WORKFLOW_RUN_SQL)
     .bind(
       nn(row.id),
@@ -181,38 +169,64 @@ async function returningWorkflowRunRow(
       nn(row.error),
       nn(row.statsJson)
     );
-  const written = await bound.first<{ id: string; started_at?: number }>();
-  if (d1RowId(written) !== row.id) {
-    throw new Error(`workflow_runs RETURNING missed ${row.id}`);
+}
+
+async function readLatestWorkflowRunId(
+  db: D1Runner
+): Promise<string | undefined> {
+  const stmt = db.prepare(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
+  if (typeof stmt.run === "function") {
+    return d1RowId(await stmt.run());
+  }
+  if (typeof stmt.first === "function") {
+    return d1RowId(await stmt.first<{ id: string }>());
+  }
+  return d1RowId(await stmt.bind().first<{ id: string }>());
+}
+
+function assertWriteOk(result: unknown): void {
+  if (d1RunFailed(result)) {
+    throw new Error("workflow_runs upsert returned success=false");
+  }
+  if (d1DidNotWrite(result)) {
+    throw new Error("workflow_runs upsert wrote 0 rows");
   }
 }
 
-async function verifyWorkflowRunIsLastRun(
-  db: D1Runner,
-  id: string
-): Promise<void> {
-  const byId = await db
-    .prepare(SELECT_WORKFLOW_RUN_ID_SQL)
-    .bind(id)
-    .first<{ id: string }>();
-  if (d1RowId(byId) !== id) {
-    throw new Error(`workflow_runs verify missed ${id}`);
-  }
-  const latestStmt = db.prepare(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
-  const latest = latestStmt.first
-    ? await latestStmt.first<{ id: string }>()
-    : await latestStmt.bind().first<{ id: string }>();
-  if (d1RowId(latest) !== id) {
+function assertLastRun(latestId: string | undefined, id: string): void {
+  if (latestId !== id) {
     throw new Error(
-      `workflow_runs lastRun is ${d1RowId(latest) ?? "null"} after persist ${id}`
+      `workflow_runs lastRun is ${latestId ?? "null"} after persist ${id}`
     );
   }
 }
 
+/** `.run()` / `batch()` write, then the same lastRun SELECT `/api/system`
+ * uses. INSERT RETURNING + `.first()` is not a D1 write API. */
+async function persistAndConfirmLastRun(
+  db: D1Runner,
+  row: WorkflowRunRecord
+): Promise<void> {
+  const upsert = boundUpsert(db, row);
+  if (typeof db.batch === "function") {
+    const latestStmt = db.prepare(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
+    const [writeResult, latestResult] = await db.batch([upsert, latestStmt]);
+    assertWriteOk(writeResult);
+    // Second batch result only — INSERT `{id}` / empty `.results` is not lastRun.
+    assertLastRun(d1RowId(latestResult), row.id);
+    return;
+  }
+  const writeResult = await upsert.run();
+  assertWriteOk(writeResult);
+  assertLastRun(await readLatestWorkflowRunId(db), row.id);
+}
+
 /** Upsert that must stick before POST /api/admin/ingest returns. Throws
- * after retries if D1 does not RETURN the id and show it as lastRun —
- * #1411's WHERE-id SELECT still let live POST `5419a68e-…` return 2xx
- * while `/api/system` lastRun stayed `42d830a9-…`. */
+ * after retries if D1 does not show the id as lastRun (`ORDER BY
+ * started_at DESC, id DESC LIMIT 1` — same query `/api/system` uses).
+ * #1413's INSERT…RETURNING `.first()` 500'd the live force POST while
+ * lastRun stayed `42d830a9-…`; #1411's WHERE-id SELECT was 2xx for
+ * `5419a68e-…` without that row becoming lastRun. */
 export async function persistOpenedWorkflowRunVerified(
   db: D1Runner,
   id: string,
@@ -224,8 +238,7 @@ export async function persistOpenedWorkflowRunVerified(
   let lastError: unknown;
   for (let attempt = 1; attempt <= PERSIST_ATTEMPTS; attempt++) {
     try {
-      await returningWorkflowRunRow(session, row);
-      await verifyWorkflowRunIsLastRun(session, id);
+      await persistAndConfirmLastRun(session, row);
       return;
     } catch (error) {
       lastError = error;

--- a/apps/news/worker/workflow-run.ts
+++ b/apps/news/worker/workflow-run.ts
@@ -52,12 +52,13 @@ export interface D1PreparedStatement {
   run?: () => Promise<unknown>;
 }
 
+/** Structural subset of `D1Database` / `D1DatabaseSession` so `Env.DB` stays
+ * assignable. Do not add `batch` here: real D1 `batch(D1PreparedStatement[])`
+ * is not assignable to a union that includes `D1BoundStatement` (TS2345 on
+ * `tickIngest(env)` / persist). Call `batch` through `d1Batch()` instead. */
 export interface D1Runner {
   prepare: (sql: string) => D1PreparedStatement;
   withSession?: (constraint: string) => D1Runner;
-  batch?: (
-    statements: Array<D1BoundStatement | D1PreparedStatement>
-  ) => Promise<unknown[]>;
 }
 
 function d1RunFailed(result: unknown): boolean {
@@ -106,6 +107,15 @@ export function d1Session(db: D1Runner): D1Runner {
     return db.withSession("first-primary");
   }
   return db;
+}
+
+/** Duck-typed D1 `batch()`. Kept off `D1Runner` so `D1Database` assigns. */
+function d1BatchFn(
+  db: D1Runner
+): ((statements: unknown[]) => Promise<unknown[]>) | undefined {
+  const batch = (db as { batch?: unknown }).batch;
+  if (typeof batch !== "function") return undefined;
+  return batch as (statements: unknown[]) => Promise<unknown[]>;
 }
 
 export async function persistWorkflowRun(
@@ -208,9 +218,10 @@ async function persistAndConfirmLastRun(
   row: WorkflowRunRecord
 ): Promise<void> {
   const upsert = boundUpsert(db, row);
-  if (typeof db.batch === "function") {
+  const batch = d1BatchFn(db);
+  if (batch) {
     const latestStmt = db.prepare(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
-    const [writeResult, latestResult] = await db.batch([upsert, latestStmt]);
+    const [writeResult, latestResult] = await batch([upsert, latestStmt]);
     assertWriteOk(writeResult);
     // Second batch result only — INSERT `{id}` / empty `.results` is not lastRun.
     assertLastRun(d1RowId(latestResult), row.id);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes leftover https://github.com/duyet/monorepo/issues/1414 after #1413.

## What I found (not a schedule fire)

Live leftover recert after `eb1ecfd4` (#1413). Same HTTP 500 on **both** trigger shapes — persist is shared; the 500 is not unique to `?force=1`:

- Force News Ingest [33229659855](https://github.com/duyet/monorepo/actions/runs/33229659855) `workflow_dispatch` (`?force=1`) → HTTP **500**. Actions red. Body suppressed on non-2xx.
- Hourly News Ingest [33229895386](https://github.com/duyet/monorepo/actions/runs/33229895386) `schedule` at 2026-08-29T02:49:28Z (no `?force=1`) → same HTTP **500**. A coalesce skip would have been 2xx `{skipped:true}`, not 500.
- `GET https://news.duyet.net/api/system` still `lastRun.id` `42d830a9-689c-4e9a-9e91-98e812016b97` (finished 2026-08-26 23:20 ICT), `runsToday` 0. Host 200.

#1413’s fail-closed half is correct: POST is no longer 2xx with a phantom Workflow id. The remaining bug is that persist never produces a `workflow_runs` row `/api/system` can read as lastRun.

**Hypothesis check (persist / `NEWS_INGEST.create` / `canStart` / `markStarted` throwing):**

- `create()` / `markStarted` run *after* persist. If those were the 500, lastRun would already have moved. It did not. Discarded as the 500 cause.
- `canStart` skip is 2xx, not 500. Schedule without `force` also 500'd, so the gate did not skip — persist ran on both paths. Unchanged `canStart` logic is not the new throw.
- Persist *did* throw. #1413 gated 2xx on `INSERT … RETURNING` + `.first()`. Cloudflare D1 documents that **write `.results` are empty** for INSERT/UPDATE/DELETE. `.first()` on that upsert returns `null` → `RETURNING missed` → HTTP 500, and lastRun stays `42d830a9-…`.
- #1411’s `WHERE id = ?` SELECT was a different false positive (bind-shaped `{id}` / not the lastRun query). This change does not use that as proof.

No Worker cron. No Workflow `schedules`. Does not touch #1362, #1365, or #1407.

## Fix

- Upsert `workflow_runs` with `.run()` (and duck-typed `batch()` when bound): the documented D1 write API. Drop RETURNING from the shared UPSERT so Workflow close-run `.run()` is not on an INSERT-RETURNING statement.
- Gate POST 2xx on `SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 1` matching the POST id — same ordering `/api/system` uses for `lastRun` (`id DESC` breaks second-precision ties).
- Write+lastRun SELECT in one D1 `batch()` when available (same primary). Else `.run()` then that SELECT on a `first-primary` session.
- Still fail closed: unbound DB, lastRun miss, `create()`, `canStart`, `markStarted` (3×) → non-2xx. No phantom id.

## Review follow-up (`76c6b301`)

Preview Type check failed TS2345: `D1Runner.batch((D1BoundStatement | D1PreparedStatement)[])` is not assignable from `D1Database.batch(D1PreparedStatement[])`, so `Env` could not be passed to `tickIngest` / persist. `batch` is no longer on `D1Runner` (duck-typed in the persist helper). Persist is still `.run()` / `batch()` + lastRun SELECT — not INSERT RETURNING + `.first()`. Local `pnpm --filter news run check-types` is clean.

## Verify note

`GET /api/system` (no-store, `first-primary`) loads `lastRun` as `runs[0]` from:

```sql
SELECT … FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 30
```

HTTP persist uses the same `ORDER BY started_at DESC, id DESC LIMIT 1`. A 2xx POST cannot happen unless that SELECT returns the POST uuid: persist throws after 3 attempts, and the admin route maps that to HTTP 500. INSERT RETURNING / WHERE-id / Workflow `create({id})` are not that proof. Force and hourly watchdog share that persist; only `canStart` differs (`?force=1` bypasses the 45-minute window).

## Verify (do not wait for or invent a cron fire)

1. Deploy `duyet-news` from this PR.
2. Manual **News Ingest** `workflow_dispatch` (yml POSTs `?force=1`). Treat Actions SUCCESS as POST 2xx only. Note the JSON `id`.
3. As soon as the POST returns — not after ingest finishes — `GET https://news.duyet.net/api/system`: `lastRun.id` must leave `42d830a9-…` and should match the POST `id`. `finished_at` today, `runsToday > 0`.
4. If persist still cannot stick, the POST should fail (Actions red) instead of returning a phantom Workflow id.

Closes #1414.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21cab619-61aa-4ac4-bfea-04bb7a80bd8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21cab619-61aa-4ac4-bfea-04bb7a80bd8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fix news ingest run persistence and verify the recorded run before reporting a successful ingest request.

Bug Fixes:
- Fix news ingest persistence failures caused by relying on D1 INSERT ... RETURNING results for write verification.
- Ensure ingest requests only return success after the persisted run is confirmed as the latest workflow run, preventing phantom workflow IDs.

Enhancements:
- Use D1-supported write execution with `.run()` or `batch()` and align last-run verification with the `/api/system` ordering.
- Retain fail-closed behavior across persistence, workflow creation, coalescing, and start-recording failures.

Documentation:
- Update news ingest algorithm and operational documentation to describe D1 write behavior and last-run verification.

Tests:
- Update ingest persistence tests for `.run()`-based writes, latest-run verification, batch execution, and failure handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ingest reliability by confirming that workflow runs are successfully persisted before reporting success.
  * Prevented false-success responses when the recorded run cannot be verified as the latest run.
  * Updated failure handling and diagnostics for persistence verification issues.

* **Documentation**
  * Clarified ingest-run persistence and verification requirements in the project documentation.

* **Tests**
  * Expanded coverage for successful persistence, batch writes, and failed latest-run verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->