### PR TITLE
fix(deps): pin @clerk/shared@3.47.8 so blog Pages can build

### DIFF
--- a/.cursor/skills/verify-blog/SKILL.md
+++ b/.cursor/skills/verify-blog/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: verify-blog
+description: Drive and prove blog.duyet.net locally — Vite/TanStack production build, prerendered HTML, and preview. Use when verifying apps/blog Pages deploys, post copy, or Clerk-related production-build failures.
+---
+
+# Verify blog (apps/blog)
+
+Agent-facing skill for the static Vite + TanStack Start blog at `apps/blog` (live: `https://blog.duyet.net`). Public pages are prerendered HTML. The production Pages command is `pnpm --filter blog build` (output `apps/blog/dist/client`). Do not treat `tsc` or unit tests as proof that Pages can publish.
+
+Harness binary (the lever): `.cursor/skills/verify-blog/bin/verify-blog`. Always invoke it by that path from the repo root. It prints JSON. Evidence survives cleanup under `$VERIFY_BLOG_EVIDENCE` (default `/tmp/verify-blog/<run-id>/`).
+
+Feature map: [`features/README.md`](features/README.md). Drive the mapped feature you are claiming, not a convenient substitute.
+
+## Launch
+
+From the monorepo root, with pnpm 10 and workspace `node_modules` installed:
+
+```bash
+pnpm --filter blog build
+```
+
+Ready when the command exits 0 and `apps/blog/dist/client/index.html` exists. This is the same graph CI uses for the `duyet-blog` Pages job (`apps/blog` `build` / `cf:deploy:prod`). A failing production build is a failed launch — do not fall back to `vite dev`.
+
+Optional preview of that output (separate from launch):
+
+```bash
+.cursor/skills/verify-blog/bin/verify-blog preview-start
+```
+
+Ready when `preview.url` in the JSON is answering HTTP 200. Default port 4173 (vite preview). Teardown with `preview-stop` or `cleanup`.
+
+For a short-lived check there is no long-running server: `prove` builds once, inspects HTML, and exits.
+
+## Doctor
+
+Read-only. Run first whenever anything looks off:
+
+```bash
+.cursor/skills/verify-blog/bin/verify-blog doctor
+```
+
+Pass requires:
+
+- Root `pnpm.overrides["@clerk/shared"]` is `3.x` (currently `3.47.8`). `@clerk/clerk-react` 5.x imports `ClientContext` / `OrganizationProvider` / `SessionContext` / `UserContext` from `@clerk/shared/react`. Shared v4 dropped those exports and fails the rolldown production build with `MISSING_EXPORT`.
+- If `node_modules` is present, the resolved `@clerk/shared` package version is also `3.x`.
+- `apps/blog/package.json` `build` script still invokes Vite via `scripts/force-workspace-react.mjs`.
+
+Do not drive an instance whose doctor reports `clerkAligned: false`.
+
+## Drive
+
+Prefer the lever over ad-hoc grep. Recipes live in `features/`. Stable handles:
+
+- Post URL path: `/2026/07/anyrouter/` (file `apps/blog/_posts/2026/07/anyrouter.md`, prerender `apps/blog/dist/client/2026/07/anyrouter/index.html`).
+- Pricing copy that must appear after #1427: `Why Go at $2/mo` and `$4 credits`.
+- Pricing copy that must not appear: `Why Starter at $1/mo`.
+- Clerk failure token: `MISSING_EXPORT` plus those four export names.
+
+```bash
+.cursor/skills/verify-blog/bin/verify-blog prove --feature anyrouter-pricing
+```
+
+That is the proven-drive command: doctor, production build, HTML assertions, JSON report. For HTML-only after a successful build:
+
+```bash
+.cursor/skills/verify-blog/bin/verify-blog drive anyrouter-pricing
+```
+
+Preview (optional, after `preview-start`): open `http://127.0.0.1:<port>/2026/07/anyrouter/`. Assert the visible heading contains `Why Go at $2/mo`. Screenshot the article, not only the chrome.
+
+## Evidence
+
+Named location: `/tmp/verify-blog/<run-id>/` (printed as `evidenceDir` in every command's JSON). Capture:
+
+- `report.json` — lever output (exit, clerk versions, assertion results).
+- `build.log` — full `pnpm --filter blog build` stdout+stderr.
+- `anyrouter.html` — copy of the prerendered post (or an excerpt file if the full HTML is huge).
+- Screenshots: `anyrouter.png` when a preview session was driven. Video optional.
+
+Proof standards:
+
+- Exercise the real Pages artifact (`dist/client` HTML), not the markdown source alone. Source can be merged while production stays on the previous deploy.
+- Capture the action (build command + exit) and the resulting state (file exists + strings present/absent).
+- A green TypeScript check is not proof. The outage was a rolldown `MISSING_EXPORT` during `vite build`.
+- Cleanup must not delete this directory.
+
+## Cleanup
+
+```bash
+.cursor/skills/verify-blog/bin/verify-blog cleanup
+```
+
+Stops only the preview PID this lever started (recorded in `/tmp/verify-blog/state.json`). Never `pkill vite` / `pkill node`. Never delete `evidenceDir`.
+
+## Helpers
+
+```bash
+.cursor/skills/verify-blog/bin/verify-blog doctor
+.cursor/skills/verify-blog/bin/verify-blog build
+.cursor/skills/verify-blog/bin/verify-blog drive anyrouter-pricing
+.cursor/skills/verify-blog/bin/verify-blog prove --feature anyrouter-pricing
+.cursor/skills/verify-blog/bin/verify-blog preview-start
+.cursor/skills/verify-blog/bin/verify-blog preview-stop
+.cursor/skills/verify-blog/bin/verify-blog cleanup
+```
+
+`--help` prints the same list. All commands emit one JSON object on stdout. Non-zero exit means the claim is not verified.

--- a/.cursor/skills/verify-blog/SKILL.md
+++ b/.cursor/skills/verify-blog/SKILL.md
@@ -61,8 +61,9 @@ Do not drive an instance whose doctor reports `clerkAligned: false`.
 Prefer the lever over ad-hoc grep. Recipes live in `features/`. Stable handles:
 
 - Post URL path: `/2026/07/anyrouter/` (file `apps/blog/_posts/2026/07/anyrouter.md`, prerender `apps/blog/dist/client/2026/07/anyrouter/index.html`).
-- Pricing copy that must appear after #1427: `Why Go at $2/mo` and `$4 credits`.
-- Pricing copy that must not appear: `Why Starter at $1/mo`.
+- Pricing copy that must appear: `Why Go is $2/mo`, `$4 monthly credits`, `$2.63`.
+- CLI copy that must appear: `https://anyrouter.dev/setup.sh` and `anyr claude --model z-ai/glm-5.2`.
+- Pricing/CLI copy that must not appear: `Why Starter at $1/mo`, `Why Go at $2/mo`, `npx @anyr/cli claude`.
 - Clerk failure token: `MISSING_EXPORT` plus those four export names.
 
 ```bash
@@ -75,7 +76,7 @@ That is the proven-drive command: doctor, production build, HTML assertions, JSO
 .cursor/skills/verify-blog/bin/verify-blog drive anyrouter-pricing
 ```
 
-Preview (optional, after `preview-start`): open `http://127.0.0.1:<port>/2026/07/anyrouter/`. Assert the visible heading contains `Why Go at $2/mo`. Screenshot the article, not only the chrome.
+Preview (optional, after `preview-start`): open `http://127.0.0.1:<port>/2026/07/anyrouter/`. Assert the visible heading contains `Why Go is $2/mo`. Screenshot the article, not only the chrome.
 
 ## Evidence
 

--- a/.cursor/skills/verify-blog/SKILL.md
+++ b/.cursor/skills/verify-blog/SKILL.md
@@ -114,4 +114,4 @@ Stops only the preview PID this lever started (recorded in `/tmp/verify-blog/sta
 .cursor/skills/verify-blog/bin/verify-blog cleanup
 ```
 
-`--help` prints the same list. All commands emit one JSON object on stdout. Non-zero exit means the claim is not verified.
+`--help` or an empty invocation prints the same list instead of JSON. All other commands emit one JSON object on stdout. Non-zero exit means the claim is not verified.

--- a/.cursor/skills/verify-blog/SKILL.md
+++ b/.cursor/skills/verify-blog/SKILL.md
@@ -13,13 +13,21 @@ Feature map: [`features/README.md`](features/README.md). Drive the mapped featur
 
 ## Launch
 
-From the monorepo root, with pnpm 10 and workspace `node_modules` installed:
+From the monorepo root, with pnpm 10 and workspace `node_modules` installed. WASM pkg files are gitignored; CI runs `pnpm run wasm:build:release` before the blog Pages job. Locally, if `packages/wasm/pkg/markdown/markdown.js` is missing:
+
+```bash
+# rustc 1.85+ (edition 2024), wasm32-unknown-unknown, wasm-pack
+wasm-pack build --target web --out-dir packages/wasm/pkg/markdown --out-name markdown crates/markdown
+# or: pnpm run wasm:build
+```
+
+Then:
 
 ```bash
 pnpm --filter blog build
 ```
 
-Ready when the command exits 0 and `apps/blog/dist/client/index.html` exists. This is the same graph CI uses for the `duyet-blog` Pages job (`apps/blog` `build` / `cf:deploy:prod`). A failing production build is a failed launch — do not fall back to `vite dev`.
+Ready when the command exits 0 and `apps/blog/dist/client/index.html` exists. This is the same graph CI uses for the `duyet-blog` Pages job (`apps/blog` `build` / `cf:deploy:prod`). A failing production build is a failed launch — do not fall back to `vite dev`. Prebuild failing with `Cannot find module .../packages/wasm/pkg/markdown/markdown.js` means WASM was skipped, not a Clerk miss.
 
 Optional preview of that output (separate from launch):
 
@@ -44,6 +52,7 @@ Pass requires:
 - Root `pnpm.overrides["@clerk/shared"]` is `3.x` (currently `3.47.8`). `@clerk/clerk-react` 5.x imports `ClientContext` / `OrganizationProvider` / `SessionContext` / `UserContext` from `@clerk/shared/react`. Shared v4 dropped those exports and fails the rolldown production build with `MISSING_EXPORT`.
 - If `node_modules` is present, the resolved `@clerk/shared` package version is also `3.x`.
 - `apps/blog/package.json` `build` script still invokes Vite via `scripts/force-workspace-react.mjs`.
+- Doctor also reports `wasmMarkdown` (whether `packages/wasm/pkg/markdown/markdown.js` exists). Missing WASM fails prebuild, not Clerk; CI builds WASM before Pages.
 
 Do not drive an instance whose doctor reports `clerkAligned: false`.
 

--- a/.cursor/skills/verify-blog/bin/verify-blog
+++ b/.cursor/skills/verify-blog/bin/verify-blog
@@ -210,8 +210,19 @@ src = pathlib.Path(html_path)
 dest = pathlib.Path(evidence) / "anyrouter.html"
 shutil.copyfile(src, dest)
 text = src.read_text(encoding="utf-8", errors="replace")
-needles_present = ["Why Go at $2/mo", "$4 credits"]
-needles_absent = ["Why Starter at $1/mo"]
+needles_present = [
+    "Why Go is $2/mo",
+    "$4 monthly credits",
+    "$2.63",
+    "anyrouter/free",
+    "https://anyrouter.dev/setup.sh",
+    "anyr claude --model z-ai/glm-5.2",
+]
+needles_absent = [
+    "Why Starter at $1/mo",
+    "Why Go at $2/mo",
+    "npx @anyr/cli claude",
+]
 present = {n: n in text for n in needles_present}
 absent_ok = {n: n not in text for n in needles_absent}
 ok = all(present.values()) and all(absent_ok.values())

--- a/.cursor/skills/verify-blog/bin/verify-blog
+++ b/.cursor/skills/verify-blog/bin/verify-blog
@@ -132,9 +132,11 @@ if pnpm_dir.is_dir():
 resolved_shared = first_version(shared_candidates)
 resolved_react = first_version([root / "node_modules/@clerk/clerk-react/package.json"])
 aligned = override.startswith("3.") and (not resolved_shared or resolved_shared.startswith("3."))
+wasm_md = (root / "packages/wasm/pkg/markdown/markdown.js").is_file()
 out = {
     "ok": aligned,
     "clerkAligned": aligned,
+    "wasmMarkdown": wasm_md,
     "override": override,
     "resolvedShared": resolved_shared,
     "resolvedClerkReact": resolved_react,

--- a/.cursor/skills/verify-blog/bin/verify-blog
+++ b/.cursor/skills/verify-blog/bin/verify-blog
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# CLI lever for .cursor/skills/verify-blog — run from the monorepo root.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+STATE_DIR="${VERIFY_BLOG_STATE_DIR:-/tmp/verify-blog}"
+STATE_FILE="${STATE_DIR}/state.json"
+CMD="${1:-}"
+shift || true
+
+mkdir -p "${STATE_DIR}"
+
+die() {
+  python3 -c 'import json,sys; print(json.dumps({"ok": False, "error": sys.argv[1]}))' "$1"
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+verify-blog — drive apps/blog production build and prerendered HTML
+
+Commands:
+  doctor                         Read-only Clerk pin + script checks
+  build                          pnpm --filter blog build (Pages production)
+  drive <feature>                Inspect prerendered HTML (anyrouter-pricing|post-page|homepage)
+  prove [--feature <id>]         doctor + build + drive (default anyrouter-pricing)
+  preview-start                  vite preview of dist/client
+  preview-stop                   Stop the preview this lever started
+  cleanup                        preview-stop; keep evidence
+  --help                         This text
+
+Evidence: $VERIFY_BLOG_EVIDENCE or /tmp/verify-blog/<run-id>/
+EOF
+}
+
+ensure_root() {
+  [[ -f "${ROOT}/package.json" && -d "${ROOT}/apps/blog" ]] || die "not the monorepo root (${ROOT})"
+}
+
+new_run_id() {
+  date -u +%Y%m%dT%H%M%SZ
+}
+
+read_state_run_id() {
+  python3 - "$STATE_FILE" <<'PY'
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+if not p.is_file():
+    print("")
+    raise SystemExit(0)
+try:
+    print(json.loads(p.read_text()).get("runId", "") or "")
+except json.JSONDecodeError:
+    print("")
+PY
+}
+
+evidence_dir_for() {
+  local id="$1"
+  if [[ -n "${VERIFY_BLOG_EVIDENCE:-}" ]]; then
+    printf '%s' "${VERIFY_BLOG_EVIDENCE}"
+  else
+    printf '%s/%s' "${STATE_DIR}" "${id}"
+  fi
+}
+
+write_state() {
+  python3 - "$STATE_FILE" "$1" "$2" <<'PY'
+import json, sys, pathlib
+path, run_id, evidence = pathlib.Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+state = {}
+if path.is_file():
+    try:
+        state = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        state = {}
+state["runId"] = run_id
+state["evidenceDir"] = evidence
+path.write_text(json.dumps(state))
+PY
+}
+
+resolve_run() {
+  local id="${VERIFY_BLOG_RUN_ID:-}"
+  if [[ -z "${id}" ]]; then
+    id="$(read_state_run_id)"
+  fi
+  if [[ -z "${id}" ]]; then
+    id="$(new_run_id)"
+  fi
+  local evidence
+  evidence="$(evidence_dir_for "${id}")"
+  mkdir -p "${evidence}"
+  write_state "${id}" "${evidence}"
+  printf '%s %s' "${id}" "${evidence}"
+}
+
+html_path_for_anyrouter() {
+  local p="${ROOT}/apps/blog/dist/client/2026/07/anyrouter/index.html"
+  if [[ -f "${p}" ]]; then
+    printf '%s' "${p}"
+    return
+  fi
+  p="${ROOT}/apps/blog/dist/client/2026/07/anyrouter.html"
+  if [[ -f "${p}" ]]; then
+    printf '%s' "${p}"
+  fi
+}
+
+cmd_doctor() {
+  ensure_root
+  python3 - "$ROOT" <<'PY'
+import json, os, sys, pathlib
+root = pathlib.Path(sys.argv[1])
+pkg = json.loads((root / "package.json").read_text())
+override = pkg.get("pnpm", {}).get("overrides", {}).get("@clerk/shared", "")
+blog_build = json.loads((root / "apps/blog/package.json").read_text()).get("scripts", {}).get("build", "")
+
+def first_version(candidates):
+    for path in candidates:
+        if path.is_file():
+            return json.loads(path.read_text()).get("version", "")
+    return ""
+
+shared_candidates = [root / "node_modules/@clerk/shared/package.json"]
+pnpm_dir = root / "node_modules/.pnpm"
+if pnpm_dir.is_dir():
+    for name in os.listdir(pnpm_dir):
+        if name.startswith("@clerk+shared@"):
+            shared_candidates.append(pnpm_dir / name / "node_modules/@clerk/shared/package.json")
+            break
+resolved_shared = first_version(shared_candidates)
+resolved_react = first_version([root / "node_modules/@clerk/clerk-react/package.json"])
+aligned = override.startswith("3.") and (not resolved_shared or resolved_shared.startswith("3."))
+out = {
+    "ok": aligned,
+    "clerkAligned": aligned,
+    "override": override,
+    "resolvedShared": resolved_shared,
+    "resolvedClerkReact": resolved_react,
+    "blogBuildScriptUsesVite": "vite" in blog_build,
+    "expectedOverridePrefix": "3.",
+}
+print(json.dumps(out))
+raise SystemExit(0 if aligned else 1)
+PY
+}
+
+cmd_build() {
+  ensure_root
+  local pair id evidence
+  pair="$(resolve_run)"
+  id="${pair%% *}"
+  evidence="${pair#* }"
+  local log="${evidence}/build.log"
+  local start end elapsed status
+  start="$(date +%s)"
+  set +e
+  (
+    cd "${ROOT}"
+    pnpm --filter blog build
+  ) >"${log}" 2>&1
+  status=$?
+  set -e
+  end="$(date +%s)"
+  elapsed=$((end - start))
+  python3 - "$log" "$status" "$elapsed" "$id" "$evidence" "$ROOT" <<'PY'
+import json, sys, pathlib
+log, status, elapsed, run_id, evidence, root = sys.argv[1:7]
+text = pathlib.Path(log).read_text(encoding="utf-8", errors="replace")
+missing = "MISSING_EXPORT" in text
+index_html = (pathlib.Path(root) / "apps/blog/dist/client/index.html").is_file()
+ok = int(status) == 0 and not missing
+out = {
+    "ok": ok,
+    "command": "pnpm --filter blog build",
+    "exitCode": int(status),
+    "elapsedSec": int(elapsed),
+    "missingExport": missing,
+    "indexHtml": index_html,
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "buildLog": log,
+}
+print(json.dumps(out))
+raise SystemExit(0 if ok else 1)
+PY
+}
+
+cmd_drive() {
+  ensure_root
+  local feature="${1:-}"
+  [[ -n "${feature}" ]] || die "drive requires a feature id"
+  local pair id evidence
+  pair="$(resolve_run)"
+  id="${pair%% *}"
+  evidence="${pair#* }"
+
+  case "${feature}" in
+    anyrouter-pricing|post-page)
+      local html
+      html="$(html_path_for_anyrouter)"
+      [[ -n "${html}" ]] || die "prerendered anyrouter HTML not found under apps/blog/dist/client; run build first"
+      python3 - "$feature" "$html" "$evidence" "$id" <<'PY'
+import json, sys, pathlib, shutil
+feature, html_path, evidence, run_id = sys.argv[1:5]
+src = pathlib.Path(html_path)
+dest = pathlib.Path(evidence) / "anyrouter.html"
+shutil.copyfile(src, dest)
+text = src.read_text(encoding="utf-8", errors="replace")
+needles_present = ["Why Go at $2/mo", "$4 credits"]
+needles_absent = ["Why Starter at $1/mo"]
+present = {n: n in text for n in needles_present}
+absent_ok = {n: n not in text for n in needles_absent}
+ok = all(present.values()) and all(absent_ok.values())
+report = {
+    "ok": ok,
+    "feature": feature,
+    "htmlPath": html_path,
+    "bytes": len(text),
+    "mustContain": present,
+    "mustNotContain": absent_ok,
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "copiedTo": str(dest),
+}
+(pathlib.Path(evidence) / "report.json").write_text(json.dumps(report, indent=2) + "\n")
+print(json.dumps(report))
+raise SystemExit(0 if ok else 1)
+PY
+      ;;
+    homepage)
+      local home="${ROOT}/apps/blog/dist/client/index.html"
+      [[ -f "${home}" ]] || die "apps/blog/dist/client/index.html missing; run build first"
+      python3 - "$home" "$evidence" "$id" <<'PY'
+import json, sys, pathlib, shutil
+html_path, evidence, run_id = sys.argv[1:4]
+src = pathlib.Path(html_path)
+shutil.copyfile(src, pathlib.Path(evidence) / "index.html")
+text = src.read_text(encoding="utf-8", errors="replace")
+ok = ("blog.duyet.net" in text) or ("Tôi là Duyệt" in text)
+report = {
+    "ok": ok,
+    "feature": "homepage",
+    "htmlPath": html_path,
+    "bytes": len(text),
+    "hasBlogIdentity": ok,
+    "runId": run_id,
+    "evidenceDir": evidence,
+}
+(pathlib.Path(evidence) / "report.json").write_text(json.dumps(report, indent=2) + "\n")
+print(json.dumps(report))
+raise SystemExit(0 if ok else 1)
+PY
+      ;;
+    production-build)
+      die "drive production-build is the build command; use: verify-blog prove --feature production-build"
+      ;;
+    *)
+      die "unknown feature: ${feature}"
+      ;;
+  esac
+}
+
+cmd_prove() {
+  local feature="anyrouter-pricing"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --feature)
+        feature="${2:-}"
+        shift 2
+        ;;
+      *)
+        die "unknown prove arg: $1"
+        ;;
+    esac
+  done
+  [[ -n "${feature}" ]] || die "--feature requires an id"
+
+  local id evidence
+  id="$(new_run_id)"
+  export VERIFY_BLOG_RUN_ID="${id}"
+  evidence="$(evidence_dir_for "${id}")"
+  export VERIFY_BLOG_EVIDENCE="${evidence}"
+  mkdir -p "${evidence}"
+  write_state "${id}" "${evidence}"
+
+  set +e
+  cmd_doctor >"${evidence}/doctor.json"
+  local doctor_st=$?
+  set -e
+  if [[ ${doctor_st} -ne 0 ]]; then
+    python3 - "$evidence" "$id" <<'PY'
+import json, sys, pathlib
+evidence, run_id = sys.argv[1:3]
+out = {
+    "ok": False,
+    "stage": "doctor",
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "doctor.json").read_text()),
+}
+print(json.dumps(out))
+raise SystemExit(1)
+PY
+  fi
+
+  set +e
+  cmd_build >"${evidence}/build.json"
+  local build_st=$?
+  set -e
+  if [[ ${build_st} -ne 0 ]]; then
+    python3 - "$evidence" "$id" <<'PY'
+import json, sys, pathlib
+evidence, run_id = sys.argv[1:3]
+out = {
+    "ok": False,
+    "stage": "build",
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "doctor.json").read_text()),
+    "build": json.loads(pathlib.Path(evidence, "build.json").read_text()),
+}
+print(json.dumps(out))
+raise SystemExit(1)
+PY
+  fi
+
+  local drive_feature="${feature}"
+  if [[ "${feature}" == "production-build" ]]; then
+    drive_feature="homepage"
+  fi
+  set +e
+  cmd_drive "${drive_feature}" >"${evidence}/drive.json"
+  local drive_st=$?
+  set -e
+  python3 - "$evidence" "$id" "$feature" "$drive_st" <<'PY'
+import json, sys, pathlib
+evidence, run_id, feature, drive_st = sys.argv[1:5]
+out = {
+    "ok": int(drive_st) == 0,
+    "feature": feature,
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "doctor.json").read_text()),
+    "build": json.loads(pathlib.Path(evidence, "build.json").read_text()),
+    "drive": json.loads(pathlib.Path(evidence, "drive.json").read_text()),
+}
+print(json.dumps(out))
+raise SystemExit(0 if out["ok"] else 1)
+PY
+}
+
+cmd_preview_start() {
+  ensure_root
+  [[ -f "${ROOT}/apps/blog/dist/client/index.html" ]] || die "dist/client missing; run build first"
+  local port="${VERIFY_BLOG_PREVIEW_PORT:-4173}"
+  local log="${STATE_DIR}/preview.log"
+  (
+    cd "${ROOT}/apps/blog"
+    pnpm exec vite preview --host 127.0.0.1 --port "${port}" --strictPort
+  ) >"${log}" 2>&1 &
+  local pid=$!
+  python3 - "$STATE_FILE" "$pid" "$port" "$log" <<'PY'
+import json, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+state = {}
+if path.is_file():
+    try:
+        state = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        state = {}
+state["previewPid"] = int(sys.argv[2])
+state["previewPort"] = int(sys.argv[3])
+state["previewLog"] = sys.argv[4]
+path.write_text(json.dumps(state))
+PY
+  local i=0
+  while [[ ${i} -lt 50 ]]; do
+    if curl -sf -o /dev/null "http://127.0.0.1:${port}/"; then
+      python3 -c 'import json,sys; print(json.dumps({"ok": True, "previewPid": int(sys.argv[1]), "url": sys.argv[2], "anyrouter": sys.argv[3], "log": sys.argv[4]}))' \
+        "${pid}" "http://127.0.0.1:${port}/" "http://127.0.0.1:${port}/2026/07/anyrouter/" "${log}"
+      return 0
+    fi
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      die "preview process exited; see ${log}"
+    fi
+    sleep 0.2
+    i=$((i + 1))
+  done
+  die "preview did not become ready on port ${port}; see ${log}"
+}
+
+cmd_preview_stop() {
+  python3 - "$STATE_FILE" <<'PY'
+import json, os, sys, signal, pathlib
+path = pathlib.Path(sys.argv[1])
+if not path.is_file():
+    print(json.dumps({"ok": True, "stopped": False, "reason": "no state file"}))
+    raise SystemExit(0)
+try:
+    state = json.loads(path.read_text())
+except json.JSONDecodeError:
+    print(json.dumps({"ok": True, "stopped": False, "reason": "empty state"}))
+    raise SystemExit(0)
+pid = state.get("previewPid")
+if not pid:
+    print(json.dumps({"ok": True, "stopped": False, "reason": "no previewPid"}))
+    raise SystemExit(0)
+try:
+    os.kill(int(pid), signal.SIGTERM)
+    stopped, reason = True, "sigterm"
+except ProcessLookupError:
+    stopped, reason = False, "not running"
+state.pop("previewPid", None)
+path.write_text(json.dumps(state))
+print(json.dumps({"ok": True, "stopped": stopped, "pid": pid, "reason": reason}))
+PY
+}
+
+case "${CMD}" in
+  doctor) cmd_doctor ;;
+  build) cmd_build ;;
+  drive) cmd_drive "${1:-}" ;;
+  prove) cmd_prove "$@" ;;
+  preview-start) cmd_preview_start ;;
+  preview-stop) cmd_preview_stop ;;
+  cleanup) cmd_preview_stop ;;
+  -h|--help|help|"") usage ;;
+  *) die "unknown command: ${CMD}" ;;
+esac

