### PR TITLE
fix(blog): update AnyRouter post to Go $2/mo pricing

### DIFF
--- a/apps/blog/_posts/2026/07/anyrouter.md
+++ b/apps/blog/_posts/2026/07/anyrouter.md
@@ -109,17 +109,17 @@ When those keys go into the shared pool, the idle capacity turns into credits an
   <img src="/media/2026/07/anyrouter/anyrouter-shared-pool-2-bg.png" alt="Shared pool models" loading="lazy" />
 </div>
 
-# Why Starter at $1/mo
+# Why Go at $2/mo
 
 I launched a few weeks ago giving each new user $2 free right after sign up. Thousands of spam accounts got created.
-So I am starting the plan at $1/mo — nothing compared to a $200 Claude or Codex plan or the bunch of other subscriptions you already pay for, not even worth your morning coffee. Honestly, it's a good way to prevent spam.
+So the paid floor is now Go at $2/mo, with $4 credits included — nothing compared to a $200 Claude or Codex plan or the bunch of other subscriptions you already pay for, not even worth your morning coffee. Honestly, it's a good way to prevent spam.
 
 <div class="img-row">
   <img src="/media/2026/07/anyrouter/anyrouter-spam.jpeg" alt="Spam accounts after launch" loading="lazy" />
-  <img src="/media/2026/07/anyrouter/anyrouter-to-start-bg.png" alt="Getting the Starter plan" loading="lazy" />
+  <img src="/media/2026/07/anyrouter/anyrouter-to-start-bg.png" alt="Getting the Go plan" loading="lazy" />
 </div>
 
-Another way to get the Starter plan: donate at least one good shared key to the pool.
+Another way to get Go: donate at least one good shared key to the pool.
 I will improve this over time.
 
 # How I built anyrouter: Self improvement


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Live leftover on [blog.duyet.net/2026/07/anyrouter](https://blog.duyet.net/2026/07/anyrouter/) still presented **Starter at $1/mo** as the current paid plan. Public AnyRouter billing is **Go $2/mo → $4 credits** ([Pricing & Plans](https://docs.anyrouter.dev/features/pricing)).

## Change

`apps/blog/_posts/2026/07/anyrouter.md` (also the `apps/home/_posts` symlink):

- Heading `Why Starter at $1/mo` → `Why Go at $2/mo`
- Keep the $2-free-on-signup spam story as history
- State the current paid floor: Go is $2/mo and includes $4 credits
- Rename Starter → Go in the donate-a-key sentence and screenshot alt text

Small copy change only. No layout, no other plan prices.

## Scope check

Repo search for leftover current-product `Starter` / `$1/mo` AnyRouter pricing:

| Surface | Result |
| --- | --- |
| Blog post | **Fixed** — was claiming $1 as live |
| Home `_posts` | Same file via symlink; no extra edit |
| Home landing `/p/anyrouter` | Out of scope — product blurb, no pricing |
| CV | Out of scope — name + URL only |
| KB | Out of scope — no Starter / $1/mo pricing copy |
| `apps/blog/public/llms-full.txt` | Out of scope — prebuild artifact (`generate-static-files.ts`, gitignored + assume-unchanged). Regenerates from `_posts` on the next blog build/deploy. |

Does not touch #1362, #1365, or #1422. Does not edit anyrouter or chmonitor repos.

Please do not squash-merge.

## Verify

- `rg -n 'Starter|\$1/mo' --glob '*.{md,mdx,tsx,ts,jsx,js,html}'` → no remaining source matches
- Public copy matched against https://docs.anyrouter.dev/features/pricing (`Go — $2/mo`, `$4 in credits every month`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5abf5bd3-740d-4e7b-9e87-788a266ef700?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5abf5bd3-740d-4e7b-9e87-788a266ef700&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Align the AnyRouter blog post with the current Go plan pricing and benefits.

Bug Fixes:
- Update the AnyRouter blog post to accurately present Go at $2/month with $4 in included credits as the current paid plan.

Documentation:
- Refresh AnyRouter plan references, including the heading, plan descriptions, and image alternative text, while preserving the historical signup-credit context.