### PR TITLE
fix(blog): cache-bust replaced AnyRouter Go $2 illustrations

### DIFF
--- a/apps/blog/_posts/2026/07/anyrouter.md
+++ b/apps/blog/_posts/2026/07/anyrouter.md
@@ -105,7 +105,7 @@ A lot of providers give you some free tokens. This one unifies and combines them
 When those keys go into the shared pool, the idle capacity turns into credits and free models for everyone. **You donate what you're not using, and you draw from what others aren't using.** [Donating your idle free keys to the pool](https://anyrouter.dev/donate) is the way to a good source of free tokens for everyone.
 
 <div class="img-row">
-  <img src="/media/2026/07/anyrouter/anyrouter-shared-pool-bg.png" alt="The shared key pool" loading="lazy" />
+  <img src="/media/2026/07/anyrouter/anyrouter-shared-pool-bg.png?v=d83b17c3" alt="The shared key pool" loading="lazy" />
   <img src="/media/2026/07/anyrouter/anyrouter-shared-pool-2-bg.png" alt="Shared pool models" loading="lazy" />
 </div>
 
@@ -117,7 +117,7 @@ The cheap paid door is now Go at $2/mo. Polar charges the card $2.63 so their fe
 
 <div class="img-row">
   <img src="/media/2026/07/anyrouter/anyrouter-spam.jpeg" alt="Spam accounts after launch" loading="lazy" />
-  <img src="/media/2026/07/anyrouter/anyrouter-to-start-bg.png" alt="Getting the Go plan" loading="lazy" />
+  <img src="/media/2026/07/anyrouter/anyrouter-to-start-bg.png?v=d83b17c3" alt="Getting the Go plan" loading="lazy" />
 </div>
 
 The Free plan has no monthly credits and no signup bonus. `anyrouter/free` on Free returns 403 until you take Go or donate a key.
@@ -206,6 +206,6 @@ anyr claude --model z-ai/glm-5.2
 
 People wire it into coding agents, chat apps, and batch jobs — anywhere they'd otherwise juggle several provider keys by hand. A few real setups are collected at [anyrouter.dev/use-cases](https://anyrouter.dev/use-cases). Take whatever's useful.
 
-![AnyRouter use cases](/media/2026/07/anyrouter/anyrouter-use-cases.png)
+![AnyRouter use cases](/media/2026/07/anyrouter/anyrouter-use-cases.png?v=d83b17c3)
 
 I hope everyone can use it and give me more feedback: [https://anyrouter.dev](https://anyrouter.dev/?utm_source=blog&utm_medium=post&ref=blog)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1430 (`d83b17c3`). The three replaced PNGs are already live on origin (`anyrouter-to-start-bg.png` is 1454149 bytes, etag `ee2e29ef`), but the URL path is unchanged, so Cloudflare still HIT-serves the old 1647597-byte Start $1/mo file (`cache-control max-age=2678400, s-maxage=86400`).

Add `?v=d83b17c3` on the three img srcs that were replaced:

- `/media/2026/07/anyrouter/anyrouter-to-start-bg.png`
- `/media/2026/07/anyrouter/anyrouter-use-cases.png`
- `/media/2026/07/anyrouter/anyrouter-shared-pool-bg.png`

Copy and other images are unchanged.

## Verification

`.cursor/skills/verify-blog prove --feature anyrouter-pricing` → `"ok": true`

- doctor: Clerk pin `@clerk/shared` 3.47.8, `clerkAligned: true`
- production `pnpm --filter blog build` 22s, no `MISSING_EXPORT`
- HTML still has Why Go is $2/mo / `$4 monthly credits` / `$2.63` / setup.sh CLI; does not have Why Starter at $1/mo

Prerendered `dist/client/2026/07/anyrouter/index.html` and local preview `http://127.0.0.1:4173/2026/07/anyrouter/` carry:

- `anyrouter-to-start-bg.png?v=d83b17c3`
- `anyrouter-use-cases.png?v=d83b17c3`
- `anyrouter-shared-pool-bg.png?v=d83b17c3`

Untouched images (`shared-pool-2-bg.png`, `anyrouter-spam.jpeg`, etc.) have no query.

Do not merge from this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40c15998-02f8-47c4-a1b3-dc285d7bad9b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40c15998-02f8-47c4-a1b3-dc285d7bad9b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Bug Fixes:
- Cache-bust the three replaced AnyRouter blog illustrations so visitors receive the updated image assets.