### PR TITLE
fix(news): call D1 batch with binding this so ingest persist sticks

### DIFF
--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -15,7 +15,10 @@ timeout; a failed score/TL;DR call must not abort close-run. HTTP
 with `.run()` / `batch()` (D1 writes do not populate `.first()` / `.results`)
 then lastRun-verifies** on the Worker D1 binding (`first-primary` session,
 `ORDER BY started_at DESC, id DESC LIMIT 1` — same query `/api/system`
-uses). A 2xx POST cannot happen unless that SELECT returns the POST id.
+uses). Invoke `batch()` as a method on the binding — extracting
+`db.batch` throws `Illegal invocation` on the native host object (#1415
+type-check follow-up, live force POST HTTP 500). A 2xx POST cannot happen
+unless that SELECT returns the POST id.
 Then `NEWS_INGEST.create({ id })` from that isolate. The Durable Object
 only gates the 45-minute coalesce and records last-started. #1413's
 INSERT…RETURNING `.first()` 500'd the live force POST; #1411's WHERE-id

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -56,7 +56,8 @@ skip. Actions SUCCESS is only the POST; poll `GET /api/system` (no admin
 token, `Cache-Control: no-store`) until `lastRun.id` is no longer the
 previous id and `runsToday > 0`. The POST JSON `id` is chosen before
 `NEWS_INGEST.create({ id })` and must be lastRun: D1 `.run()`/`batch()`
