### PR TITLE
fix(news): persist ingest lastRun with method-call D1 and epoch ORDER BY

### DIFF
--- a/apps/news/ALGORITHM.md
+++ b/apps/news/ALGORITHM.md
@@ -14,11 +14,14 @@ timeout; a failed score/TL;DR call must not abort close-run. HTTP
 `POST /api/admin/ingest` picks the instance uuid, **upserts `workflow_runs`
 with `.run()` / `batch()` (D1 writes do not populate `.first()` / `.results`)
 then lastRun-verifies** on the Worker D1 binding (`first-primary` session,
-`ORDER BY started_at DESC, id DESC LIMIT 1` — same query `/api/system`
-uses). Invoke `batch()` as a method on the binding — extracting
-`db.batch` throws `Illegal invocation` on the native host object (#1415
-type-check follow-up, live force POST HTTP 500). A 2xx POST cannot happen
-unless that SELECT returns the POST id.
+epoch-normalized `ORDER BY CASE WHEN started_at > 1e12 THEN started_at / 1000
+ELSE started_at END DESC, id DESC LIMIT 1` — same query `/api/system`
+uses). Invoke `batch()` as a **method** on the binding (`db.batch(stmts)`).
+Extracting `db.batch` or `batch.call(db, stmts)` throws `Illegal invocation`
+on native Workers D1 (#1415 extract, #1417 `Function.prototype.call`
+leftover — live force POST still HTTP 500). A leftover millisecond
+`started_at` on `42d830a9-…` must not sort above a newer seconds persist.
+A 2xx POST cannot happen unless that SELECT returns the POST id.
 Then `NEWS_INGEST.create({ id })` from that isolate. The Durable Object
 only gates the 45-minute coalesce and records last-started. #1413's
 INSERT…RETURNING `.first()` 500'd the live force POST; #1411's WHERE-id

--- a/apps/news/README.md
+++ b/apps/news/README.md
@@ -56,11 +56,14 @@ skip. Actions SUCCESS is only the POST; poll `GET /api/system` (no admin
 token, `Cache-Control: no-store`) until `lastRun.id` is no longer the
 previous id and `runsToday > 0`. The POST JSON `id` is chosen before
 `NEWS_INGEST.create({ id })` and must be lastRun: D1 `.run()`/`batch()`
-upsert (call `batch` on the binding; do not extract the host method),
-then `SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC
-LIMIT 1` (the same query `/api/system` uses for `lastRun`). A persist miss
-fails the POST instead of returning a Workflow id. INSERT RETURNING +
-`.first()` is not that proof — D1 write results are empty.
+upsert (`db.batch(stmts)` method call — do not extract the host method
+and do not `.call()` it), then `SELECT id FROM workflow_runs ORDER BY
+CASE WHEN started_at > 1e12 THEN started_at / 1000 ELSE started_at END
+DESC, id DESC LIMIT 1` (the same query `/api/system` uses for `lastRun`).
+A persist miss fails the POST instead of returning a Workflow id.
+INSERT RETURNING + `.first()` is not that proof — D1 write results are
+empty. Native host methods throw `Illegal invocation` for extract and
+for `.call()`.
 Do not invent a scheduled `:05/:20/:35/:50` fire.
 
 ## Admin API / MCP

--- a/apps/news/src/lib/system-queries.test.ts
+++ b/apps/news/src/lib/system-queries.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { WORKFLOW_RUN_STARTED_AT_ORDER_SQL } from "../../worker/workflow-run.js";
 import { loadSystemStats } from "./system-queries";
 
 function makeDb(stubs: Record<string, unknown>) {
@@ -55,5 +56,40 @@ describe("loadSystemStats run timestamp normalization", () => {
     const stats = await loadSystemStats(db, {});
     expect(stats.runs[0]?.started_at).toBe(Math.floor(msStarted / 1000));
     expect(stats.runs[0]?.finished_at).toBe(Math.floor((msStarted + 60_000) / 1000));
+  });
+
+  it("orders lastRun with epoch-normalized started_at so leftover ms rows cannot stay on top", async () => {
+    const seen: string[] = [];
+    const inner = makeDb({
+      "FROM workflow_runs": {
+        all: async () => ({ results: [] }),
+      },
+      "SELECT llm_tokens": {
+        all: async () => {
+          throw new Error("no column");
+        },
+      },
+      "FROM llm_calls": {
+        all: async () => {
+          throw new Error("no table");
+        },
+      },
+      "SELECT stats FROM workflow_runs": {
+        all: async () => ({ results: [{ stats: null }] }),
+      },
+    });
+    const db = {
+      prepare(sql: string) {
+        seen.push(sql);
+        return inner.prepare(sql);
+      },
+    } as unknown as D1Database;
+
+    await loadSystemStats(db, {});
+    const runsSql = seen.find(
+      (sql) => sql.includes("FROM workflow_runs") && sql.includes("LIMIT 30")
+    );
+    expect(runsSql).toContain(WORKFLOW_RUN_STARTED_AT_ORDER_SQL);
+    expect(runsSql).not.toContain("ORDER BY started_at DESC");
   });
 });