--- a/.cursor/skills/verify-blog/bin/verify-blog
+++ b/.cursor/skills/verify-blog/bin/verify-blog
@@ -172,7 +172,7 @@ log, status, elapsed, run_id, evidence, root = sys.argv[1:7]
 text = pathlib.Path(log).read_text(encoding="utf-8", errors="replace")
 missing = "MISSING_EXPORT" in text
 index_html = (pathlib.Path(root) / "apps/blog/dist/client/index.html").is_file()
-ok = int(status) == 0 and not missing
+ok = int(status) == 0 and not missing and index_html
 out = {
     "ok": ok,
     "command": "pnpm --filter blog build",

--- a/.cursor/skills/verify-blog/features/README.md
+++ b/.cursor/skills/verify-blog/features/README.md
@@ -1,0 +1,48 @@
+# Blog verification map
+
+This directory is the maintained source for verifying user-facing behavior of `apps/blog` (`https://blog.duyet.net`). Read the index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Work from the monorepo root with pnpm 10.
+- `pnpm.overrides["@clerk/shared"]` is `3.47.8`. Shared v4 breaks the Vite/rolldown production build (`MISSING_EXPORT` of Clerk React contexts).
+- Launch means `pnpm --filter blog build` (Pages output `apps/blog/dist/client`). `vite dev` is not a substitute for a production-build claim.
+- Put `.cursor/skills/verify-blog/bin` on `PATH` or invoke the binary by repo-relative path.
+- Run `verify-blog doctor` and require `clerkAligned: true`.
+- Never drive a preview that this run did not start. Preview is optional; prerendered HTML is the source of truth for copy.
+
+## Driving conventions
+
+- Start every recipe from a fresh production build unless the feature says HTML is already present.
+- Treat post paths as literal (`/2026/07/anyrouter/`).
+- Run build/HTML actions through `verify-blog`.
+- Run optional browser actions against `verify-blog preview-start` (`http://127.0.0.1:4173`).
+- Cleanup stops only the preview PID in `/tmp/verify-blog/state.json`. Do not remove proof artifacts.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- Build proof includes the command, exit code, and `build.log` (must not contain `MISSING_EXPORT`).
+- Copy proof includes the prerendered HTML file, not only `_posts/*.md`.
+- UI proof (optional) includes a screenshot of the article with the heading visible.
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and the unmet precondition.
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with verify-blog` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable handles, required state, commands, and observable proof.
+
+## Features
+
+- [Production build](./production-build.md) covers the Clerk-safe Vite/rolldown Pages build.
+- [AnyRouter pricing copy](./anyrouter-pricing.md) covers Go $2/mo / $4 credits in prerendered HTML.
+- [Post page](./post-page.md) covers a published post URL rendering its title and body.
+- [Homepage](./homepage.md) covers the blog index identity in `dist/client/index.html`.

--- a/.cursor/skills/verify-blog/features/README.md
+++ b/.cursor/skills/verify-blog/features/README.md
@@ -44,6 +44,6 @@ Keep implementation details out of the map. Name only user paths, stable handles
 ## Features
 
 - [Production build](./production-build.md) covers the Clerk-safe Vite/rolldown Pages build.
-- [AnyRouter pricing copy](./anyrouter-pricing.md) covers Go $2/mo / $4 credits in prerendered HTML.
+- [AnyRouter pricing copy](./anyrouter-pricing.md) covers Why Go is $2/mo, Polar $2.63 / $4 monthly credits, Free 403, and setup.sh CLI.
 - [Post page](./post-page.md) covers a published post URL rendering its title and body.
 - [Homepage](./homepage.md) covers the blog index identity in `dist/client/index.html`.

--- a/.cursor/skills/verify-blog/features/README.md
+++ b/.cursor/skills/verify-blog/features/README.md
@@ -6,6 +6,7 @@ This directory is the maintained source for verifying user-facing behavior of `a
 
 - Work from the monorepo root with pnpm 10.
 - `pnpm.overrides["@clerk/shared"]` is `3.47.8`. Shared v4 breaks the Vite/rolldown production build (`MISSING_EXPORT` of Clerk React contexts).
+- `packages/wasm/pkg/markdown/markdown.js` exists (gitignored; build with wasm-pack or `pnpm run wasm:build` as CI does).
 - Launch means `pnpm --filter blog build` (Pages output `apps/blog/dist/client`). `vite dev` is not a substitute for a production-build claim.
 - Put `.cursor/skills/verify-blog/bin` on `PATH` or invoke the binary by repo-relative path.
 - Run `verify-blog doctor` and require `clerkAligned: true`.

--- a/.cursor/skills/verify-blog/features/anyrouter-pricing.md
+++ b/.cursor/skills/verify-blog/features/anyrouter-pricing.md
@@ -1,12 +1,14 @@
 # AnyRouter pricing copy
 
-The AnyRouter post must show the Go plan at $2/mo with $4 credits in the published HTML. Markdown on `master` is not what a reader sees until the production build publishes.
+The AnyRouter post must show why Go is $2/mo, Polar's $2.63 charge, $4 monthly credits, the Free-plan 403, and the setup.sh CLI — in the published HTML, not only in markdown.
 
 ## Sub-features
 
-- `pricing-heading` shows `Why Go at $2/mo`.
-- `pricing-credits` mentions `$4 credits`.
-- `pricing-not-starter` does not show the retired `Why Starter at $1/mo` heading.
+- `pricing-heading` shows `Why Go is $2/mo`.
+- `pricing-charge` mentions Polar charging `$2.63` and `$4 monthly credits`.
+- `pricing-free` says `anyrouter/free` on Free returns 403 until Go or a donated key.
+- `pricing-not-starter` does not show `Why Starter at $1/mo` or `Why Go at $2/mo`.
+- `cli-setup` uses `curl -fsSL https://anyrouter.dev/setup.sh | bash` and `anyr claude --model z-ai/glm-5.2`, not `npx @anyr/cli claude`.
 
 ## How to get to it (user POV)
 
@@ -18,16 +20,16 @@ The AnyRouter post must show the Go plan at $2/mo with $4 credits in the publish
 
 Preconditions:
 
-- Source file `apps/blog/_posts/2026/07/anyrouter.md` already contains the Go $2 copy (merged in #1427). Do not edit that file to make the check pass.
+- Source file `apps/blog/_posts/2026/07/anyrouter.md` has the Go-is-$2 copy and setup.sh CLI. Do not revert the Clerk `@clerk/shared` 3.47.8 pin to make a build pass.
 - Production build has succeeded in this run (`verify-blog build`).
 
 - **Build if needed.** Run `.cursor/skills/verify-blog/bin/verify-blog prove --feature anyrouter-pricing`. Combined JSON `"ok": true`.
-- **HTML.** Run `.cursor/skills/verify-blog/bin/verify-blog drive anyrouter-pricing` when `dist/client` already exists. `"mustContain"` is true for `Why Go at $2/mo` and `$4 credits`. `"mustNotContain"` is true for `Why Starter at $1/mo`.
+- **HTML.** Run `.cursor/skills/verify-blog/bin/verify-blog drive anyrouter-pricing` when `dist/client` already exists. `"mustContain"` is true for `Why Go is $2/mo`, `$4 monthly credits`, `$2.63`, `anyrouter/free`, `https://anyrouter.dev/setup.sh`, and `anyr claude --model z-ai/glm-5.2`. `"mustNotContain"` is true for `Why Starter at $1/mo`, `Why Go at $2/mo`, and `npx @anyr/cli claude`.
 - **Artifact.** `evidenceDir/anyrouter.html` is a copy of the prerendered post.
-- **Optional preview.** Run `verify-blog preview-start` and open `http://127.0.0.1:4173/2026/07/anyrouter/`. The article heading visible on the page matches `Why Go at $2/mo`. Screenshot the article body, not only the site header.
+- **Optional preview.** Run `verify-blog preview-start` and open `http://127.0.0.1:4173/2026/07/anyrouter/`. The article heading visible on the page matches `Why Go is $2/mo`. Screenshot the article body, not only the site header.
 
 ## Gotchas
 
-- Live `blog.duyet.net` can still show Starter $1 while `master` has Go $2, if the Pages job failed. Always assert `dist/client` (or a new preview deploy), not the stale production URL.
-- Do not "fix" a failed HTML assertion by changing the post. The copy leftover is already merged.
+- Live `blog.duyet.net` can still show Starter $1 or the older `Why Go at $2/mo` heading while this branch has the new copy, if Pages has not published this commit. Always assert `dist/client` (or a new preview deploy), not the stale production URL.
 - Searching `_posts/2026/07/anyrouter.md` alone does not prove the reader-facing page.
+- Do not drop the `@clerk/shared` 3.47.8 override. A v4 pin fails the production build before this copy can ship.

--- a/.cursor/skills/verify-blog/features/anyrouter-pricing.md
+++ b/.cursor/skills/verify-blog/features/anyrouter-pricing.md
@@ -1,0 +1,33 @@
+# AnyRouter pricing copy
+
+The AnyRouter post must show the Go plan at $2/mo with $4 credits in the published HTML. Markdown on `master` is not what a reader sees until the production build publishes.
+
+## Sub-features
+
+- `pricing-heading` shows `Why Go at $2/mo`.
+- `pricing-credits` mentions `$4 credits`.
+- `pricing-not-starter` does not show the retired `Why Starter at $1/mo` heading.
+
+## How to get to it (user POV)
+
+- Open `https://blog.duyet.net/2026/07/anyrouter/`.
+- Open the same path on a Pages preview hostname after a green blog build.
+- After a local production build, open `/2026/07/anyrouter/` on the preview server.
+
+## Driving it with verify-blog
+
+Preconditions:
+
+- Source file `apps/blog/_posts/2026/07/anyrouter.md` already contains the Go $2 copy (merged in #1427). Do not edit that file to make the check pass.
+- Production build has succeeded in this run (`verify-blog build`).
+
+- **Build if needed.** Run `.cursor/skills/verify-blog/bin/verify-blog prove --feature anyrouter-pricing`. Combined JSON `"ok": true`.
+- **HTML.** Run `.cursor/skills/verify-blog/bin/verify-blog drive anyrouter-pricing` when `dist/client` already exists. `"mustContain"` is true for `Why Go at $2/mo` and `$4 credits`. `"mustNotContain"` is true for `Why Starter at $1/mo`.
+- **Artifact.** `evidenceDir/anyrouter.html` is a copy of the prerendered post.
+- **Optional preview.** Run `verify-blog preview-start` and open `http://127.0.0.1:4173/2026/07/anyrouter/`. The article heading visible on the page matches `Why Go at $2/mo`. Screenshot the article body, not only the site header.
+
+## Gotchas
+
+- Live `blog.duyet.net` can still show Starter $1 while `master` has Go $2, if the Pages job failed. Always assert `dist/client` (or a new preview deploy), not the stale production URL.
+- Do not "fix" a failed HTML assertion by changing the post. The copy leftover is already merged.
+- Searching `_posts/2026/07/anyrouter.md` alone does not prove the reader-facing page.

--- a/.cursor/skills/verify-blog/features/homepage.md
+++ b/.cursor/skills/verify-blog/features/homepage.md
@@ -1,0 +1,28 @@
+# Homepage
+
+The blog index is static HTML that identifies the site as blog.duyet.net / Tôi là Duyệt and lists recent posts.
+
+## Sub-features
+
+- `home-html` writes `apps/blog/dist/client/index.html`.
+- `home-identity` includes the blog name or hostname in that file.
+- `home-preview` serves `/` from `vite preview` after a production build.
+
+## How to get to it (user POV)
+
+- Open `https://blog.duyet.net/`.
+- Open `/` on a Pages preview or local `vite preview`.
+
+## Driving it with verify-blog
+
+Preconditions:
+
+- Production build completed in this run.
+
+- **Index file.** Run `.cursor/skills/verify-blog/bin/verify-blog drive homepage`. `"hasBlogIdentity": true` and `index.html` is copied to `evidenceDir`.
+- **Optional preview.** `verify-blog preview-start` then `GET http://127.0.0.1:4173/` returns 200 with the same identity strings.
+
+## Gotchas
+
+- The index is prerendered. Driving `vite dev` does not prove the Pages artifact.
+- Do not treat a header-only screenshot as proof that posts rendered; identity strings must be in `index.html`.

--- a/.cursor/skills/verify-blog/features/post-page.md
+++ b/.cursor/skills/verify-blog/features/post-page.md
@@ -1,0 +1,30 @@
+# Post page
+
+A published post is a year/month/slug URL that prerenders the title, date, and article body into static HTML.
+
+## Sub-features
+
+- `post-route` serves `/2026/07/anyrouter/` from prerendered files.
+- `post-body` includes article content from the markdown source.
+- `post-chrome` includes the shared site header shell in the HTML.
+
+## How to get to it (user POV)
+
+- From the homepage, follow the AnyRouter post link.
+- Open `/2026/07/anyrouter/` directly.
+- Open an archive or tag listing and follow the same slug.
+
+## Driving it with verify-blog
+
+Preconditions:
+
+- `apps/blog/dist/client` comes from this run's production build.
+
+- **Locate HTML.** Run `.cursor/skills/verify-blog/bin/verify-blog drive post-page`. The JSON `htmlPath` points at `apps/blog/dist/client/2026/07/anyrouter/index.html` (or `anyrouter.html`).
+- **Body.** The copied HTML contains the post heading and is larger than an empty shell (`bytes` well above a layout-only page).
+- **Optional preview.** `verify-blog preview-start` then open `/2026/07/anyrouter/`. The document title or `h1` matches the post title.
+
+## Gotchas
+
+- TanStack prerender may write either `.../anyrouter/index.html` or `.../anyrouter.html`. The lever checks both.
+- A 200 from production is not proof of this commit if the latest Pages deploy failed.

--- a/.cursor/skills/verify-blog/features/production-build.md
+++ b/.cursor/skills/verify-blog/features/production-build.md
@@ -23,7 +23,7 @@ Preconditions:
 - Markdown WASM is present (`packages/wasm/pkg/markdown/markdown.js`). CI builds it; a fresh checkout will not have `pkg/`.
 
 - **Doctor pin.** Confirm Clerk shared is 3.x. Run `.cursor/skills/verify-blog/bin/verify-blog doctor`. JSON has `"clerkAligned": true` and `"override": "3.47.8"`.
-- **Build.** Produce the Pages artifact. Run `.cursor/skills/verify-blog/bin/verify-blog build` (or `prove --feature production-build`). Exit code `0`, `"missingExport": false`, `"indexHtml": true`.
+- **Build.** Produce the Pages artifact. Run `.cursor/skills/verify-blog/bin/verify-blog build` (or `prove --feature production-build`). Exit code `0`, `"missingExport": false`, and `"indexHtml": true`. The lever fails if Vite exits 0 without writing `apps/blog/dist/client/index.html`.
 - **Log.** Open `evidenceDir/build.log`. It must not contain `MISSING_EXPORT`, `ClientContext`, or `OrganizationProvider is not exported`.
 - **Proof.** `apps/blog/dist/client/index.html` exists after the command returns.
 

--- a/.cursor/skills/verify-blog/features/production-build.md
+++ b/.cursor/skills/verify-blog/features/production-build.md
@@ -1,0 +1,33 @@
+# Production build
+
+The blog ships as static HTML from a Vite/TanStack production build. A reader only sees new posts after that build succeeds and Cloudflare Pages publishes `dist/client`.
+
+## Sub-features
+
+- `build-cli` runs the same production command Pages CI uses.
+- `build-clerk` completes without `MISSING_EXPORT` from `@clerk/shared`.
+- `build-output` writes `apps/blog/dist/client/index.html`.
+
+## How to get to it (user POV)
+
+- Push to `master` so `.github/workflows/cf-deploy.yml` deploys `duyet-blog`.
+- Open a PR so preview Pages runs the same `pnpm --filter blog build`.
+- Run the production build locally before merge.
+
+## Driving it with verify-blog
+
+Preconditions:
+
+- `verify-blog doctor` reports `clerkAligned: true` and override `3.47.8`.
+- Workspace dependencies are installed (`pnpm install`).
+
+- **Doctor pin.** Confirm Clerk shared is 3.x. Run `.cursor/skills/verify-blog/bin/verify-blog doctor`. JSON has `"clerkAligned": true` and `"override": "3.47.8"`.
+- **Build.** Produce the Pages artifact. Run `.cursor/skills/verify-blog/bin/verify-blog build` (or `prove --feature production-build`). Exit code `0`, `"missingExport": false`, `"indexHtml": true`.
+- **Log.** Open `evidenceDir/build.log`. It must not contain `MISSING_EXPORT`, `ClientContext`, or `OrganizationProvider is not exported`.
+- **Proof.** `apps/blog/dist/client/index.html` exists after the command returns.
+
+## Gotchas
+
+- `pnpm --filter blog check-types` can pass while `vite build` fails on Clerk exports. The outage was rolldown, not tsc.
+- `@clerk/shared` 4.x looks like a valid Renovate major bump. It is not compatible with `@clerk/clerk-react` 5.x (`^3.47`).
+- `failOnError: false` on prerender crawl errors does not hide a bundler `MISSING_EXPORT`. If Vite exits non-zero, Pages stays on the previous deploy.

--- a/.cursor/skills/verify-blog/features/production-build.md
+++ b/.cursor/skills/verify-blog/features/production-build.md
@@ -20,6 +20,7 @@ Preconditions:
 
 - `verify-blog doctor` reports `clerkAligned: true` and override `3.47.8`.
 - Workspace dependencies are installed (`pnpm install`).
+- Markdown WASM is present (`packages/wasm/pkg/markdown/markdown.js`). CI builds it; a fresh checkout will not have `pkg/`.
 
 - **Doctor pin.** Confirm Clerk shared is 3.x. Run `.cursor/skills/verify-blog/bin/verify-blog doctor`. JSON has `"clerkAligned": true` and `"override": "3.47.8"`.
 - **Build.** Produce the Pages artifact. Run `.cursor/skills/verify-blog/bin/verify-blog build` (or `prove --feature production-build`). Exit code `0`, `"missingExport": false`, `"indexHtml": true`.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,13 @@
     "security:openssf-scorecard"
   ],
   "automerge": true,
+  "packageRules": [
+    {
+      "description": "clerk-react 5.x and @clerk/backend 2.x require @clerk/shared ^3.47. v4 drops ClientContext/OrganizationProvider/SessionContext/UserContext and breaks the blog Vite/rolldown production build.",
+      "matchPackageNames": ["@clerk/shared"],
+      "allowedVersions": "<4"
+    }
+  ],
   "ignoreDeps": [
     "@duyet/tsconfig",
     "@duyet/components",

--- a/apps/blog/_posts/2026/07/anyrouter.md
+++ b/apps/blog/_posts/2026/07/anyrouter.md
@@ -109,18 +109,22 @@ When those keys go into the shared pool, the idle capacity turns into credits an
   <img src="/media/2026/07/anyrouter/anyrouter-shared-pool-2-bg.png" alt="Shared pool models" loading="lazy" />
 </div>
 
-# Why Go at $2/mo
+# Why Go is $2/mo
 
-I launched a few weeks ago giving each new user $2 free right after sign up. Thousands of spam accounts got created.
-So the paid floor is now Go at $2/mo, with $4 credits included — nothing compared to a $200 Claude or Codex plan or the bunch of other subscriptions you already pay for, not even worth your morning coffee. Honestly, it's a good way to prevent spam.
+I launched a few weeks ago giving each new user $2 free credit right after sign up. Thousands of spam accounts got created.
+
+The cheap paid door is now Go at $2/mo. Polar charges the card $2.63 so their fee is covered. You get $4 monthly credits — not a $1 plan.
 
 <div class="img-row">
   <img src="/media/2026/07/anyrouter/anyrouter-spam.jpeg" alt="Spam accounts after launch" loading="lazy" />
   <img src="/media/2026/07/anyrouter/anyrouter-to-start-bg.png" alt="Getting the Go plan" loading="lazy" />
 </div>
 
-Another way to get Go: donate at least one good shared key to the pool.
-I will improve this over time.
+The Free plan has no monthly credits and no signup bonus. `anyrouter/free` on Free returns 403 until you take Go or donate a key.
+
+Another way to get Go: donate at least one good shared key to the pool. No card. I do not take Alipay or WeChat.
+
+I will keep improving this. Live table: [docs.anyrouter.dev/features/pricing](https://docs.anyrouter.dev/features/pricing).
 
 # How I built anyrouter: Self improvement
 
@@ -191,8 +195,8 @@ const { text } = await generateText({
 <div class="tab-panel">
 
 ```bash
-# Pick any model (e.g. GLM-5.2)
-npx @anyr/cli claude --model z-ai/glm-5.2
+curl -fsSL https://anyrouter.dev/setup.sh | bash
+anyr claude --model z-ai/glm-5.2
 ```
 
 </div>

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,7 @@
 # Documentation Index
 
-- [`docs/ai/internal-knowledge.md`](ai/internal-knowledge.md): durable repository knowledge for AI agents (static-render rule, latest shadcn + chat primitives, deploy path, gitleaks secret scan). Public-app UI direction lives here; [`DESIGN.md`](../DESIGN.md) is the short companion.
+- [`docs/ai/internal-knowledge.md`](ai/internal-knowledge.md): durable repository knowledge for AI agents (static-render rule, latest shadcn + chat primitives, deploy path, gitleaks secret scan, Clerk `@clerk/shared` 3.47 pin). Public-app UI direction lives here; [`DESIGN.md`](../DESIGN.md) is the short companion.
+- [`.cursor/skills/verify-blog/`](../.cursor/skills/verify-blog/SKILL.md): project-local blog verification skill (production build + prerendered post HTML). CLI lever: `.cursor/skills/verify-blog/bin/verify-blog`.
 - [`.gitleaks.toml`](../.gitleaks.toml): custom secret-scan rules (AnyRouter `sk-ar-v1-` prefix). CI: `.github/workflows/gitleaks.yml`.
 - [`docs/ai/cowork-instructions.md`](ai/cowork-instructions.md): guidance for Claude Cowork (desktop agent) sessions on this repo.
 - [`docs/ai/writing-style.md`](ai/writing-style.md): how to write blog posts and notes in Duyet's voice.

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -18,6 +18,7 @@ GitHub repo metadata (description + topics) must match the current stack. When m
 - UI primitives come from **latest shadcn/ui** under `packages/components/ui/` (registry style `new-york-v4`). Chat conversations use the official June 2026 set: `MessageScroller`, `Message`, `Bubble`, `Attachment`, `Marker`. Compose them via `ChatTranscript` / `ChatMessageList` in `packages/components/chat/`. Do not invent a parallel chat kit.
 - Ignore generated Next dumps: `.next/`, `out/`, `next-env.d.ts`. Do not commit `apps/agents/` scratch or leftover agent worktrees.
 - Secret scanning: `.gitleaks.toml` (custom AnyRouter `sk-ar-v1-` prefix). CI workflow `gitleaks.yml` scans the working tree with `--no-git` so historical leaks do not fail the gate. Do not rewrite git history for leaked keys; rotate the live credentials instead. Distinct from `.deepsec/` (SAST).
+- Clerk pin: keep `pnpm.overrides["@clerk/shared"]` on **3.47.8** (and Renovate `allowedVersions: "<4"`) while apps still depend on `@clerk/clerk-react` 5.x / `@clerk/backend` 2.x. Those packages declare `@clerk/shared ^3.47`. A v4 override makes Vite/rolldown fail with `MISSING_EXPORT` for `ClientContext` / `OrganizationProvider` / `SessionContext` / `UserContext` and takes down `apps/blog` Pages deploys. Do not bump shared to v4 until those apps move to `@clerk/react` 6.x.
 
 ## Herdr (isolated coding agents)
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
       "ai": "^7.0.4",
       "@ai-sdk/react": "^4.0.5",
       "@assistant-ui/core": "^0.3.0",
-      "@clerk/shared": "4.30.2",
+      "@clerk/shared": "3.47.8",
       "@tanstack/history": "1.162.1",
       "@tanstack/react-router": "1.170.32",
       "@tanstack/react-start": "1.168.49",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   ai: ^7.0.4
   '@ai-sdk/react': ^4.0.5
   '@assistant-ui/core': ^0.3.0
-  '@clerk/shared': 4.30.2
+  '@clerk/shared': 3.47.8
   '@tanstack/history': 1.162.1
   '@tanstack/react-router': 1.170.32
   '@tanstack/react-start': 1.168.49
@@ -2152,9 +2152,9 @@ packages:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/shared@4.30.2':
-    resolution: {integrity: sha512-2U8jE2Gno2uRxg5b2fv5uY3zxzxAvmBzjiaOPAfoAVUgJ2Ys9kPu+6k2TaBNTkeF0ncQ/5erECIx6dPt0d8XyQ==}
-    engines: {node: '>=20.9.0'}
+  '@clerk/shared@3.47.8':
+    resolution: {integrity: sha512-cPURU1it/Eal4uXO9SOcHzw9sfE6Opi21W8EJUg+Ri80Q6JKtK8qBmyOpIyqgf09EanexhTzS4xrmYlvn2p7Iw==}
+    engines: {node: '>=18.17.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -5734,6 +5734,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -8603,6 +8606,11 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   swr@2.5.1:
     resolution: {integrity: sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==}
     peerDependencies:
@@ -9854,7 +9862,7 @@ snapshots:
 
   '@clerk/backend@2.33.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@clerk/shared': 4.30.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/shared': 3.47.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@clerk/types': 4.101.26(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
@@ -9864,24 +9872,26 @@ snapshots:
 
   '@clerk/clerk-react@5.61.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@clerk/shared': 4.30.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/shared': 3.47.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
 
-  '@clerk/shared@4.30.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@clerk/shared@3.47.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/query-core': 5.102.8
+      csstype: 3.1.3
       dequal: 2.0.3
       glob-to-regexp: 0.4.1
       js-cookie: 3.0.7
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.8)
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
   '@clerk/types@4.101.26(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@clerk/shared': 4.30.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@clerk/shared': 3.47.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -13434,6 +13444,8 @@ snapshots:
       source-map-resolve: 0.6.0
 
   cssesc@3.0.0: {}
+
+  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -17032,6 +17044,12 @@ snapshots:
   suspend-react@0.1.3(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  swr@2.3.4(react@19.2.8):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
   swr@2.5.1(react@19.2.8):
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## TL;DR

Unblock production Pages by pinning `@clerk/shared` to **3.47.8**, then apply leftover AnyRouter copy polish. The already-merged Go pricing stays; the heading is now **Why Go is $2/mo**, with Polar's **$2.63** charge, **$4 monthly credits**, Free-plan 403, donate-without-card, and `setup.sh` / `anyr claude`.

Please **merge (do not squash-merge)**. Do not drop the Clerk pin.

## Why production is down

- #1427 (`43c6c6ec`) updated the AnyRouter post. Live https://blog.duyet.net/2026/07/anyrouter/ still showed **Why Starter at $1/mo** because the production Pages job failed.
- Failed run: https://github.com/duyet/monorepo/actions/runs/33533846615 (`Deploy blog`).
- Error: `MISSING_EXPORT` of `ClientContext` / `OrganizationProvider` / `SessionContext` / `UserContext` from `@clerk/shared` v4, imported by `@clerk/clerk-react` 5.x.

## Fix (do not drop)

- Restore `pnpm.overrides["@clerk/shared"]` to `3.47.8`.
- Renovate `allowedVersions: "<4"`.
- Durable note in `docs/ai/internal-knowledge.md`.

## Copy polish (follow-up)

`apps/blog/_posts/2026/07/anyrouter.md` only:

- Heading **Why Go is $2/mo**.
- $2 signup credit → spam; Go $2/mo; Polar charges **$2.63**; **$4 monthly credits**, not a $1 plan.
- Free has no monthly credits / signup bonus; `anyrouter/free` returns 403 until Go or a donated key.
- Donate a shared key for Go, no card, no Alipay/WeChat.
- Live table: https://docs.anyrouter.dev/features/pricing
- CLI tab: `curl -fsSL https://anyrouter.dev/setup.sh | bash` then `anyr claude --model z-ai/glm-5.2` (replaces `npx @anyr/cli claude`).

No anyrouter/chmonitor repo edits. Clerk pin unchanged.

## Local verification

```bash
.cursor/skills/verify-blog/bin/verify-blog prove --feature anyrouter-pricing
```

Verdict: **VERIFIED** (run `20260901T172709Z`)

| Check | Result |
| --- | --- |
| Clerk pin | `3.47.8` / `clerkAligned: true` / no `MISSING_EXPORT` |
| `pnpm --filter blog build` | exit 0 |
| Heading | `Why Go is $2/mo` present; `Why Go at $2/mo` and `Why Starter at $1/mo` absent |
| Polar / credits | `$2.63`, `$4 monthly credits` |
| Free 403 | `anyrouter/free` |
| CLI | `https://anyrouter.dev/setup.sh`, `anyr claude --model z-ai/glm-5.2`; `npx @anyr/cli claude` absent |

![Local preview of Why Go is $2/mo pricing section](https://cursor.com/artifacts/c/art-55f06ee5-bead-4605-bf40-5af53cc40ab4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d0991fb-c0b7-4692-b019-132867511929?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d0991fb-c0b7-4692-b019-132867511929&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Restore the Clerk dependency compatibility required for Blog Pages builds and refresh the AnyRouter pricing and CLI guidance.

Bug Fixes:
- Pin `@clerk/shared` to 3.47.8 to restore successful blog production builds and unblock Pages deployments.
- Update the AnyRouter article with corrected Go pricing, Free-plan access details, donation guidance, and the current CLI setup command.

Enhancements:
- Add a reusable verification skill for validating the blog’s production build, prerendered HTML, and feature-specific copy.
- Document the Clerk version constraint and blog verification workflow for future maintenance.

Build:
- Update the dependency lockfile and workspace override to use the Clerk shared package version compatible with the current Clerk integrations.

Documentation:
- Add documentation links and durable guidance covering the Clerk pin and blog verification skill.

Tests:
- Add feature-driven verification recipes and tooling for production-build and prerendered-content checks.