-upsert, then `SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC
+upsert (call `batch` on the binding; do not extract the host method),
+then `SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC
 LIMIT 1` (the same query `/api/system` uses for `lastRun`). A persist miss
 fails the POST instead of returning a Workflow id. INSERT RETURNING +
 `.first()` is not that proof — D1 write results are empty.

--- a/apps/news/worker/__tests__/workflow-run.test.ts
+++ b/apps/news/worker/__tests__/workflow-run.test.ts
@@ -248,4 +248,136 @@ describe("persistOpenedWorkflowRunVerified", () => {
     ).rejects.toThrow(/lastRun is 42d830a9/);
     expect(prepare).toHaveBeenCalled();
   });
+
+  it("invokes native-style D1 batch with the binding as this", async () => {
+    /** Host-object D1 `batch` throws if extracted (`const fn = db.batch`).
+     * #1415's type-check follow-up did that and live force POST 500'd. */
+    class HostStyleD1 {
+      lastId = "42d830a9-689c-4e9a-9e91-98e812016b97";
+      started = new Map<string, number>([[this.lastId, 1]]);
+
+      latest() {
+        const id = [...this.started.entries()].sort(
+          (a, b) => b[1] - a[1] || b[0].localeCompare(a[0])
+        )[0]?.[0];
+        this.lastId = id ?? this.lastId;
+        return {
+          id: this.lastId,
+          started_at: this.started.get(this.lastId),
+          results: [
+            { id: this.lastId, started_at: this.started.get(this.lastId) },
+          ],
+        };
+      }
+
+      prepare(sql: string) {
+        const isLatest = sql.includes("ORDER BY");
+        return {
+          bind: (...args: unknown[]) => ({
+            run: async () => {
+              const id = args[0] as string;
+              const startedAt = args[1] as number;
+              this.started.set(id, startedAt);
+              return {
+                success: true,
+                meta: { changes: 1, rows_written: 1 },
+                results: [],
+              };
+            },
+            first: async () => this.latest(),
+            all: async () => this.latest(),
+          }),
+          run: async () =>
+            isLatest
+              ? this.latest()
+              : { success: true, meta: { changes: 1 }, results: [] },
+          first: async () => this.latest(),
+          all: async () => this.latest(),
+        };
+      }
+
+      async batch(statements: { run: () => Promise<unknown> }[]) {
+        if (this == null || typeof this.prepare !== "function") {
+          throw new TypeError(
+            "Illegal invocation: D1Database.batch requires the binding receiver"
+          );
+        }
+        const results = [];
+        for (const stmt of statements) results.push(await stmt.run());
+        return results;
+      }
+    }
+
+    const db = new HostStyleD1();
+    const extracted = db.batch;
+    await expect(extracted([])).rejects.toThrow(/Illegal invocation/);
+    await persistOpenedWorkflowRunVerified(
+      db as unknown as D1Runner,
+      "wf-new",
+      2,
+      "create"
+    );
+    expect(db.lastId).toBe("wf-new");
+  });
+
+  it("falls back to .run() + lastRun SELECT when batch throws", async () => {
+    let lastId = "42d830a9-689c-4e9a-9e91-98e812016b97";
+    const prepare = vi.fn((sql: string) => ({
+      bind: (...args: unknown[]) => ({
+        run: async () => {
+          lastId = args[0] as string;
+          return { success: true, meta: { changes: 1 }, results: [] };
+        },
+        first: async () => ({ id: lastId }),
+      }),
+      first: async () => ({ id: lastId }),
+      all: async () => ({ results: [{ id: lastId }] }),
+      run: async () =>
+        sql.includes("ORDER BY")
+          ? { results: [{ id: lastId }] }
+          : { success: true, meta: { changes: 1 }, results: [] },
+    }));
+    const batch = vi.fn(async () => {
+      throw new TypeError("Illegal invocation");
+    });
+    await persistOpenedWorkflowRunVerified(
+      { prepare, batch } as D1Runner,
+      "wf-fallback",
+      2,
+      "create"
+    );
+    expect(batch).toHaveBeenCalled();
+    expect(lastId).toBe("wf-fallback");
+  });
+
+  it("does not treat empty D1 write-shaped batch SELECT results as lastRun", async () => {
+    let lastId = "42d830a9-689c-4e9a-9e91-98e812016b97";
+    const prepare = vi.fn((sql: string) => ({
+      bind: (...args: unknown[]) => ({
+        run: async () => {
+          lastId = args[0] as string;
+          return { success: true, meta: { changes: 1 }, results: [] };
+        },
+        first: async () => ({ id: lastId }),
+      }),
+      first: async () => ({ id: lastId }),
+      all: async () => ({ results: [{ id: lastId }] }),
+      run: async () =>
+        sql.includes("ORDER BY")
+          ? { success: true, meta: {}, results: [] }
+          : { success: true, meta: { changes: 1 }, results: [] },
+    }));
+    const batch = vi.fn(async (stmts: { run: () => Promise<unknown> }[]) => {
+      const results = [];
+      for (const stmt of stmts) results.push(await stmt.run());
+      return results;
+    });
+    await persistOpenedWorkflowRunVerified(
+      { prepare, batch } as D1Runner,
+      "wf-new",
+      2,
+      "create"
+    );
+    expect(lastId).toBe("wf-new");
+  });
 });

--- a/apps/news/worker/workflow-run.ts
+++ b/apps/news/worker/workflow-run.ts
@@ -50,6 +50,7 @@ export interface D1PreparedStatement {
   bind: (...args: unknown[]) => D1BoundStatement;
   first?: <T>() => Promise<T | null>;
   run?: () => Promise<unknown>;
+  all?: () => Promise<{ results?: unknown[] } | unknown>;
 }
 
 /** Structural subset of `D1Database` / `D1DatabaseSession` so `Env.DB` stays
@@ -109,13 +110,21 @@ export function d1Session(db: D1Runner): D1Runner {
   return db;
 }
 
-/** Duck-typed D1 `batch()`. Kept off `D1Runner` so `D1Database` assigns. */
-function d1BatchFn(
-  db: D1Runner
-): ((statements: unknown[]) => Promise<unknown[]>) | undefined {
+/** Duck-typed D1 `batch()`, always invoked with the binding as `this`.
+ * Kept off `D1Runner` so `D1Database` assigns. Do not extract
+ * `const batch = db.batch` and call it unbound: native Workers D1 host
+ * methods throw `Illegal invocation` (#1415 type-check follow-up, live
+ * force POST HTTP 500, lastRun stayed `42d830a9-…`). */
+async function d1Batch(
+  db: D1Runner,
+  statements: unknown[]
+): Promise<unknown[] | undefined> {
   const batch = (db as { batch?: unknown }).batch;
   if (typeof batch !== "function") return undefined;
-  return batch as (statements: unknown[]) => Promise<unknown[]>;
+  const result = await (
+    batch as (this: unknown, stmts: unknown[]) => unknown
+  ).call(db, statements);
+  return Array.isArray(result) ? result : undefined;
 }
 
 export async function persistWorkflowRun(
@@ -185,11 +194,19 @@ async function readLatestWorkflowRunId(
   db: D1Runner
 ): Promise<string | undefined> {
   const stmt = db.prepare(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
-  if (typeof stmt.run === "function") {
-    return d1RowId(await stmt.run());
+  // Prefer row-returning APIs. `.run()` on a write is empty `.results`
+  // (#1413); a SELECT `.run()` that also comes back empty is not lastRun.
+  if (typeof stmt.all === "function") {
+    const id = d1RowId(await stmt.all());
+    if (id) return id;
   }
   if (typeof stmt.first === "function") {
-    return d1RowId(await stmt.first<{ id: string }>());
+    const id = d1RowId(await stmt.first<{ id: string }>());
+    if (id) return id;
+  }
+  if (typeof stmt.run === "function") {
+    const id = d1RowId(await stmt.run());
+    if (id) return id;
   }
   return d1RowId(await stmt.bind().first<{ id: string }>());
 }
@@ -212,23 +229,34 @@ function assertLastRun(latestId: string | undefined, id: string): void {
 }
 
 /** `.run()` / `batch()` write, then the same lastRun SELECT `/api/system`
- * uses. INSERT RETURNING + `.first()` is not a D1 write API. */
+ * uses. INSERT RETURNING + `.first()` is not a D1 write API. Native D1
+ * `batch()` is invoked with the binding as `this`; if that throws or the
+ * SELECT `.results` are empty, fall through to `.run()` + a row read. */
 async function persistAndConfirmLastRun(
   db: D1Runner,
   row: WorkflowRunRecord
 ): Promise<void> {
   const upsert = boundUpsert(db, row);
-  const batch = d1BatchFn(db);
-  if (batch) {
-    const latestStmt = db.prepare(SELECT_LATEST_WORKFLOW_RUN_ID_SQL);
-    const [writeResult, latestResult] = await batch([upsert, latestStmt]);
-    assertWriteOk(writeResult);
-    // Second batch result only — INSERT `{id}` / empty `.results` is not lastRun.
-    assertLastRun(d1RowId(latestResult), row.id);
-    return;
+  let wrote = false;
+  if (typeof (db as { batch?: unknown }).batch === "function") {
+    try {
+      const batched = await d1Batch(db, [
+        upsert,
+        db.prepare(SELECT_LATEST_WORKFLOW_RUN_ID_SQL),
+      ]);
+      if (batched && batched.length >= 2) {
+        assertWriteOk(batched[0]);
+        wrote = true;
+        // Second batch result only — INSERT `{id}` / empty `.results` is not lastRun.
+        if (d1RowId(batched[1]) === row.id) return;
+      }
+    } catch (error) {
+      console.error("create d1 batch failed:", error);
+    }
   }
-  const writeResult = await upsert.run();
-  assertWriteOk(writeResult);
+  if (!wrote) {
+    assertWriteOk(await upsert.run());
+  }
   assertLastRun(await readLatestWorkflowRunId(db), row.id);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1416.

## What I found (force-dispatch leftover, not a schedule)

#1415 (`bde2a293`) is deployed. Force News Ingest [33230803509](https://github.com/duyet/monorepo/actions/runs/33230803509) `workflow_dispatch` (`?force=1`) is still HTTP 500. `GET /api/system` lastRun.id stays `42d830a9-689c-4e9a-9e91-98e812016b97`, `runsToday` 0. Host 200. This leftover is that force POST only — do not invent a `:05/:20/:35/:50` fire.

#1415’s persist path (`.run()` / `batch()` + lastRun `ORDER BY started_at DESC, id DESC LIMIT 1`) is still the 500. `create()` / `markStarted` run after persist; if those threw, lastRun would already have moved. It did not. `canStart` skip is 2xx, not 500.

The type-check follow-up (`76c6b301`) extracted `const batch = db.batch` so `batch` could stay off `D1Runner` (TS2345 vs `D1Database.batch(D1PreparedStatement[])`). Native Workers D1 `batch` is a host method: calling it unbound throws `Illegal invocation`. Persist retries 3× then HTTP 500; the upsert never commits; lastRun stays `42d830a9-…`. Tests passed because they used a standalone `vi.fn()` that does not need `this`.

## Fix

- Invoke D1 `batch()` with the binding as `this` (`Function.prototype.call`).
- If `batch` throws or the batch SELECT comes back write-shaped (empty `.results`), fall through to `.run()` plus a row-returning lastRun read (`.all()` / `.first()`, not INSERT `{id}`).
- Still fail closed: lastRun miss, unbound DB, `create()`, `canStart`, `markStarted` → non-2xx. No phantom Workflow id.

No Worker cron. DO alarm + GitHub watchdog unchanged. Does not touch #1362, #1365, or #1407.

## Tests

Added coverage that fails on the #1415 extract:

- Host-object `batch` that throws `Illegal invocation` when extracted without `this`, and persist still sticks past `42d830a9-…` when called as a method.
- Fallback `.run()` + lastRun SELECT when `batch` throws.
- Empty D1 write-shaped batch SELECT `.results` is not lastRun proof.

`pnpm exec biome lint` on the touched worker files, `pnpm --filter news exec vitest run` on the ingest persist tests, and `pnpm --filter news run check-types` are green.

## Verify (do not wait for or invent a cron fire)

1. Deploy `duyet-news` from this PR.
2. Manual **News Ingest** `workflow_dispatch` (yml POSTs `?force=1`). Treat Actions SUCCESS as POST 2xx only. Note the JSON `id`.
3. As soon as the POST returns — not after ingest finishes — `GET https://news.duyet.net/api/system`: `lastRun.id` must leave `42d830a9-…` and should match the POST `id`. `finished_at` today, `runsToday > 0`.
4. If persist still cannot stick, the POST should fail (Actions red) instead of returning a phantom Workflow id.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-838ca286-333f-40e6-abfa-c10ef09a9a06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-838ca286-333f-40e6-abfa-c10ef09a9a06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Ensure News ingest persists and verifies workflow runs reliably before returning success.

Bug Fixes:
- Fix News ingest persistence failures caused by invoking the native D1 batch method without its database binding.
- Prevent successful ingest responses when lastRun persistence cannot be verified, including empty or write-shaped D1 query results.

Enhancements:
- Add fallback persistence and row-returning lastRun verification when D1 batch execution fails or does not provide proof of the latest run.

Documentation:
- Document the requirement to invoke D1 batch on its binding and verify persistence through the lastRun query.

Tests:
- Add coverage for native-style D1 batch invocation, batch failure fallback, and rejection of empty batch SELECT results as lastRun proof.