--- a/apps/news/src/lib/system-queries.ts
+++ b/apps/news/src/lib/system-queries.ts
@@ -1,3 +1,5 @@
+import { WORKFLOW_RUN_STARTED_AT_ORDER_SQL } from "../../worker/workflow-run.js";
+
 export interface WorkflowRunStats {
   bySource?: Record<string, number>;
   new?: number;
@@ -227,9 +229,10 @@ export async function loadSystemStats(
     supportsLlmCalls(db),
   ]);
 
-  const runsQuery = hasRunStats
-    ? "SELECT id, started_at, finished_at, items_fetched, items_new, error, stats FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 30"
-    : "SELECT id, started_at, finished_at, items_fetched, items_new, error FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 30";
+  const runColumns = hasRunStats
+    ? "id, started_at, finished_at, items_fetched, items_new, error, stats"
+    : "id, started_at, finished_at, items_fetched, items_new, error";
+  const runsQuery = `SELECT ${runColumns} FROM workflow_runs ORDER BY ${WORKFLOW_RUN_STARTED_AT_ORDER_SQL} DESC, id DESC LIMIT 30`;
 
   const [
     itemsTotal,

--- a/apps/news/worker/__tests__/admin.test.ts
+++ b/apps/news/worker/__tests__/admin.test.ts
@@ -62,14 +62,19 @@ class FakeD1 {
     }
 
     if (
-      sql.startsWith(
-        "SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 1"
-      )
+      sql.startsWith("SELECT id FROM workflow_runs") &&
+      sql.includes("ORDER BY") &&
+      sql.includes("LIMIT 1") &&
+      !sql.includes("WHERE")
     ) {
+      const normalize = sql.includes("WHEN started_at");
+      const epoch = (value: unknown): number => {
+        const n = Number(value ?? 0);
+        return normalize && n > 1_000_000_000_000 ? n / 1000 : n;
+      };
       const rows = [...this.workflowRuns].sort(
         (a: Record<string, unknown>, b: Record<string, unknown>): number => {
-          const byStarted =
-            Number(b.started_at ?? 0) - Number(a.started_at ?? 0);
+          const byStarted = epoch(b.started_at) - epoch(a.started_at);
           if (byStarted !== 0) return byStarted;
           return String(b.id ?? "").localeCompare(String(a.id ?? ""));
         }
@@ -954,6 +959,32 @@ describe("triggerIngest", () => {
     const runs = (env.DB as unknown as FakeD1).workflowRuns;
     expect(runs).toHaveLength(1);
     expect(runs[0]?.id).toBe(result.id);
+  });
+
+  it("force persist beats a leftover millisecond lastRun row", async () => {
+    const leftover = "42d830a9-689c-4e9a-9e91-98e812016b97";
+    const env = makeEnv();
+    (env.DB as unknown as FakeD1).workflowRuns.push({
+      id: leftover,
+      started_at: 1_787_761_102_000,
+      finished_at: 1_787_761_102_000,
+      items_fetched: 0,
+      items_new: 0,
+      error: null,
+      stats: "{}",
+    });
+    const result = await triggerIngest(env, { force: true });
+    expect(result.skipped).toBe(false);
+    expect(result.id).not.toBe(leftover);
+    const runs = (env.DB as unknown as FakeD1).workflowRuns;
+    const last = [...runs].sort((a, b) => {
+      const epoch = (value: unknown): number => {
+        const n = Number(value ?? 0);
+        return n > 1_000_000_000_000 ? n / 1000 : n;
+      };
+      return epoch(b.started_at) - epoch(a.started_at);
+    })[0];
+    expect(last?.id).toBe(result.id);
   });
 });
 

--- a/apps/news/worker/__tests__/workflow-run.test.ts
+++ b/apps/news/worker/__tests__/workflow-run.test.ts
@@ -10,6 +10,7 @@ import {
   persistWorkflowRun,
   SELECT_LATEST_WORKFLOW_RUN_ID_SQL,
   UPSERT_WORKFLOW_RUN_SQL,
+  WORKFLOW_RUN_STARTED_AT_ORDER_SQL,
 } from "../workflow-run.js";
 
 describe("UPSERT_WORKFLOW_RUN_SQL", () => {
@@ -112,8 +113,11 @@ describe("openedWorkflowRun", () => {
 });
 
 describe("SELECT_LATEST_WORKFLOW_RUN_ID_SQL", () => {
-  it("breaks started_at ties with id DESC so lastRun is deterministic", () => {
+  it("orders lastRun by epoch-normalized started_at so leftover ms rows lose", () => {
     expect(SELECT_LATEST_WORKFLOW_RUN_ID_SQL).toContain(
+      `${WORKFLOW_RUN_STARTED_AT_ORDER_SQL} DESC, id DESC`
+    );
+    expect(SELECT_LATEST_WORKFLOW_RUN_ID_SQL).not.toContain(
       "ORDER BY started_at DESC, id DESC"
     );
   });
@@ -249,12 +253,16 @@ describe("persistOpenedWorkflowRunVerified", () => {
     expect(prepare).toHaveBeenCalled();
   });
 
-  it("invokes native-style D1 batch with the binding as this", async () => {
-    /** Host-object D1 `batch` throws if extracted (`const fn = db.batch`).
-     * #1415's type-check follow-up did that and live force POST 500'd. */
+  it("invokes native-style D1 batch as a method, never Function.prototype.call", async () => {
+    /** Host-object D1 `batch` throws if extracted (`const fn = db.batch`)
+     * and its own `.call`/`.apply` also throw. #1415 extracted; #1417 used
+     * `batch.call(db, stmts)` which native Workers D1 still rejects. */
+    const leftover = "42d830a9-689c-4e9a-9e91-98e812016b97";
+    const callFlag = { usedCall: false };
+
     class HostStyleD1 {
-      lastId = "42d830a9-689c-4e9a-9e91-98e812016b97";
-      started = new Map<string, number>([[this.lastId, 1]]);
+      lastId = leftover;
+      started = new Map<string, number>([[leftover, 1]]);
 
       latest() {
         const id = [...this.started.entries()].sort(
@@ -272,28 +280,27 @@ describe("persistOpenedWorkflowRunVerified", () => {
 
       prepare(sql: string) {
         const isLatest = sql.includes("ORDER BY");
-        return {
-          bind: (...args: unknown[]) => ({
-            run: async () => {
-              const id = args[0] as string;
-              const startedAt = args[1] as number;
-              this.started.set(id, startedAt);
-              return {
-                success: true,
-                meta: { changes: 1, rows_written: 1 },
-                results: [],
-              };
-            },
-            first: async () => this.latest(),
-            all: async () => this.latest(),
-          }),
-          run: async () =>
-            isLatest
-              ? this.latest()
-              : { success: true, meta: { changes: 1 }, results: [] },
+        const run = async () =>
+          isLatest
+            ? this.latest()
+            : { success: true, meta: { changes: 1 }, results: [] };
+        const first = async () => this.latest();
+        const all = async () => this.latest();
+        const bind = (...args: unknown[]) => ({
+          run: async () => {
+            const id = args[0] as string;
+            const startedAt = args[1] as number;
+            this.started.set(id, startedAt);
+            return {
+              success: true,
+              meta: { changes: 1, rows_written: 1 },
+              results: [],
+            };
+          },
           first: async () => this.latest(),
           all: async () => this.latest(),
-        };
+        });
+        return { bind, run, first, all };
       }
 
       async batch(statements: { run: () => Promise<unknown> }[]) {
@@ -308,15 +315,40 @@ describe("persistOpenedWorkflowRunVerified", () => {
       }
     }
 
+    function installIllegalCall(fn: (...args: never[]) => unknown): void {
+      for (const key of ["call", "apply"] as const) {
+        Object.defineProperty(fn, key, {
+          configurable: true,
+          value(..._args: unknown[]) {
+            callFlag.usedCall = true;
+            throw new TypeError(
+              `Illegal invocation: D1 ${key} requires the binding receiver`
+            );
+          },
+        });
+      }
+    }
+
     const db = new HostStyleD1();
+    installIllegalCall(db.batch);
     const extracted = db.batch;
     await expect(extracted([])).rejects.toThrow(/Illegal invocation/);
+    expect(() =>
+      (
+        extracted as unknown as {
+          call: (thisArg: unknown, stmts: unknown[]) => unknown;
+        }
+      ).call(db, [])
+    ).toThrow(/Illegal invocation/);
+    callFlag.usedCall = false;
+
     await persistOpenedWorkflowRunVerified(
       db as unknown as D1Runner,
       "wf-new",
       2,
       "create"
     );
+    expect(callFlag.usedCall).toBe(false);
     expect(db.lastId).toBe("wf-new");
   });
 
@@ -379,5 +411,174 @@ describe("persistOpenedWorkflowRunVerified", () => {
       "create"
     );
     expect(lastId).toBe("wf-new");
+  });
+
+  it("does not treat a leftover millisecond started_at as lastRun after a seconds persist", async () => {
+    const leftover = "42d830a9-689c-4e9a-9e91-98e812016b97";
+    /** Live GET lastRun after JS normalizeTs is 1787761102 (2026-08-26).
+     * If the D1 row is still stored in ms, raw ORDER BY started_at DESC
+     * keeps it above a newer seconds persist and 500s POST. */
+    const leftoverMs = 1_787_761_102_000;
+    const newId = "wf-seconds";
+    const newSeconds = 1_788_000_000;
+
+    class MixedEpochD1 {
+      started = new Map<string, number>([[leftover, leftoverMs]]);
+
+      latest(sql: string) {
+        const normalize = sql.includes("WHEN started_at");
+        const key = (value: number): number =>
+          normalize && value > 1_000_000_000_000 ? value / 1000 : value;
+        const id = [...this.started.entries()].sort(
+          (a, b) => key(b[1]) - key(a[1]) || b[0].localeCompare(a[0])
+        )[0]?.[0];
+        return {
+          id,
+          started_at: id ? this.started.get(id) : undefined,
+          results: id
+            ? [{ id, started_at: this.started.get(id) }]
+            : [],
+        };
+      }
+
+      prepare(sql: string) {
+        const isLatest = sql.includes("ORDER BY");
+        return {
+          bind: (...args: unknown[]) => ({
+            run: async () => {
+              this.started.set(args[0] as string, args[1] as number);
+              return {
+                success: true,
+                meta: { changes: 1, rows_written: 1 },
+                results: [],
+              };
+            },
+            first: async () => this.latest(sql),
+            all: async () => this.latest(sql),
+          }),
+          run: async () =>
+            isLatest
+              ? this.latest(sql)
+              : { success: true, meta: { changes: 1 }, results: [] },
+          first: async () => this.latest(sql),
+          all: async () => this.latest(sql),
+        };
+      }
+    }
+
+    const db = new MixedEpochD1();
+    await persistOpenedWorkflowRunVerified(
+      db as unknown as D1Runner,
+      newId,
+      newSeconds,
+      "create"
+    );
+    expect(db.latest(SELECT_LATEST_WORKFLOW_RUN_ID_SQL).id).toBe(newId);
+  });
+
+  it("invokes D1 statement run/all/first as methods, not extracted .call", async () => {
+    const leftover = "42d830a9-689c-4e9a-9e91-98e812016b97";
+    const callFlag = { usedCall: false };
+
+    function installIllegalCall(fn: (...args: never[]) => unknown): void {
+      for (const key of ["call", "apply"] as const) {
+        Object.defineProperty(fn, key, {
+          configurable: true,
+          value(..._args: unknown[]) {
+            callFlag.usedCall = true;
+            throw new TypeError(
+              `Illegal invocation: D1 ${key} requires the binding receiver`
+            );
+          },
+        });
+      }
+    }
+
+    class HostStatement {
+      constructor(
+        private readonly owner: HostStmtD1,
+        private readonly sql: string,
+        private readonly args: unknown[] = []
+      ) {}
+
+      bind(...args: unknown[]) {
+        if (this == null) {
+          throw new TypeError("Illegal invocation");
+        }
+        return new HostStatement(this.owner, this.sql, args);
+      }
+
+      async run() {
+        if (this == null) {
+          throw new TypeError("Illegal invocation");
+        }
+        if (this.sql.includes("INSERT") && this.args[0]) {
+          this.owner.started.set(
+            this.args[0] as string,
+            this.args[1] as number
+          );
+          return { success: true, meta: { changes: 1 }, results: [] };
+        }
+        return this.owner.latest();
+      }
+
+      async first() {
+        if (this == null) {
+          throw new TypeError("Illegal invocation");
+        }
+        return this.owner.latest();
+      }
+
+      async all() {
+        if (this == null) {
+          throw new TypeError("Illegal invocation");
+        }
+        return this.owner.latest();
+      }
+    }
+
+    class HostStmtD1 {
+      lastId = leftover;
+      started = new Map<string, number>([[leftover, 1]]);
+
+      latest() {
+        const id = [...this.started.entries()].sort(
+          (a, b) => b[1] - a[1] || b[0].localeCompare(a[0])
+        )[0]?.[0];
+        this.lastId = id ?? this.lastId;
+        return {
+          id: this.lastId,
+          started_at: this.started.get(this.lastId),
+          results: [
+            { id: this.lastId, started_at: this.started.get(this.lastId) },
+          ],
+        };
+      }
+
+      prepare(sql: string) {
+        if (this == null) {
+          throw new TypeError("Illegal invocation");
+        }
+        return new HostStatement(this, sql);
+      }
+    }
+
+    const db = new HostStmtD1();
+    installIllegalCall(HostStatement.prototype.run);
+    installIllegalCall(HostStatement.prototype.first);
+    installIllegalCall(HostStatement.prototype.all);
+    installIllegalCall(HostStatement.prototype.bind);
+    installIllegalCall(HostStmtD1.prototype.prepare);
+    const extractedRun = new HostStatement(db, "SELECT 1").run;
+    await expect(extractedRun()).rejects.toThrow(/Illegal invocation/);
+
+    await persistOpenedWorkflowRunVerified(
+      db as unknown as D1Runner,
+      "wf-stmt",
+      2,
+      "create"
+    );
+    expect(callFlag.usedCall).toBe(false);
+    expect(db.lastId).toBe("wf-stmt");
   });
 });

--- a/apps/news/worker/ingest-schedule.ts
+++ b/apps/news/worker/ingest-schedule.ts
@@ -137,7 +137,8 @@ export async function persistCreatedIngestRun(
 }
 
 /** Must succeed before `create()` / POST 2xx. Throws if D1 is unbound or
- * lastRun (`ORDER BY started_at DESC, id DESC LIMIT 1`) is not this id. */
+ * lastRun (`ORDER BY` epoch-normalized `started_at` DESC, `id` DESC
+ * LIMIT 1) is not this id. */
 export async function persistCreatedIngestRunVerified(
   db: D1Runner | undefined,
   result: IngestTickResult

--- a/apps/news/worker/workflow-run.ts
+++ b/apps/news/worker/workflow-run.ts
@@ -21,12 +21,16 @@ ON CONFLICT(id) DO UPDATE SET
   error = excluded.error,
   stats = excluded.stats`;
 
-/** Same ordering `/api/system` uses for lastRun. `id DESC` breaks ties when
- * two rows share a second-precision `started_at` (concurrent force/alarm).
- * This SELECT — not WHERE-id and not INSERT RETURNING — is the 2xx gate:
- * a bind-echo or write-shaped `{id}` is not lastRun. */
-export const SELECT_LATEST_WORKFLOW_RUN_ID_SQL =
-  "SELECT id FROM workflow_runs ORDER BY started_at DESC, id DESC LIMIT 1";
+/** Same ordering `/api/system` uses for lastRun. Epoch-ms legacy rows
+ * (`started_at > 1e12`) must not sort above a newer seconds persist —
+ * live `42d830a9-…` is 2026-08-26 and may still be stored in ms, so a
+ * raw `ORDER BY started_at DESC` keeps it as lastRun and 500s POST.
+ * `id DESC` breaks second-precision ties. This SELECT — not WHERE-id
+ * and not INSERT RETURNING — is the 2xx gate. */
+export const WORKFLOW_RUN_STARTED_AT_ORDER_SQL =
+  "CASE WHEN started_at > 1000000000000 THEN started_at / 1000 ELSE started_at END";
+
+export const SELECT_LATEST_WORKFLOW_RUN_ID_SQL = `SELECT id FROM workflow_runs ORDER BY ${WORKFLOW_RUN_STARTED_AT_ORDER_SQL} DESC, id DESC LIMIT 1`;
 
 const PERSIST_ATTEMPTS = 3;
 
@@ -110,20 +114,21 @@ export function d1Session(db: D1Runner): D1Runner {
   return db;
 }
 
-/** Duck-typed D1 `batch()`, always invoked with the binding as `this`.
+/** Duck-typed D1 `batch()` via **method call** (`db.batch(stmts)`).
  * Kept off `D1Runner` so `D1Database` assigns. Do not extract
- * `const batch = db.batch` and call it unbound: native Workers D1 host
- * methods throw `Illegal invocation` (#1415 type-check follow-up, live
- * force POST HTTP 500, lastRun stayed `42d830a9-…`). */
+ * `const batch = db.batch` and do not `batch.call(db, stmts)`: native
+ * Workers D1 host methods throw `Illegal invocation` for both (#1415
+ * extract, #1417 `Function.prototype.call` leftover — live force POST
+ * still HTTP 500, lastRun stayed `42d830a9-…`). */
 async function d1Batch(
   db: D1Runner,
   statements: unknown[]
 ): Promise<unknown[] | undefined> {
-  const batch = (db as { batch?: unknown }).batch;
-  if (typeof batch !== "function") return undefined;
-  const result = await (
-    batch as (this: unknown, stmts: unknown[]) => unknown
-  ).call(db, statements);
+  const runner = db as {
+    batch?: (stmts: unknown[]) => Promise<unknown>;
+  };
+  if (typeof runner.batch !== "function") return undefined;
+  const result = await runner.batch(statements);
   return Array.isArray(result) ? result : undefined;
 }
 
@@ -230,8 +235,9 @@ function assertLastRun(latestId: string | undefined, id: string): void {
 
 /** `.run()` / `batch()` write, then the same lastRun SELECT `/api/system`
  * uses. INSERT RETURNING + `.first()` is not a D1 write API. Native D1
- * `batch()` is invoked with the binding as `this`; if that throws or the
- * SELECT `.results` are empty, fall through to `.run()` + a row read. */
+ * `batch()` is a method call on the binding (never extracted, never
+ * `.call()`); if that throws or the SELECT `.results` are empty, fall
+ * through to `.run()` + a row read. */
 async function persistAndConfirmLastRun(
   db: D1Runner,
   row: WorkflowRunRecord
@@ -261,8 +267,8 @@ async function persistAndConfirmLastRun(
 }
 
 /** Upsert that must stick before POST /api/admin/ingest returns. Throws
- * after retries if D1 does not show the id as lastRun (`ORDER BY
- * started_at DESC, id DESC LIMIT 1` — same query `/api/system` uses).
+ * after retries if D1 does not show the id as lastRun (epoch-normalized
+ * `started_at` DESC, `id` DESC LIMIT 1 — same query `/api/system` uses).
  * #1413's INSERT…RETURNING `.first()` 500'd the live force POST while
  * lastRun stayed `42d830a9-…`; #1411's WHERE-id SELECT was 2xx for
  * `5419a68e-…` without that row becoming lastRun. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1418.

#1416 closed at the #1417 merge. This leftover is the recert after that ship — not a reopen of #1416.

## What I found (force-dispatch leftover after #1417, not a schedule)

#1417 squash-merged as `5cf0ba142a017b586b3a4f3342ac2b760c1893ae`. Workers [33231706303](https://github.com/duyet/monorepo/actions/runs/33231706303) + Pages [33231706403](https://github.com/duyet/monorepo/actions/runs/33231706403) green. Host `https://news.duyet.net` 200.

Force News Ingest [33231809423](https://github.com/duyet/monorepo/actions/runs/33231809423) @ `5cf0ba14` `workflow_dispatch` (`?force=1`) is still HTTP 500. No JSON `id`. `GET /api/system` lastRun.id stays `42d830a9-689c-4e9a-9e91-98e812016b97`, `runsToday` 0. Fail-closed is working (no phantom Workflow id). Persist still does not stick.

This leftover is that force POST only. Do not invent a `:05/:20/:35/:50` fire on `5cf0ba14`. Schedule [33231674997](https://github.com/duyet/monorepo/actions/runs/33231674997) at 2026-08-29T03:32:55Z was on `bde2a293` (pre-#1417).

`create()` / `markStarted` run after persist; if those threw, lastRun would already have moved. It did not. `canStart` skip is 2xx, not 500.

#1417 bound `batch` with `Function.prototype.call` / `.call(db, stmts)` after extract. Tests only threw when `this == null`, so `.call(db)` passed. Native Workers D1 host methods can still throw `Illegal invocation` for extract **and** for `.call()` / `.apply()`. A leftover `started_at` stored in milliseconds also sorts above a newer seconds persist under raw `ORDER BY started_at DESC`, so lastRun stays `42d830a9-…` and POST 500s.

## Fix (news worker persist path only)

- Invoke D1 `batch()` as a **method** (`db.batch(stmts)`). Never extract. Never `.call()`.
- lastRun SELECT (and `/api/system` LIMIT 30) use epoch-normalized `started_at` (`CASE WHEN started_at > 1e12 THEN started_at / 1000 ELSE started_at END DESC, id DESC`) so a millisecond leftover cannot stay lastRun after a seconds persist.
- Statement `.run()` / `.all()` / `.first()` stay method calls. Fallback `.run()` + row-returning lastRun read is unchanged.
- Still fail closed: lastRun miss, unbound DB, `create()`, `canStart`, `markStarted` → non-2xx. No phantom Workflow id.

No Worker cron. DO alarm + GitHub watchdog unchanged. Does not touch #1362, #1365, or #1407.

## Tests (fail on the #1417 gap)

- Host-object `batch` whose own `.call` / `.apply` throw `Illegal invocation`; persist must not use `.call()` (`usedCall === false`).
- Host-object statement `.run()` / `.all()` / `.first()` that throw when extracted.
- In-memory leftover `42d830a9-…` with millisecond `started_at`; raw `ORDER BY started_at DESC` would keep it lastRun and throw; CASE SQL lets a seconds persist win.
- `/api/system` runs query uses the same CASE ORDER BY.

`pnpm exec biome lint` on the touched files, `pnpm --filter news exec vitest run` on the ingest persist tests, and `pnpm --filter news run check-types` are green.

## Verify (do not wait for or invent a cron fire)

1. Deploy `duyet-news` from this PR.
2. Manual **News Ingest** `workflow_dispatch` (yml POSTs `?force=1`). Treat Actions SUCCESS as POST 2xx only. Note the JSON `id`.
3. **Immediately after POST 2xx** — not after ingest finishes — `GET https://news.duyet.net/api/system`: `lastRun.id` must leave `42d830a9-689c-4e9a-9e91-98e812016b97` and should match the POST `id`. `finished_at` today, `runsToday > 0`.
4. If persist still cannot stick, the POST must stay non-2xx (Actions red) instead of returning a phantom Workflow id.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-838ca286-333f-40e6-abfa-c10ef09a9a06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-838ca286-333f-40e6-abfa-c10ef09a9a06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Fix News ingest run persistence and lastRun detection so forced ingests reliably verify their stored workflow run before succeeding.

Bug Fixes:
- Fix News ingest persistence failures caused by invoking native D1 host methods incorrectly and by millisecond timestamps overriding newer second-based runs.
- Ensure failed lastRun verification continues to fail the ingest request instead of returning a phantom workflow ID.

Enhancements:
- Use epoch-normalized workflow-run ordering consistently for ingest verification and system statistics, including deterministic ID tie-breaking.

Documentation:
- Update News ingest documentation and algorithm guidance for D1 method invocation and normalized lastRun ordering.

Tests:
- Add coverage for native-style D1 batch and statement methods, mixed timestamp units, force-ingest persistence, and system query ordering.