### PR TITLE
chore: migrate clsx + tailwind-merge cn to shadcn-ui/cn

### DIFF
--- a/apps/agent-assistant/lib/utils.ts
+++ b/apps/agent-assistant/lib/utils.ts
@@ -1,6 +1,1 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cn";

--- a/apps/agent-assistant/package.json
+++ b/apps/agent-assistant/package.json
@@ -36,12 +36,11 @@
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.4",
     "lucide-react": "^1.16.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.3.0",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/apps/cv/package.json
+++ b/apps/cv/package.json
@@ -24,12 +24,10 @@
     "@seline-analytics/web": "^1.0.0",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
-    "clsx": "^2.1.1",
     "computer-modern": "^0.1.3",
     "lucide-react": "^1.0.0",
     "react": "19.2.8",
-    "react-dom": "19.2.8",
-    "tailwind-merge": "^3.0.0"
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@duyet/tailwind-config": "*",

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -28,12 +28,10 @@
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "motion": "^12.36.0",
     "lucide-react": "^1.0.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "tailwind-merge": "^3.4.0",
     "three": "^0.185.0"
   },
   "devDependencies": {

--- a/apps/home/src/lib/utils.ts
+++ b/apps/home/src/lib/utils.ts
@@ -1,2 +1,2 @@
-// Re-export cn from the shared libs package which has clsx + tailwind-merge
+// Re-export cn from the shared libs package (shadcn-ui/cn)
 export { cn } from "@duyet/libs/utils";

--- a/apps/homelab/components/dither-kit/lib.ts
+++ b/apps/homelab/components/dither-kit/lib.ts
@@ -1,8 +1,1 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-/** Tailwind-aware className combiner — local copy so the chart pack is
- * self-contained and portable as a registry. */
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from "cn";

--- a/apps/homelab/package.json
+++ b/apps/homelab/package.json
@@ -22,14 +22,13 @@
     "@duyet/libs": "*",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.4",
     "d3-scale": "^4.0.2",
     "d3-shape": "^3.2.0",
     "lucide-react": "^1.0.0",
     "motion": "^13.1.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "tailwind-merge": "^3.6.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/insights/components/dither-kit/lib.ts
+++ b/apps/insights/components/dither-kit/lib.ts
@@ -1,8 +1,1 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-/** Tailwind-aware className combiner — local copy so the chart pack is
- * self-contained and portable as a registry. */
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from "cn";

--- a/apps/insights/package.json
+++ b/apps/insights/package.json
@@ -37,7 +37,7 @@
     "@tailwindcss/vite": "^4.0.0",
     "@tanstack/react-router": "^1.122.0",
     "@tanstack/react-start": "^1.0.0",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.4",
     "d3-scale": "^4.0.2",
     "d3-shape": "^3.2.0",
     "graphql-request": "^6.1.0",
@@ -47,7 +47,6 @@
     "react-dom": "19.2.8",
     "react-is": "^19.1.0",
     "recharts": "^3.7.0",
-    "tailwind-merge": "^2.6.0",
     "vite": "^8.0.0",
     "vite-tsconfig-paths": "^6.0.0"
   },

--- a/apps/news/package.json
+++ b/apps/news/package.json
@@ -25,14 +25,13 @@
     "@duyet/urls": "*",
     "@tanstack/react-router": "^1.0.0",
     "@tanstack/react-start": "^1.0.0",
-    "clsx": "^2.1.1",
+    "cn": "^0.2.4",
     "d3-scale": "^4.0.2",
     "d3-shape": "^3.2.0",
     "lucide-react": "^1.16.0",
     "motion": "^13.1.0",
     "react": "19.2.8",
-    "react-dom": "19.2.8",
-    "tailwind-merge": "^3.3.0"
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",

--- a/apps/news/src/components/dither-kit/lib.ts
+++ b/apps/news/src/components/dither-kit/lib.ts
@@ -1,8 +1,1 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-/** Tailwind-aware className combiner — local copy so the chart pack is
- * self-contained and portable as a registry. */
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}
+export { cn } from "cn";

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,13 +37,11 @@
     "@thesvg/react": "^3.0.10",
     "@tremor/react": "^3.18.3",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^1.0.0",
     "next-themes": "^0.4.0",
     "react": "19.2.8",
-    "react-dom": "19.2.8",
-    "tailwind-merge": "^3.4.0"
+    "react-dom": "19.2.8"
   },
   "devDependencies": {
     "@duyet/interfaces": "*",

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@duyet/wasm": "*",
-    "clsx": "^2.0.0",
+    "cn": "^0.2.4",
     "date-fns": "^4.0.0",
     "github-slugger": "^2.0.0",
     "gray-matter": "4.0.3",
@@ -34,7 +34,6 @@
     "rehype-stringify": "^10.0.0",
     "remark-parse": "^11.0.0",
     "sanitize-html": "^2.13.0",
-    "tailwind-merge": "^3.0.0",
     "unified": "^11.0.0",
     "unist-util-visit": "^5.0.0",
     "vfile": "^6.0.3"

--- a/packages/libs/utils.ts
+++ b/packages/libs/utils.ts
@@ -1,6 +1,1 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cn";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,9 +250,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.4
+        version: 0.2.4
       lucide-react:
         specifier: ^1.16.0
         version: 1.37.0(react@19.2.8)
@@ -265,9 +265,6 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
-      tailwind-merge:
-        specifier: ^3.3.0
-        version: 3.6.0
       zustand:
         specifier: ^5.0.13
         version: 5.0.15(@types/react@19.2.18)(immer@11.1.15)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
@@ -706,9 +703,6 @@ importers:
       '@tanstack/react-start':
         specifier: 1.168.49
         version: 1.168.49(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.61.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       computer-modern:
         specifier: ^0.1.3
         version: 0.1.3
@@ -721,9 +715,6 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
-      tailwind-merge:
-        specifier: ^3.0.0
-        version: 3.6.0
     devDependencies:
       '@duyet/tailwind-config':
         specifier: '*'
@@ -801,9 +792,6 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       lucide-react:
         specifier: ^1.0.0
         version: 1.37.0(react@19.2.8)
@@ -816,9 +804,6 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
-      tailwind-merge:
-        specifier: ^3.4.0
-        version: 3.6.0
       three:
         specifier: ^0.185.0
         version: 0.185.1
@@ -862,9 +847,9 @@ importers:
       '@tanstack/react-start':
         specifier: 1.168.49
         version: 1.168.49(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.61.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.4
+        version: 0.2.4
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
@@ -883,9 +868,6 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
       zod:
         specifier: ^4.3.6
         version: 4.5.4
@@ -950,9 +932,9 @@ importers:
       '@tanstack/react-start':
         specifier: 1.168.49
         version: 1.168.49(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.61.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.4
+        version: 0.2.4
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
@@ -980,9 +962,6 @@ importers:
       recharts:
         specifier: ^3.7.0
         version: 3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.8)(react@19.2.8)(redux@5.0.1)
-      tailwind-merge:
-        specifier: ^2.6.0
-        version: 2.6.1
       vite:
         specifier: ^8.0.0
         version: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
@@ -1205,9 +1184,9 @@ importers:
       '@tanstack/react-start':
         specifier: 1.168.49
         version: 1.168.49(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.61.0)(vite@8.2.2(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.4
+        version: 0.2.4
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1226,9 +1205,6 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
-      tailwind-merge:
-        specifier: ^3.3.0
-        version: 3.6.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.14
@@ -1551,9 +1527,6 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1569,9 +1542,6 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
-      tailwind-merge:
-        specifier: ^3.4.0
-        version: 3.6.0
     devDependencies:
       '@duyet/interfaces':
         specifier: '*'
@@ -1630,9 +1600,9 @@ importers:
       '@duyet/wasm':
         specifier: '*'
         version: link:../wasm
-      clsx:
-        specifier: ^2.0.0
-        version: 2.1.1
+      cn:
+        specifier: ^0.2.4
+        version: 0.2.4
       date-fns:
         specifier: ^4.0.0
         version: 4.4.0
@@ -1663,9 +1633,6 @@ importers:
       sanitize-html:
         specifier: ^2.13.0
         version: 2.17.7
-      tailwind-merge:
-        specifier: ^3.0.0
-        version: 3.6.0
       unified:
         specifier: ^11.0.0
         version: 11.0.5
@@ -5572,6 +5539,11 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  cn@0.2.4:
+    resolution: {integrity: sha512-SzQvoh5FwizWtQg9+JueKdjWhlfCZMdu5DqNHm9q1wUlRVmKb9WXlepR9bTTbPwzEOyX1ujJ6lcCppmn3bNUCg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -12722,7 +12694,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.4.0
+      '@types/node': 25.9.5
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -13160,7 +13132,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 26.4.0
+      '@types/node': 25.9.5
 
   buffer@5.7.1:
     dependencies:
@@ -13312,6 +13284,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  cn@0.2.4: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -14336,7 +14310,7 @@ snapshots:
 
   happy-dom@20.12.0:
     dependencies:
-      '@types/node': 26.4.0
+      '@types/node': 25.9.5
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1432.

Migrate the local `twMerge(clsx(...))` helpers to [`shadcn-ui/cn`](https://github.com/shadcn-ui/cn) with the official CLI (`npx shadcn migrate cn --yes`), not a hand-rolled replacement.

## What changed

- Ran `npx shadcn@latest migrate cn --yes` in:
  - `packages/libs` (shared `cn`; public import path `@duyet/libs/utils` now re-exports from `cn`)
  - `apps/agent-assistant`
  - `apps/news` (dither-kit)
  - `apps/homelab` (dither-kit)
  - `apps/insights` (dither-kit; already Tailwind v4, but `tailwind-merge` was still on v2 so the CLI refused until that specifier was bumped)
- Left `apps/agent-ui`’s tiny join-only `cn` alone (no clsx / tailwind-merge).
- Left callers importing `cn` from `@duyet/libs` / `@duyet/libs/utils` / `@/lib/utils` unchanged.
- Removed leftover unused `clsx` / `tailwind-merge` deps from `apps/home`, `apps/cv`, and `packages/components`.

## Verify

- `pnpm --filter @duyet/libs exec vitest run utils.test.ts` — pass (conflict last-wins still `p-2`+`p-4` → `p-4`)
- Direct `cn@0.2.4` prove: `cn("p-2","p-4") === "p-4"`, conditionals drop falsy values
- `pnpm --filter agent-assistant --filter news --filter homelab --filter insights --filter home --filter cv check-types` — pass
- `pnpm exec biome lint` on migrated files — pass
- `pnpm run lint` — exit 0 (pre-existing warnings only; none in the migrated `cn` files)
- No remaining `"clsx"` / `"tailwind-merge"` in workspace `package.json` files

Does not mix in leftover PRs #1362 / #1365 / #1422. Does not touch anyrouter or chmonitor.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64b0dd58-df68-4b5b-a9c2-e070a435af31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64b0dd58-df68-4b5b-a9c2-e070a435af31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Replace local clsx and tailwind-merge class name helpers with the shadcn-ui/cn implementation across the workspace.

Enhancements:
- Standardize Tailwind class name composition on the shadcn-ui/cn package across shared libraries and migrated applications.
- Remove obsolete local clsx and tailwind-merge dependencies while preserving existing cn import paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized class name handling across applications and shared packages through a common utility.
  * Removed duplicated class name-processing implementations.
* **Chores**
  * Streamlined package dependencies by replacing legacy class name utilities with the shared solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->