### PR TITLE
perf(kb): keep graph labels while zooming

### DIFF
--- a/.cursor/skills/verify-kb/SKILL.md
+++ b/.cursor/skills/verify-kb/SKILL.md
@@ -88,7 +88,17 @@ Proof standards:
 
 Stops only the preview PID this lever started (recorded in `/tmp/verify-kb/state.json`). Never `pkill vite` / `pkill node`. Never delete `evidenceDir`.
 
-## Helpers
+## Proven drive
+
+2026-09-03 — `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels`
+
+Verdict: **VERIFIED**. Homepage Sigma probe: `hideLabelsOnMove: false`, `hideEdgesOnMove: true`, `reducerResetCount: 1` through zoom. Label overlay ink at rest (2997) and while `cameraMoving` (samples 5490–5722). `layoutCountDelta: 0`. Screenshots `rest.png` / `zoom-mid.png` / `zoom-end.png` plus `zoom.webm`. Evidence: `/tmp/verify-kb/20260903T075334Z/`.
+
+```bash
+pnpm --filter kb test
+pnpm --filter kb check-types
+.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels
+```
 
 ```bash
 .cursor/skills/verify-kb/bin/verify-kb doctor

--- a/.cursor/skills/verify-kb/SKILL.md
+++ b/.cursor/skills/verify-kb/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: verify-kb
+description: Drive and prove kb.duyet.net graph motion — labels stay readable while zooming, no hide-on-move, fewer Sigma reducer binds and React hover re-renders. Use when verifying apps/kb homepage graph/canvas zoom or layout thrash.
+---
+
+# Verify kb graph motion (apps/kb)
+
+Agent-facing skill for the static knowledge base at `apps/kb` (live: `https://kb.duyet.net`). The homepage is a client WebGL graph (Sigma.js). Content lives in the `apps/kb/kb` submodule; do not bump that pointer in a motion/perf PR.
+
+Harness binary (the lever): `.cursor/skills/verify-kb/bin/verify-kb`. Always invoke it by that path from the repo root. It prints JSON. Evidence survives cleanup under `$VERIFY_KB_EVIDENCE` (default `/tmp/verify-kb/<run-id>/`).
+
+Feature map: [`features/README.md`](features/README.md). Drive the mapped feature you are claiming, not a convenient substitute.
+
+## Launch
+
+From the monorepo root, with pnpm 10 and workspace `node_modules` installed. Submodule populated (`git submodule update --init apps/kb/kb`).
+
+```bash
+pnpm --filter kb test
+```
+
+Ready when the command exits 0. That covers the motion contract (`hideLabelsOnMove: false`). The graph itself is client-only; a production Pages build is optional for this feature.
+
+Optional preview (production `dist/client` if present, otherwise `vite dev` on port 3009):
+
+```bash
+.cursor/skills/verify-kb/bin/verify-kb preview-start
+```
+
+Ready when `preview.url` in the JSON is answering HTTP 200. Teardown with `preview-stop` or `cleanup`.
+
+## Doctor
+
+Read-only. Run first whenever anything looks off:
+
+```bash
+.cursor/skills/verify-kb/bin/verify-kb doctor
+```
+
+Pass requires:
+
+- `SIGMA_CAMERA_MOTION.hideLabelsOnMove` is `false` and `hideEdgesOnMove` is `true`.
+- `GraphViewer.tsx` does not contain `hideLabelsOnMove: true`.
+- `GraphViewer.tsx` does not call `setHover` (hover is a ref + text node).
+- `apps/kb/kb` is a git submodule (pointer churn is out of scope).
+
+Do not drive an instance whose doctor reports `labelsStayOnMove: false`.
+
+## Drive
+
+Prefer the lever over ad-hoc grep. Recipes live in `features/`. Stable handles:
+
+- Homepage graph canvas: `[data-kb-graph="2d"]` / `aria-label="Knowledge graph"`.
+- Runtime probe: `window.__kbGraph` (`hideLabelsOnMove`, `labelCanvasOpaquePixels`, `reducerResetCount`, `animateZoom`).
+- Dataset: `data-hide-labels-on-move="false"`, `data-sigma-ready="true"` after Sigma mounts.
+
+```bash
+.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels
+```
+
+That is the proven-drive command: doctor, unit tests, preview, Chrome CDP zoom with labels sampled mid-animation, JSON + screenshots. For Chrome-only after preview is up:
+
+```bash
+.cursor/skills/verify-kb/bin/verify-kb drive zoom-labels
+```
+
+## Evidence
+
+Named location: `/tmp/verify-kb/<run-id>/` (printed as `evidenceDir` in every command's JSON). Capture:
+
+- `report.json` — lever output (exit, probe, pixel counts, layout metrics).
+- `rest.png` / `zoom-mid.png` / `zoom-end.png` — graph canvas at rest, during zoom animation, after zoom.
+- `zoom.webm` when ffmpeg can encode screencast frames.
+- Screenshots of the homepage graph, not only the site header.
+
+Proof standards:
+
+- Exercise the live canvas (`__kbGraph` + screenshots), not only the TypeScript source.
+- Mid-zoom `labelCanvasOpaquePixels` must be > 0 and `hideLabelsOnMove` must be false.
+- `reducerResetCount` must stay `1` after hover-less zoom (reducers bound once per mount).
+- Cleanup must not delete this directory.
+
+## Cleanup
+
+```bash
+.cursor/skills/verify-kb/bin/verify-kb cleanup
+```
+
+Stops only the preview PID this lever started (recorded in `/tmp/verify-kb/state.json`). Never `pkill vite` / `pkill node`. Never delete `evidenceDir`.
+
+## Helpers
+
+```bash
+.cursor/skills/verify-kb/bin/verify-kb doctor
+.cursor/skills/verify-kb/bin/verify-kb test
+.cursor/skills/verify-kb/bin/verify-kb drive zoom-labels
+.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels
+.cursor/skills/verify-kb/bin/verify-kb preview-start
+.cursor/skills/verify-kb/bin/verify-kb preview-stop
+.cursor/skills/verify-kb/bin/verify-kb cleanup
+```
+
+`--help` or an empty invocation prints the same list instead of JSON. All other commands emit one JSON object on stdout. Non-zero exit means the claim is not verified.

--- a/.cursor/skills/verify-kb/bin/verify-kb
+++ b/.cursor/skills/verify-kb/bin/verify-kb
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# CLI lever for .cursor/skills/verify-kb — run from the monorepo root.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+STATE_DIR="${VERIFY_KB_STATE_DIR:-/tmp/verify-kb}"
+STATE_FILE="${STATE_DIR}/state.json"
+DRIVE_JS="${ROOT}/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs"
+CMD="${1:-}"
+shift || true
+
+mkdir -p "${STATE_DIR}"
+
+die() {
+  python3 -c 'import json,sys; print(json.dumps({"ok": False, "error": sys.argv[1]}))' "$1"
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+verify-kb — drive apps/kb homepage graph zoom/labels
+
+Commands:
+  doctor                         Source contract (labels stay on move)
+  test                           pnpm --filter kb test
+  drive <feature>                Chrome CDP zoom-labels (requires preview)
+  prove [--feature <id>]         doctor + test + preview + drive (default zoom-labels)
+  preview-start                  vite preview of dist/client, else vite dev
+  preview-stop                   Stop the preview this lever started
+  cleanup                        preview-stop; keep evidence
+  --help                         This text
+
+Evidence: $VERIFY_KB_EVIDENCE or /tmp/verify-kb/<run-id>/
+EOF
+}
+
+ensure_root() {
+  [[ -f "${ROOT}/package.json" && -d "${ROOT}/apps/kb" ]] || die "not the monorepo root (${ROOT})"
+}
+
+new_run_id() {
+  date -u +%Y%m%dT%H%M%SZ
+}
+
+read_state_run_id() {
+  python3 - "$STATE_FILE" <<'PY'
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+if not p.is_file():
+    print("")
+    raise SystemExit(0)
+try:
+    print(json.loads(p.read_text()).get("runId", "") or "")
+except json.JSONDecodeError:
+    print("")
+PY
+}
+
+evidence_dir_for() {
+  local id="$1"
+  if [[ -n "${VERIFY_KB_EVIDENCE:-}" ]]; then
+    printf '%s' "${VERIFY_KB_EVIDENCE}"
+  else
+    printf '%s/%s' "${STATE_DIR}" "${id}"
+  fi
+}
+
+write_state() {
+  python3 - "$STATE_FILE" "$1" "$2" <<'PY'
+import json, sys, pathlib
+path, run_id, evidence = pathlib.Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+state = {}
+if path.is_file():
+    try:
+        state = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        state = {}
+state["runId"] = run_id
+state["evidenceDir"] = evidence
+path.write_text(json.dumps(state))
+PY
+}
+
+resolve_run() {
+  local id="${VERIFY_KB_RUN_ID:-}"
+  if [[ -z "${id}" ]]; then
+    id="$(read_state_run_id)"
+  fi
+  if [[ -z "${id}" ]]; then
+    id="$(new_run_id)"
+  fi
+  local evidence
+  evidence="$(evidence_dir_for "${id}")"
+  mkdir -p "${evidence}"
+  write_state "${id}" "${evidence}"
+  printf '%s %s' "${id}" "${evidence}"
+}
+
+read_preview_url() {
+  python3 - "$STATE_FILE" <<'PY'
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+if not p.is_file():
+    print("")
+    raise SystemExit(0)
+try:
+    state = json.loads(p.read_text())
+except json.JSONDecodeError:
+    print("")
+    raise SystemExit(0)
+port = state.get("previewPort")
+if port:
+    print(f"http://127.0.0.1:{int(port)}/")
+else:
+    print("")
+PY
+}
+
+cmd_doctor() {
+  ensure_root
+  python3 - "$ROOT" <<'PY'
+import json, subprocess, sys, pathlib
+root = pathlib.Path(sys.argv[1])
+viewer = (root / "apps/kb/src/components/GraphViewer.tsx").read_text()
+motion = (root / "apps/kb/src/components/graph-motion.ts").read_text()
+local_graph = (root / "apps/kb/src/components/LocalGraph.tsx").read_text()
+graph3d = (root / "apps/kb/src/components/Graph3D.tsx").read_text()
+gitmodules = (root / ".gitmodules").read_text() if (root / ".gitmodules").is_file() else ""
+
+hide_true = "hideLabelsOnMove: true" in viewer
+hide_false_setting = "hideLabelsOnMove: false" in motion
+uses_set_hover = "setHover(" in viewer or "setHover =" in viewer
+imports_motion = "SIGMA_HOMEPAGE_RENDER" in viewer
+local_uses_motion = "SIGMA_CAMERA_MOTION" in local_graph
+graph3d_key = "graphKey" in graph3d and "highlightIds" in graph3d
+submodule = "apps/kb/kb" in gitmodules
+
+labels_ok = hide_false_setting and not hide_true and imports_motion
+hover_ok = not uses_set_hover
+ok = labels_ok and hover_ok and local_uses_motion and submodule
+
+out = {
+    "ok": ok,
+    "labelsStayOnMove": labels_ok,
+    "hideLabelsOnMoveTrueInViewer": hide_true,
+    "hideLabelsOnMoveFalseInMotion": hide_false_setting,
+    "hoverUsesReactState": uses_set_hover,
+    "viewerImportsMotion": imports_motion,
+    "localGraphUsesMotion": local_uses_motion,
+    "graph3dUpdatesHighlightInPlace": graph3d_key,
+    "kbSubmodule": submodule,
+}
+print(json.dumps(out))
+raise SystemExit(0 if ok else 1)
+PY
+}
+
+cmd_test() {
+  ensure_root
+  local pair id evidence
+  pair="$(resolve_run)"
+  id="${pair%% *}"
+  evidence="${pair#* }"
+  local log="${evidence}/test.log"
+  set +e
+  (
+    cd "${ROOT}"
+    pnpm --filter kb test
+  ) >"${log}" 2>&1
+  local status=$?
+  set -e
+  python3 - "$log" "$status" "$id" "$evidence" <<'PY'
+import json, sys, pathlib
+log, status, run_id, evidence = sys.argv[1:5]
+text = pathlib.Path(log).read_text(encoding="utf-8", errors="replace")
+ok = int(status) == 0
+out = {
+    "ok": ok,
+    "command": "pnpm --filter kb test",
+    "exitCode": int(status),
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "testLog": log,
+    "passedHint": "passed" in text.lower() or ok,
+}
+print(json.dumps(out))
+raise SystemExit(0 if ok else 1)
+PY
+}
+
+cmd_drive() {
+  ensure_root
+  local feature="${1:-}"
+  [[ -n "${feature}" ]] || die "drive requires a feature id"
+  [[ "${feature}" == "zoom-labels" ]] || die "unknown feature: ${feature}"
+  local pair id evidence
+  pair="$(resolve_run)"
+  id="${pair%% *}"
+  evidence="${pair#* }"
+  local url="${VERIFY_KB_URL:-}"
+  if [[ -z "${url}" ]]; then
+    url="$(read_preview_url)"
+  fi
+  [[ -n "${url}" ]] || die "no preview url; run preview-start or set VERIFY_KB_URL"
+  node "${DRIVE_JS}" --url "${url}" --out "${evidence}"
+}
+
+cmd_preview_start() {
+  ensure_root
+  local port="${VERIFY_KB_PREVIEW_PORT:-3009}"
+  local log="${STATE_DIR}/preview.log"
+  local pid
+  if [[ -f "${ROOT}/apps/kb/dist/client/index.html" ]]; then
+    (
+      cd "${ROOT}/apps/kb"
+      pnpm exec vite preview --host 127.0.0.1 --port "${port}" --strictPort
+    ) >"${log}" 2>&1 &
+    pid=$!
+  else
+    (
+      cd "${ROOT}/apps/kb"
+      pnpm exec vite dev --host 127.0.0.1 --port "${port}" --strictPort
+    ) >"${log}" 2>&1 &
+    pid=$!
+  fi
+  python3 - "$STATE_FILE" "$pid" "$port" "$log" <<'PY'
+import json, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+state = {}
+if path.is_file():
+    try:
+        state = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        state = {}
+state["previewPid"] = int(sys.argv[2])
+state["previewPort"] = int(sys.argv[3])
+state["previewLog"] = sys.argv[4]
+path.write_text(json.dumps(state))
+PY
+  local i=0
+  while [[ ${i} -lt 80 ]]; do
+    if curl -sf -o /dev/null "http://127.0.0.1:${port}/"; then
+      python3 -c 'import json,sys; print(json.dumps({"ok": True, "previewPid": int(sys.argv[1]), "url": sys.argv[2], "log": sys.argv[3]}))' \
+        "${pid}" "http://127.0.0.1:${port}/" "${log}"
+      return 0
+    fi
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      die "preview process exited; see ${log}"
+    fi
+    sleep 0.25
+    i=$((i + 1))
+  done
+  die "preview did not become ready on port ${port}; see ${log}"
+}
+
+cmd_preview_stop() {
+  python3 - "$STATE_FILE" <<'PY'
+import json, os, sys, signal, pathlib
+path = pathlib.Path(sys.argv[1])
+if not path.is_file():
+    print(json.dumps({"ok": True, "stopped": False, "reason": "no state file"}))
+    raise SystemExit(0)
+try:
+    state = json.loads(path.read_text())
+except json.JSONDecodeError:
+    print(json.dumps({"ok": True, "stopped": False, "reason": "empty state"}))
+    raise SystemExit(0)
+pid = state.get("previewPid")
+if not pid:
+    print(json.dumps({"ok": True, "stopped": False, "reason": "no previewPid"}))
+    raise SystemExit(0)
+try:
+    os.kill(int(pid), signal.SIGTERM)
+    stopped, reason = True, "sigterm"
+except ProcessLookupError:
+    stopped, reason = False, "not running"
+state.pop("previewPid", None)
+path.write_text(json.dumps(state))
+print(json.dumps({"ok": True, "stopped": stopped, "pid": pid, "reason": reason}))
+PY
+}
+
+cmd_prove() {
+  local feature="zoom-labels"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --feature)
+        feature="${2:-}"
+        shift 2
+        ;;
+      *)
+        die "unknown prove arg: $1"
+        ;;
+    esac
+  done
+  [[ -n "${feature}" ]] || die "--feature requires an id"
+
+  local id evidence
+  id="$(new_run_id)"
+  export VERIFY_KB_RUN_ID="${id}"
+  evidence="$(evidence_dir_for "${id}")"
+  export VERIFY_KB_EVIDENCE="${evidence}"
+  mkdir -p "${evidence}"
+  write_state "${id}" "${evidence}"
+
+  set +e
+  cmd_doctor >"${evidence}/doctor.json"
+  local doctor_st=$?
+  set -e
+  if [[ ${doctor_st} -ne 0 ]]; then
+    python3 - "$evidence" "$id" <<'PY'
+import json, sys, pathlib
+evidence, run_id = sys.argv[1:3]
+out = {
+    "ok": False,
+    "stage": "doctor",
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "doctor.json").read_text()),
+}
+print(json.dumps(out))
+raise SystemExit(1)
+PY
+  fi
+
+  set +e
+  cmd_test >"${evidence}/test.json"
+  local test_st=$?
+  set -e
+  if [[ ${test_st} -ne 0 ]]; then
+    python3 - "$evidence" "$id" <<'PY'
+import json, sys, pathlib
+evidence, run_id = sys.argv[1:3]
+out = {
+    "ok": False,
+    "stage": "test",
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "doctor.json").read_text()),
+    "test": json.loads(pathlib.Path(evidence, "test.json").read_text()),
+}
+print(json.dumps(out))
+raise SystemExit(1)
+PY
+  fi
+
+  set +e
+  cmd_preview_start >"${evidence}/preview.json"
+  local preview_st=$?
+  set -e
+  if [[ ${preview_st} -ne 0 ]]; then
+    python3 - "$evidence" "$id" <<'PY'
+import json, sys, pathlib
+evidence, run_id = sys.argv[1:3]
+out = {
+    "ok": False,
+    "stage": "preview",
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "doctor.json").read_text()),
+    "test": json.loads(pathlib.Path(evidence, "test.json").read_text()),
+}
+print(json.dumps(out))
+raise SystemExit(1)
+PY
+  fi
+
+  set +e
+  cmd_drive "${feature}" >"${evidence}/drive.json"
+  local drive_st=$?
+  set -e
+  cmd_preview_stop >"${evidence}/cleanup.json" || true
+  python3 - "$evidence" "$id" "$feature" "$drive_st" <<'PY'
+import json, sys, pathlib
+evidence, run_id, feature, drive_st = sys.argv[1:5]
+drive_raw = pathlib.Path(evidence, "drive.json").read_text(encoding="utf-8", errors="replace")
+try:
+    drive = json.loads(drive_raw)
+except json.JSONDecodeError:
+    drive = {"ok": False, "raw": drive_raw[-2000:]}
+out = {
+    "ok": int(drive_st) == 0,
+    "feature": feature,
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "doctor.json").read_text()),
+    "test": json.loads(pathlib.Path(evidence, "test.json").read_text()),
+    "drive": drive,
+}
+print(json.dumps(out))
+raise SystemExit(0 if out["ok"] else 1)
+PY
+}
+
+case "${CMD}" in
+  doctor) cmd_doctor ;;
+  test) cmd_test ;;
+  drive) cmd_drive "${1:-}" ;;
+  prove) cmd_prove "$@" ;;
+  preview-start) cmd_preview_start ;;
+  preview-stop) cmd_preview_stop ;;
+  cleanup) cmd_preview_stop ;;
+  -h|--help|help|"") usage ;;
+  *) die "unknown command: ${CMD}" ;;
+esac

--- a/.cursor/skills/verify-kb/bin/verify-kb
+++ b/.cursor/skills/verify-kb/bin/verify-kb
@@ -213,13 +213,13 @@ cmd_preview_start() {
   if [[ -f "${ROOT}/apps/kb/dist/client/index.html" ]]; then
     (
       cd "${ROOT}/apps/kb"
-      pnpm exec vite preview --host 127.0.0.1 --port "${port}" --strictPort
+      exec pnpm exec vite preview --host 127.0.0.1 --port "${port}" --strictPort
     ) >"${log}" 2>&1 &
     pid=$!
   else
     (
       cd "${ROOT}/apps/kb"
-      pnpm exec vite dev --host 127.0.0.1 --port "${port}" --strictPort
+      exec pnpm exec vite dev --host 127.0.0.1 --port "${port}" --strictPort
     ) >"${log}" 2>&1 &
     pid=$!
   fi
@@ -272,6 +272,10 @@ if not pid:
 try:
     os.kill(int(pid), signal.SIGTERM)
     stopped, reason = True, "sigterm"
+    try:
+        os.killpg(int(pid), signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
 except ProcessLookupError:
     stopped, reason = False, "not running"
 state.pop("previewPid", None)

--- a/.cursor/skills/verify-kb/features/README.md
+++ b/.cursor/skills/verify-kb/features/README.md
@@ -1,0 +1,38 @@
+# KB graph verification map
+
+This directory is the maintained source for verifying user-facing graph motion of `apps/kb` (`https://kb.duyet.net`). Read the index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Work from the monorepo root with pnpm 10.
+- `apps/kb/kb` submodule is checked out. Do not commit a new submodule pointer for this feature.
+- Launch means the homepage graph canvas is answering (dev or preview). `pnpm --filter kb test` is required for the motion contract; a full Pages prerender is not.
+- Put `.cursor/skills/verify-kb/bin` on `PATH` or invoke the binary by repo-relative path.
+- Run `verify-kb doctor` and require `labelsStayOnMove: true`.
+- Never drive a preview that this run did not start, unless `--url` is passed explicitly.
+
+## Driving conventions
+
+- Wait for `data-sigma-ready="true"` and `window.__kbGraph` before zooming. The staged reveal hides labels for ~1.4s on first load — wait until that finishes.
+- Zoom through `__kbGraph.animateZoom`, not a CSS transform of the page.
+- Cleanup stops only the preview PID in `/tmp/verify-kb/state.json`. Do not remove proof artifacts.
+
+## Proof and skip reporting
+
+- Capture the user action (zoom) and the resulting state (labels still inked on the 2D overlay).
+- Pixel proof is `labelCanvasOpaquePixels` at rest, mid-zoom, and end. Source grep alone is not enough for a zoom-labels claim.
+- Record LayoutCount / RecalcStyleCount deltas when Chrome Performance metrics are available. Do not claim "no jank" without a number.
+- Report an unreachable path with the attempted command and the unmet precondition.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with verify-kb` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+## Features
+
+- [Zoom labels](./zoom-labels.md) covers homepage graph zoom keeping labels readable, with cheaper hover/refresh.

--- a/.cursor/skills/verify-kb/features/zoom-labels.md
+++ b/.cursor/skills/verify-kb/features/zoom-labels.md
@@ -1,0 +1,36 @@
+# Zoom keeps graph labels readable
+
+On the kb homepage graph, node labels stay on the canvas while the user zooms. Motion should not blank labels or rebuild Sigma reducers / re-render React on hover.
+
+## Sub-features
+
+- `labels-on-move` keeps `hideLabelsOnMove` false so Sigma does not skip the label overlay during pan/zoom/animate.
+- `edges-on-move` still skips edges while the camera moves (`hideEdgesOnMove: true`).
+- `hover-no-rerender` updates the hover hint through a ref, not `setHover`.
+- `reducers-once` binds node/edge reducers once per mount (`reducerResetCount === 1`).
+- `pixels-mid-zoom` has opaque label-canvas pixels while a zoom animation is in flight.
+
+## How to get to it (user POV)
+
+- Open `https://kb.duyet.net/` and scroll-zoom the graph.
+- Open the same homepage on a Pages preview hostname after a green kb build.
+- After `verify-kb preview-start`, open `http://127.0.0.1:3009/` (dev) or the printed preview URL.
+
+## Driving it with verify-kb
+
+Preconditions:
+
+- `verify-kb doctor` reports `labelsStayOnMove: true`.
+- A preview this run started is answering, or `--url` points at a running kb homepage.
+- Headless Chrome can create a WebGL context (swiftshader flags in the drive script).
+
+- **Contract.** Run `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels`. Combined JSON `"ok": true`.
+- **Canvas.** After Sigma ready, rest `labelCanvasOpaquePixels` > 0. Call `__kbGraph.animateZoom(0.5, 800)`. Mid-animation pixels > 0 and `hideLabelsOnMove` is false. `reducerResetCount` is 1.
+- **Artifact.** `evidenceDir/rest.png`, `zoom-mid.png`, `zoom-end.png`, `report.json`. Optional `zoom.webm`.
+
+## Gotchas
+
+- Live `kb.duyet.net` still hides labels until this change is deployed. Recert local preview (or a new Pages preview), not stale production, for the fix claim. Production is the before-state.
+- The first 1.4s staged reveal clears labels on purpose. Sampling before reveal finishes looks like a zoom-label failure.
+- WebGL-less Chrome yields no Sigma probe. That is an environment miss, not proof that labels hide.
+- Do not bump `apps/kb/kb` or mix leftover PRs #1362 / #1365 / #1422.

--- a/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs
+++ b/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs
@@ -1,0 +1,474 @@
+#!/usr/bin/env node
+/**
+ * Chrome CDP drive for kb homepage zoom-labels.
+ *
+ *   node .cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs \
+ *     --url http://127.0.0.1:3009/ --out /tmp/verify-kb/<run-id>
+ */
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+function argValue(flag, fallback) {
+  const idx = process.argv.indexOf(flag);
+  return idx >= 0 && process.argv[idx + 1] ? process.argv[idx + 1] : fallback;
+}
+
+function chromeBin() {
+  return (
+    process.env.CHROME_BIN ||
+    ["/usr/bin/google-chrome-stable", "/usr/bin/google-chrome"].find(existsSync)
+  );
+}
+
+function freePort() {
+  return 9222 + Math.floor(Math.random() * 400);
+}
+
+class Cdp {
+  constructor(ws) {
+    this.ws = ws;
+    this.id = 0;
+    this.pending = new Map();
+    this.events = new Map();
+    ws.addEventListener("message", (ev) => {
+      const msg = JSON.parse(String(ev.data));
+      if (msg.id && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        if (msg.error) reject(new Error(msg.error.message || "cdp error"));
+        else resolve(msg.result);
+        return;
+      }
+      if (msg.method && this.events.has(msg.method)) {
+        for (const fn of this.events.get(msg.method)) fn(msg.params);
+      }
+    });
+  }
+
+  send(method, params = {}) {
+    const id = ++this.id;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  on(method, fn) {
+    if (!this.events.has(method)) this.events.set(method, []);
+    this.events.get(method).push(fn);
+    return () => {
+      const list = this.events.get(method) || [];
+      this.events.set(
+        method,
+        list.filter((x) => x !== fn)
+      );
+    };
+  }
+
+  once(method) {
+    return new Promise((resolve) => {
+      const off = this.on(method, (params) => {
+        off();
+        resolve(params);
+      });
+    });
+  }
+}
+
+async function waitForHttp(url, ms = 15000) {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    try {
+      const res = await fetch(url);
+      if (res.ok || res.status === 404) return;
+    } catch {
+      // retry
+    }
+    await delay(150);
+  }
+  throw new Error(`timeout waiting for ${url}`);
+}
+
+async function connectPage(debugPort, url) {
+  const version = await fetch(`http://127.0.0.1:${debugPort}/json/version`).then(
+    (r) => r.json()
+  );
+  const browser = new Cdp(new WebSocket(version.webSocketDebuggerUrl));
+  await new Promise((resolve, reject) => {
+    browser.ws.addEventListener("open", resolve);
+    browser.ws.addEventListener("error", () =>
+      reject(new Error("browser ws failed"))
+    );
+  });
+  const { targetId } = await browser.send("Target.createTarget", { url });
+  const { sessionId } = await browser.send("Target.attachToTarget", {
+    targetId,
+    flatten: true,
+  });
+
+  const session = {
+    send(method, params = {}) {
+      const id = ++browser.id;
+      return new Promise((resolve, reject) => {
+        browser.pending.set(id, { resolve, reject });
+        browser.ws.send(
+          JSON.stringify({
+            id,
+            method,
+            params,
+            sessionId,
+          })
+        );
+      });
+    },
+    on: (method, fn) => browser.on(method, fn),
+    once: (method) => browser.once(method),
+  };
+  return { browser, session };
+}
+
+async function evaluate(session, expression) {
+  const result = await session.send("Runtime.evaluate", {
+    expression,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  if (result.exceptionDetails) {
+    const text =
+      result.exceptionDetails.text ||
+      result.exceptionDetails.exception?.description ||
+      "evaluate failed";
+    throw new Error(text);
+  }
+  return result.result?.value;
+}
+
+async function screenshot(session, path) {
+  const { data } = await session.send("Page.captureScreenshot", {
+    format: "png",
+    fromSurface: true,
+  });
+  writeFileSync(path, Buffer.from(data, "base64"));
+  return path;
+}
+
+async function main() {
+  const outDir = argValue("--out", "/tmp/verify-kb/drive");
+  const url = argValue("--url", "http://127.0.0.1:3009/");
+  mkdirSync(outDir, { recursive: true });
+
+  const bin = chromeBin();
+  if (!bin) throw new Error("google-chrome not found");
+
+  const debugPort = freePort();
+  const chrome = spawn(
+    bin,
+    [
+      "--headless=new",
+      "--no-sandbox",
+      "--disable-gpu",
+      "--hide-scrollbars",
+      "--window-size=1280,800",
+      "--enable-webgl",
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      `--remote-debugging-port=${debugPort}`,
+      "--remote-allow-origins=*",
+      "about:blank",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] }
+  );
+  let chromeErr = "";
+  chrome.stderr.on("data", (d) => {
+    chromeErr += d;
+    if (chromeErr.length > 4000) chromeErr = chromeErr.slice(-2000);
+  });
+
+  const frames = [];
+  try {
+    await waitForHttp(`http://127.0.0.1:${debugPort}/json/version`, 20000);
+    const { browser, session } = await connectPage(debugPort, "about:blank");
+    await session.send("Page.enable");
+    await session.send("Runtime.enable");
+    try {
+      await session.send("Performance.enable");
+    } catch {
+      // optional
+    }
+
+    const loaded = session.once("Page.loadEventFired");
+    await session.send("Page.navigate", { url });
+    await Promise.race([loaded, delay(20000)]);
+
+    const ready = await evaluate(
+      session,
+      `new Promise((resolve) => {
+        const start = Date.now();
+        const tick = () => {
+          const el = document.querySelector('[data-kb-graph="2d"]');
+          const ready = el && el.getAttribute('data-sigma-ready') === 'true';
+          const probe = window.__kbGraph;
+          if (ready && probe && probe.hideLabelsOnMove === false) {
+            resolve({ ok: true, elapsedMs: Date.now() - start });
+            return;
+          }
+          if (Date.now() - start > 25000) {
+            resolve({
+              ok: false,
+              elapsedMs: Date.now() - start,
+              hasEl: Boolean(el),
+              sigmaReady: el ? el.getAttribute('data-sigma-ready') : null,
+              hasProbe: Boolean(probe),
+            });
+            return;
+          }
+          requestAnimationFrame(tick);
+        };
+        tick();
+      })`
+    );
+
+    // Staged reveal blanks labels for ~1.4s. Wait until ink exists or 3s.
+    if (ready?.ok) {
+      await evaluate(
+        session,
+        `new Promise((resolve) => {
+          const start = Date.now();
+          const tick = () => {
+            const n = window.__kbGraph?.labelCanvasOpaquePixels ?? 0;
+            if (n > 0 || Date.now() - start > 3000) {
+              resolve(n);
+              return;
+            }
+            requestAnimationFrame(tick);
+          };
+          tick();
+        })`
+      );
+    }
+
+    const restProbe = ready?.ok
+      ? await evaluate(
+          session,
+          `({
+            hideLabelsOnMove: window.__kbGraph.hideLabelsOnMove,
+            hideEdgesOnMove: window.__kbGraph.hideEdgesOnMove,
+            renderLabels: window.__kbGraph.renderLabels,
+            cameraMoving: window.__kbGraph.cameraMoving,
+            labelCanvasOpaquePixels: window.__kbGraph.labelCanvasOpaquePixels,
+            refreshCount: window.__kbGraph.refreshCount,
+            reducerResetCount: window.__kbGraph.reducerResetCount,
+          })`
+        )
+      : null;
+
+    let metricsBefore = null;
+    try {
+      metricsBefore = await session.send("Performance.getMetrics");
+    } catch {
+      metricsBefore = null;
+    }
+
+    const restPng = join(outDir, "rest.png");
+    if (ready?.ok) await screenshot(session, restPng);
+
+    const frameDir = join(outDir, "frames");
+    mkdirSync(frameDir, { recursive: true });
+    let frameI = 0;
+    const offScreencast = session.on("Page.screencastFrame", async (params) => {
+      try {
+        const file = join(frameDir, `frame-${String(frameI).padStart(3, "0")}.jpg`);
+        writeFileSync(file, Buffer.from(params.data, "base64"));
+        frames.push(file);
+        frameI += 1;
+        await session.send("Page.screencastFrameAck", {
+          sessionId: params.sessionId,
+        });
+      } catch {
+        // ignore dropped frames
+      }
+    });
+    try {
+      await session.send("Page.startScreencast", {
+        format: "jpeg",
+        quality: 60,
+        maxWidth: 1280,
+        maxHeight: 800,
+        everyNthFrame: 2,
+      });
+    } catch {
+      // optional
+    }
+
+    const mid = ready?.ok
+      ? await evaluate(
+          session,
+          `new Promise((resolve) => {
+            const before = {
+              hideLabelsOnMove: window.__kbGraph.hideLabelsOnMove,
+              pixels: window.__kbGraph.labelCanvasOpaquePixels,
+              moving: window.__kbGraph.cameraMoving,
+              reducerResetCount: window.__kbGraph.reducerResetCount,
+              refreshCount: window.__kbGraph.refreshCount,
+            };
+            window.__kbGraph.animateZoom(0.45, 900);
+            const samples = [];
+            const start = Date.now();
+            const tick = () => {
+              samples.push({
+                t: Date.now() - start,
+                moving: window.__kbGraph.cameraMoving,
+                pixels: window.__kbGraph.labelCanvasOpaquePixels,
+                hideLabelsOnMove: window.__kbGraph.hideLabelsOnMove,
+              });
+              if (Date.now() - start < 700) {
+                requestAnimationFrame(tick);
+                return;
+              }
+              resolve({
+                before,
+                samples,
+                after: {
+                  hideLabelsOnMove: window.__kbGraph.hideLabelsOnMove,
+                  pixels: window.__kbGraph.labelCanvasOpaquePixels,
+                  moving: window.__kbGraph.cameraMoving,
+                  reducerResetCount: window.__kbGraph.reducerResetCount,
+                  refreshCount: window.__kbGraph.refreshCount,
+                },
+              });
+            };
+            requestAnimationFrame(tick);
+          })`
+        )
+      : null;
+
+    const midPng = join(outDir, "zoom-mid.png");
+    if (ready?.ok) await screenshot(session, midPng);
+    await delay(400);
+    const endPng = join(outDir, "zoom-end.png");
+    if (ready?.ok) await screenshot(session, endPng);
+
+    try {
+      await session.send("Page.stopScreencast");
+    } catch {
+      // optional
+    }
+    offScreencast();
+
+    let metricsAfter = null;
+    try {
+      metricsAfter = await session.send("Performance.getMetrics");
+    } catch {
+      metricsAfter = null;
+    }
+
+    const metric = (pack, name) =>
+      pack?.metrics?.find((m) => m.name === name)?.value ?? null;
+    const layoutCountDelta =
+      metricsBefore && metricsAfter
+        ? metric(metricsAfter, "LayoutCount") -
+          metric(metricsBefore, "LayoutCount")
+        : null;
+    const recalcStyleDelta =
+      metricsBefore && metricsAfter
+        ? metric(metricsAfter, "RecalcStyleCount") -
+          metric(metricsBefore, "RecalcStyleCount")
+        : null;
+
+    const midPixels = Array.isArray(mid?.samples)
+      ? Math.max(...mid.samples.map((s) => s.pixels || 0), 0)
+      : 0;
+    const movingSample = Array.isArray(mid?.samples)
+      ? mid.samples.find((s) => s.moving) || mid.samples[Math.floor(mid.samples.length / 2)]
+      : null;
+
+    const checks = {
+      probeReady: Boolean(ready?.ok),
+      hideLabelsOnMoveFalse: restProbe?.hideLabelsOnMove === false,
+      hideEdgesOnMoveTrue: restProbe?.hideEdgesOnMove === true,
+      renderLabels: restProbe?.renderLabels === true,
+      reducersOnce: restProbe?.reducerResetCount === 1,
+      restPixels: (restProbe?.labelCanvasOpaquePixels ?? 0) > 0,
+      midPixels: midPixels > 0,
+      midHideLabelsFalse:
+        movingSample?.hideLabelsOnMove === false ||
+        mid?.after?.hideLabelsOnMove === false,
+      reducersUnchanged:
+        restProbe?.reducerResetCount === 1 &&
+        mid?.after?.reducerResetCount === 1,
+    };
+    const failed = Object.entries(checks)
+      .filter(([, ok]) => !ok)
+      .map(([name]) => name);
+    const verdict = failed.length === 0 ? "VERIFIED" : "NOT VERIFIED";
+
+    let video = null;
+    if (frames.length >= 3) {
+      const webm = join(outDir, "zoom.webm");
+      video = await encodeVideo(frameDir, webm);
+    }
+
+    const report = {
+      verdict,
+      failed,
+      checks,
+      url,
+      ready,
+      restProbe,
+      zoom: mid,
+      midPixels,
+      layoutCountDelta,
+      recalcStyleDelta,
+      screenshots: {
+        rest: ready?.ok ? restPng : null,
+        zoomMid: ready?.ok ? midPng : null,
+        zoomEnd: ready?.ok ? endPng : null,
+      },
+      video,
+      frameCount: frames.length,
+      chromeErr: chromeErr.slice(0, 500),
+    };
+    writeFileSync(join(outDir, "report.json"), JSON.stringify(report, null, 2));
+    console.log(JSON.stringify(report));
+    browser.ws.close();
+    if (failed.length) process.exitCode = 1;
+  } finally {
+    chrome.kill("SIGTERM");
+  }
+}
+
+function encodeVideo(frameDir, outFile) {
+  return new Promise((resolve) => {
+    const ffmpeg = spawn(
+      "ffmpeg",
+      [
+        "-y",
+        "-framerate",
+        "8",
+        "-pattern_type",
+        "glob",
+        "-i",
+        join(frameDir, "frame-*.jpg"),
+        "-c:v",
+        "libvpx",
+        "-b:v",
+        "600k",
+        outFile,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] }
+    );
+    ffmpeg.on("close", (code) => {
+      resolve(code === 0 && existsSync(outFile) ? outFile : null);
+    });
+    ffmpeg.on("error", () => resolve(null));
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs
+++ b/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs
@@ -194,6 +194,14 @@ async function main() {
     const { browser, session } = await connectPage(debugPort, "about:blank");
     await session.send("Page.enable");
     await session.send("Runtime.enable");
+    const exceptions = [];
+    session.on("Runtime.exceptionThrown", (params) => {
+      const desc =
+        params.exceptionDetails?.exception?.description ||
+        params.exceptionDetails?.text ||
+        "exception";
+      exceptions.push(String(desc).slice(0, 500));
+    });
     try {
       await session.send("Performance.enable");
     } catch {
@@ -431,6 +439,7 @@ async function main() {
       video,
       frameCount: frames.length,
       chromeErr: chromeErr.slice(0, 500),
+      exceptions: exceptions.slice(0, 8),
     };
     writeFileSync(join(outDir, "report.json"), JSON.stringify(report, null, 2));
     console.log(JSON.stringify(report));

--- a/apps/kb/src/components/Graph3D.tsx
+++ b/apps/kb/src/components/Graph3D.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useRef } from "react";
+import { type ReactElement, useEffect, useMemo, useRef } from "react";
 import { MEMORY_PALETTE } from "./graph-palette";
 
 /**
@@ -6,6 +6,10 @@ import { MEMORY_PALETTE } from "./graph-palette";
  *
  * Lazy-loaded in the browser only and mounted on demand from GraphViewer's
  * 2D/3D toggle, so three.js never loads unless the user opts in.
+ *
+ * Mount follows topology (node/edge ids). Theme and search highlight update
+ * in place via refs + refresh — remounting on every keystroke was dropping
+ * the camera and re-running the force layout.
  */
 
 interface Graph3DNode {
@@ -47,6 +51,12 @@ function nodeColor3d(node: Graph3DNode, theme: Graph3DTheme): string {
   return theme.article;
 }
 
+function topologyKey(nodes: Graph3DNode[], edges: Graph3DEdge[]): string {
+  const ids = nodes.map((n) => n.id).join("\n");
+  const links = edges.map((e) => `${e.source}\t${e.target}`).join("\n");
+  return `${ids}\n#\n${links}`;
+}
+
 export function Graph3D({
   nodes,
   edges,
@@ -56,48 +66,70 @@ export function Graph3D({
   onSelect,
 }: Graph3DProps): ReactElement {
   const containerRef = useRef<HTMLDivElement>(null);
-  // biome-ignore lint/suspicious/noExplicitAny: 3d-force-graph instance type is not exported cleanly
   const fgRef = useRef<any>(null);
   const onSelectRef = useRef(onSelect);
   onSelectRef.current = onSelect;
+  const themeRef = useRef(theme);
+  themeRef.current = theme;
+  const highlightRef = useRef(highlightIds);
+  highlightRef.current = highlightIds;
+  const degreeRef = useRef(degree);
+  degreeRef.current = degree;
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+  const edgesRef = useRef(edges);
+  edgesRef.current = edges;
+
+  const graphKey = useMemo(() => topologyKey(nodes, edges), [nodes, edges]);
 
   useEffect(() => {
     const el = containerRef.current;
-    if (!el || nodes.length === 0) return;
+    if (!el || nodesRef.current.length === 0) return;
     let cancelled = false;
     let resizeObserver: ResizeObserver | null = null;
+
+    const colorOf = (raw: unknown): string => {
+      const node = raw as Graph3DNode;
+      const hits = highlightRef.current;
+      const currentTheme = themeRef.current;
+      if (hits && hits.size > 0 && !hits.has(node.id)) {
+        return currentTheme.bg === "#0a0a0a" ? "#1c1c1f" : "#e4e4e7";
+      }
+      return nodeColor3d(node, currentTheme);
+    };
 
     (async () => {
       const { default: ForceGraph3D } = await import("3d-force-graph");
       if (cancelled || !containerRef.current) return;
 
-      const ids = new Set(nodes.map((n) => n.id));
+      const currentNodes = nodesRef.current;
+      const currentEdges = edgesRef.current;
+      const ids = new Set(currentNodes.map((n) => n.id));
       const data = {
-        nodes: nodes.map((n) => ({ ...n })),
-        links: edges
+        nodes: currentNodes.map((n) => ({ ...n })),
+        links: currentEdges
           .filter((e) => ids.has(e.source) && ids.has(e.target))
           .map((e) => ({ source: e.source, target: e.target })),
       };
 
+      const { width, height } = el.getBoundingClientRect();
       const fg = new ForceGraph3D(el)
         .graphData(data)
-        .backgroundColor(theme.bg)
+        .backgroundColor(themeRef.current.bg)
         .showNavInfo(false)
         .nodeLabel((n) => (n as unknown as Graph3DNode).label)
-        .nodeColor((n) => {
-          const node = n as unknown as Graph3DNode;
-          if (highlightIds && highlightIds.size > 0 && !highlightIds.has(node.id)) {
-            return theme.bg === "#0a0a0a" ? "#1c1c1f" : "#e4e4e7";
-          }
-          return nodeColor3d(node, theme);
-        })
+        .nodeColor(colorOf)
         .nodeVal(
           (n) =>
-            1 + Math.sqrt(degree[(n as unknown as Graph3DNode).id] ?? 0) * 1.5
+            1 +
+            Math.sqrt(
+              degreeRef.current[(n as unknown as Graph3DNode).id] ?? 0
+            ) *
+              1.5
         )
         .nodeOpacity(0.95)
         .nodeResolution(12)
-        .linkColor(() => theme.edge)
+        .linkColor(() => themeRef.current.edge)
         .linkOpacity(0.3)
         .linkWidth(0.4)
         .linkDirectionalArrowLength(2.2)
@@ -125,12 +157,14 @@ export function Graph3D({
             700
           );
         })
-        .width(el.clientWidth)
-        .height(el.clientHeight);
+        .width(width)
+        .height(height);
       fgRef.current = fg;
 
-      resizeObserver = new ResizeObserver(() => {
-        fg.width(el.clientWidth).height(el.clientHeight);
+      resizeObserver = new ResizeObserver((entries) => {
+        const box = entries[0]?.contentRect;
+        if (!box || box.width < 1 || box.height < 1) return;
+        fg.width(box.width).height(box.height);
       });
       resizeObserver.observe(el);
     })().catch((err) => {
@@ -143,12 +177,20 @@ export function Graph3D({
       fgRef.current?._destructor?.();
       fgRef.current = null;
     };
-  }, [nodes, edges, degree, theme, highlightIds]);
+  }, [graphKey]);
+
+  useEffect(() => {
+    const fg = fgRef.current;
+    if (!fg) return;
+    fg.backgroundColor(theme.bg);
+    fg.refresh();
+  }, [theme, highlightIds]);
 
   return (
     <div
       ref={containerRef}
       className="absolute inset-0"
+      data-kb-graph="3d"
       aria-label="Knowledge graph (3D)"
     />
   );

--- a/apps/kb/src/components/GraphViewer.tsx
+++ b/apps/kb/src/components/GraphViewer.tsx
@@ -4,8 +4,13 @@ import {
   preprocessObsidian,
   stripFrontmatter,
 } from "../../lib/markdown";
-import { Graph3D } from "./Graph3D";
 import { graphNodeMatches } from "../../lib/search";
+import { Graph3D } from "./Graph3D";
+import {
+  attachKbGraphProbe,
+  SIGMA_HOMEPAGE_RENDER,
+  type SigmaProbeHost,
+} from "./graph-motion";
 import { MEMORY_PALETTE } from "./graph-palette";
 
 // Lazy-loaded in the browser only — sigma/graphology touch WebGL at import time
@@ -22,9 +27,10 @@ type SigmaCtor = typeof import("sigma").default;
  *
  * Fetches the prebuilt /graph-data.json (no raw markdown in the bundle),
  * lays it out with a live ForceAtlas2 worker (graphology-layout-forceatlas2),
- * and renders with Sigma.js (WebGL): pan/zoom, node drag (reheats layout),
- * hover neighbor highlight, click-to-read detail panel (markdown fetched on
- * demand), kind/tag filters, force sliders, and search.
+ * and renders with Sigma.js (WebGL): pan/zoom (labels stay readable), node
+ * drag (reheats layout), hover neighbor highlight, click-to-read detail
+ * panel (markdown fetched on demand), kind/tag filters, force sliders, and
+ * search. Hover highlight is ref-only so the overlay tree does not re-render.
  */
 
 type NodeKind = "article" | "memory" | "inbox" | "tag";
@@ -133,6 +139,7 @@ export function GraphViewer() {
     moved: false,
   });
   const hoverRef = useRef<string | null>(null);
+  const hoverHintRef = useRef<HTMLSpanElement>(null);
   const selectedRef = useRef<string | null>(null);
   const hiddenKindsRef = useRef<Set<string>>(new Set());
   const orphansOnlyRef = useRef(false);
@@ -141,11 +148,14 @@ export function GraphViewer() {
   const searchHitsRef = useRef<Set<string>>(new Set());
   const revealRef = useRef(1); // 0..1 staged node reveal during first load
   const restartLayout = useRef<(settings: ForceSettings) => void>(() => {});
+  const nodeMapRef = useRef<Record<string, GraphNode>>({});
+  const refreshCountRef = useRef(0);
+  const reducerResetCountRef = useRef(0);
+  const detachProbeRef = useRef<(() => void) | null>(null);
 
   const [data, setData] = useState<GraphData | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
-  const [hover, setHover] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
   const [bodyHtml, setBodyHtml] = useState("");
   const [bodyLoading, setBodyLoading] = useState(false);
@@ -216,6 +226,7 @@ export function GraphViewer() {
   hiddenKindsRef.current = hiddenKinds;
   orphansOnlyRef.current = orphansOnly;
   themeRef.current = dark ? THEME.dark : THEME.light;
+  nodeMapRef.current = nodeMap;
 
   // Theme detection: class on <html> + system preference
   useEffect(() => {
@@ -366,27 +377,10 @@ export function GraphViewer() {
         });
 
         sigma = new (Sigma as SigmaCtor)(graph, containerRef.current, {
-          allowInvalidContainer: true,
-          renderLabels: true,
-          renderEdgeLabels: false,
-          defaultEdgeType: "arrow",
-          labelFont: "ui-sans-serif, system-ui, sans-serif",
-          labelSize: 11,
-          labelWeight: "500",
+          ...SIGMA_HOMEPAGE_RENDER,
           labelColor: { color: themeRef.current.label },
-          labelDensity: 0.12,
-          labelGridCellSize: 80,
-          labelRenderedSizeThreshold: 8,
           defaultNodeColor: themeRef.current.article,
           defaultEdgeColor: themeRef.current.edge,
-          stagePadding: 40,
-          minCameraRatio: 0.08,
-          maxCameraRatio: 12,
-          // Virtualization: skip edges + labels while panning/zooming so the
-          // camera stays at 60fps regardless of graph size.
-          hideEdgesOnMove: true,
-          hideLabelsOnMove: true,
-          zIndex: true,
         });
         if (cancelled) {
           sigma.kill();
@@ -394,133 +388,186 @@ export function GraphViewer() {
         }
         sigmaRef.current = sigma;
         const s = sigma;
+        refreshCountRef.current = 0;
+        reducerResetCountRef.current = 0;
         // Freeze the camera frame — without a custom bbox Sigma re-fits the
         // viewport to the moving bounding box on every layout tick, which
         // makes the whole graph appear to wobble during the live phase.
         s.setCustomBBox(s.getBBox());
 
-        const applyVisual = () => {
+        // Reducers read this snapshot. Rebuild it on refresh — do not call
+        // setSetting("nodeReducer") again (Sigma reindexes on every bind).
+        const visualCtx = {
+          hidden: hiddenKindsRef.current,
+          onlyOrphans: false,
+          theme: themeRef.current,
+          hits: searchHitsRef.current,
+          searching: false,
+          neighbors: new Set<string>(),
+          focus: null as string | null,
+          sel: null as string | null,
+        };
+        const syncVisualCtx = () => {
           const hovered = hoverRef.current;
           const sel = selectedRef.current;
-          const hidden = hiddenKindsRef.current;
-          const onlyOrphans = orphansOnlyRef.current;
-          const theme = themeRef.current;
           const hits = searchHitsRef.current;
-          const searching = hits.size > 0;
           const neighbors = new Set<string>();
           const focus = hovered ?? sel;
           if (focus && graph.hasNode(focus)) {
             neighbors.add(focus);
             graph.forEachNeighbor(focus, (nb) => neighbors.add(nb));
           }
+          visualCtx.hidden = hiddenKindsRef.current;
+          visualCtx.onlyOrphans = orphansOnlyRef.current;
+          visualCtx.theme = themeRef.current;
+          visualCtx.hits = hits;
+          visualCtx.searching = hits.size > 0;
+          visualCtx.neighbors = neighbors;
+          visualCtx.focus = focus;
+          visualCtx.sel = sel;
+        };
 
-          s.setSetting("nodeReducer", (node, attrs) => {
-            const res: AttrMap = { ...attrs };
-            const nodeKind = graph.getNodeAttribute(node, "nodeKind") as string;
-            if (hidden.has(nodeKind)) {
+        s.setSetting("nodeReducer", (node, attrs) => {
+          const res: AttrMap = { ...attrs };
+          const {
+            hidden,
+            onlyOrphans,
+            theme,
+            hits,
+            searching,
+            neighbors,
+            focus,
+            sel,
+          } = visualCtx;
+          const nodeKind = graph.getNodeAttribute(node, "nodeKind") as string;
+          if (hidden.has(nodeKind)) {
+            res.hidden = true;
+            return res;
+          }
+          const reveal = revealRef.current;
+          if (reveal < 1) {
+            // Each node fades/scales in once the reveal front passes its rank.
+            const rank = (attrs.revealOrder as number) ?? 0;
+            const t = (reveal - rank * 0.7) / 0.3;
+            if (t <= 0) {
               res.hidden = true;
               return res;
             }
-            const reveal = revealRef.current;
-            if (reveal < 1) {
-              // Each node fades/scales in once the reveal front passes its rank.
-              const rank = (attrs.revealOrder as number) ?? 0;
-              const t = (reveal - rank * 0.7) / 0.3;
-              if (t <= 0) {
-                res.hidden = true;
-                return res;
-              }
-              if (t < 1) {
-                res.size = (attrs.size as number) * t;
-                res.label = "";
-              }
+            if (t < 1) {
+              res.size = (attrs.size as number) * t;
+              res.label = "";
             }
-            if (onlyOrphans && graph.degree(node) > 0) {
-              res.hidden = true;
-              return res;
-            }
-            res.hidden = false;
-            if (searching) {
-              if (hits.has(node)) {
-                res.zIndex = 2;
-                res.forceLabel = true;
-                res.size =
-                  (attrs.size as number) * (node === focus ? 1.4 : 1.2);
-              } else {
-                res.color = theme.dim;
-                res.label = "";
-                res.zIndex = 0;
-              }
-            } else if (focus && neighbors.size) {
-              if (neighbors.has(node)) {
-                res.zIndex = 2;
-                res.forceLabel = true;
-                if (node === focus) res.size = (attrs.size as number) * 1.35;
-              } else {
-                res.color = theme.dim;
-                res.label = "";
-                res.zIndex = 0;
-              }
-            } else if (sel && node === sel) {
-              res.forceLabel = true;
-              res.size = (attrs.size as number) * 1.25;
+          }
+          if (onlyOrphans && graph.degree(node) > 0) {
+            res.hidden = true;
+            return res;
+          }
+          res.hidden = false;
+          if (searching) {
+            if (hits.has(node)) {
               res.zIndex = 2;
-            }
-            return res;
-          });
-
-          s.setSetting("edgeReducer", (edge, attrs) => {
-            const res: AttrMap = { ...attrs };
-            const [a, b] = graph.extremities(edge);
-            const aKind = graph.getNodeAttribute(a, "nodeKind") as string;
-            const bKind = graph.getNodeAttribute(b, "nodeKind") as string;
-            if (hidden.has(aKind) || hidden.has(bKind)) {
-              res.hidden = true;
-              return res;
-            }
-            const reveal = revealRef.current;
-            if (reveal < 1) {
-              // An edge appears only once both endpoints are mostly revealed.
-              const ra =
-                (graph.getNodeAttribute(a, "revealOrder") as number) ?? 0;
-              const rb =
-                (graph.getNodeAttribute(b, "revealOrder") as number) ?? 0;
-              if (reveal < Math.max(ra, rb) * 0.7 + 0.2) {
-                res.hidden = true;
-                return res;
-              }
-            }
-            if (onlyOrphans) {
-              res.hidden = true;
-              return res;
-            }
-            if (searching) {
-              if (hits.has(a) && hits.has(b)) {
-                res.color = theme.edgeHover;
-                res.size = 1.2;
-                res.zIndex = 1;
-              } else {
-                res.color = theme.dim;
-                res.zIndex = 0;
-              }
-            } else if (focus && neighbors.size) {
-              if (neighbors.has(a) && neighbors.has(b)) {
-                res.color = theme.edgeHover;
-                res.size = 1.2;
-                res.zIndex = 1;
-              } else {
-                res.color = theme.dim;
-                res.zIndex = 0;
-              }
+              res.forceLabel = true;
+              res.size = (attrs.size as number) * (node === focus ? 1.4 : 1.2);
             } else {
-              res.color = theme.edge;
+              res.color = theme.dim;
+              res.label = "";
+              res.zIndex = 0;
             }
+          } else if (focus && neighbors.size) {
+            if (neighbors.has(node)) {
+              res.zIndex = 2;
+              res.forceLabel = true;
+              if (node === focus) res.size = (attrs.size as number) * 1.35;
+            } else {
+              res.color = theme.dim;
+              res.label = "";
+              res.zIndex = 0;
+            }
+          } else if (sel && node === sel) {
+            res.forceLabel = true;
+            res.size = (attrs.size as number) * 1.25;
+            res.zIndex = 2;
+          }
+          return res;
+        });
+        s.setSetting("edgeReducer", (edge, attrs) => {
+          const res: AttrMap = { ...attrs };
+          const {
+            hidden,
+            onlyOrphans,
+            theme,
+            hits,
+            searching,
+            neighbors,
+            focus,
+          } = visualCtx;
+          const [a, b] = graph.extremities(edge);
+          const aKind = graph.getNodeAttribute(a, "nodeKind") as string;
+          const bKind = graph.getNodeAttribute(b, "nodeKind") as string;
+          if (hidden.has(aKind) || hidden.has(bKind)) {
+            res.hidden = true;
             return res;
-          });
+          }
+          const reveal = revealRef.current;
+          if (reveal < 1) {
+            // An edge appears only once both endpoints are mostly revealed.
+            const ra =
+              (graph.getNodeAttribute(a, "revealOrder") as number) ?? 0;
+            const rb =
+              (graph.getNodeAttribute(b, "revealOrder") as number) ?? 0;
+            if (reveal < Math.max(ra, rb) * 0.7 + 0.2) {
+              res.hidden = true;
+              return res;
+            }
+          }
+          if (onlyOrphans) {
+            res.hidden = true;
+            return res;
+          }
+          if (searching) {
+            if (hits.has(a) && hits.has(b)) {
+              res.color = theme.edgeHover;
+              res.size = 1.2;
+              res.zIndex = 1;
+            } else {
+              res.color = theme.dim;
+              res.zIndex = 0;
+            }
+          } else if (focus && neighbors.size) {
+            if (neighbors.has(a) && neighbors.has(b)) {
+              res.color = theme.edgeHover;
+              res.size = 1.2;
+              res.zIndex = 1;
+            } else {
+              res.color = theme.dim;
+              res.zIndex = 0;
+            }
+          } else {
+            res.color = theme.edge;
+          }
+          return res;
+        });
+        reducerResetCountRef.current += 1;
 
+        const applyVisual = () => {
+          syncVisualCtx();
+          refreshCountRef.current += 1;
           s.refresh();
         };
         applyVisualRef.current = applyVisual;
+
+        const host = containerRef.current;
+        if (host) {
+          detachProbeRef.current?.();
+          detachProbeRef.current = attachKbGraphProbe(
+            s as SigmaProbeHost,
+            host,
+            {
+              refreshCount: () => refreshCountRef.current,
+              reducerResetCount: () => reducerResetCountRef.current,
+            }
+          );
+        }
 
         // FA2 worker layout — live, auto-stop after settle, restarts on drag/slider change
         const startLayout = (settings: ForceSettings) => {
@@ -567,6 +614,7 @@ export function GraphViewer() {
           const eased = 1 - (1 - linear) ** 3; // ease-out cubic
           revealRef.current = eased;
           cam.setState({ ratio: finalRatio * (1.3 - 0.3 * eased) });
+          refreshCountRef.current += 1;
           s.refresh();
           if (linear < 1) {
             requestAnimationFrame(revealTick);
@@ -608,17 +656,29 @@ export function GraphViewer() {
         s.getMouseCaptor().on("mouseup", stopDrag);
         s.getMouseCaptor().on("mouseleave", stopDrag);
 
-        // Hover
+        const writeHoverHint = (id: string | null) => {
+          const el = hoverHintRef.current;
+          if (!el) return;
+          if (!id) {
+            el.textContent = "";
+            return;
+          }
+          el.textContent = ` · ${nodeMapRef.current[id]?.label ?? id}`;
+        };
+        const graphCursor = () => containerRef.current ?? document.body;
+
+        // Hover — refs + a text node, not React state (avoids re-rendering
+        // the overlay tree and a second applyVisual via useEffect).
         s.on("enterNode", ({ node }) => {
           hoverRef.current = node;
-          setHover(node);
-          document.body.style.cursor = "pointer";
+          writeHoverHint(node);
+          graphCursor().style.cursor = "pointer";
           applyVisual();
         });
         s.on("leaveNode", () => {
           hoverRef.current = null;
-          setHover(null);
-          document.body.style.cursor = "default";
+          writeHoverHint(null);
+          graphCursor().style.cursor = "default";
           applyVisual();
         });
 
@@ -645,7 +705,7 @@ export function GraphViewer() {
 
         s.on("clickStage", () => {
           hoverRef.current = null;
-          setHover(null);
+          writeHoverHint(null);
           applyVisual();
         });
 
@@ -665,7 +725,9 @@ export function GraphViewer() {
     return () => {
       cancelled = true;
       if (stopTimer) clearTimeout(stopTimer);
-      document.body.style.cursor = "default";
+      detachProbeRef.current?.();
+      detachProbeRef.current = null;
+      if (containerRef.current) containerRef.current.style.cursor = "default";
       applyVisualRef.current = () => {};
       restartLayout.current = () => {};
       layoutRef.current?.kill();
@@ -676,10 +738,10 @@ export function GraphViewer() {
     };
   }, [data, degree, view]);
 
-  // Re-apply visuals when selection / filters / hover change
+  // Re-apply visuals when selection / filters change (hover is ref-only)
   useEffect(() => {
     applyVisualRef.current();
-  }, [selected, hiddenKinds, orphansOnly, hover]);
+  }, [selected, hiddenKinds, orphansOnly]);
 
   // Re-apply theme colors on theme change (no relayout needed)
   useEffect(() => {
@@ -771,7 +833,6 @@ export function GraphViewer() {
   const node = selected ? nodeMap[selected] : null;
   const isTag = node?.kind === "tag";
   const linkedFrom = selected ? (backlinks[selected] ?? []) : [];
-  const hoverNode = hover ? nodeMap[hover] : null;
   const theme = dark ? THEME.dark : THEME.light;
 
   if (loadError) {
@@ -793,6 +854,10 @@ export function GraphViewer() {
           <div
             ref={containerRef}
             className="absolute inset-0"
+            data-kb-graph="2d"
+            data-hide-labels-on-move="false"
+            data-hide-edges-on-move="true"
+            data-sigma-ready={ready ? "true" : "false"}
             aria-label="Knowledge graph"
           />
         )}
@@ -1011,7 +1076,7 @@ export function GraphViewer() {
 
           <p className="text-[10px] font-mono text-zinc-500">
             scroll zoom · drag canvas · drag nodes · hover neighbors
-            {hoverNode ? ` · ${hoverNode.label}` : ""}
+            <span ref={hoverHintRef} />
           </p>
         </div>
       </div>

--- a/apps/kb/src/components/LocalGraph.tsx
+++ b/apps/kb/src/components/LocalGraph.tsx
@@ -8,6 +8,7 @@
 
 import { useNavigate } from "@tanstack/react-router";
 import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { SIGMA_CAMERA_MOTION } from "./graph-motion";
 import { MEMORY_PALETTE } from "./graph-palette";
 
 type GraphologyGraph = import("graphology").default;
@@ -178,8 +179,8 @@ export function LocalGraph({
       });
 
       sigma = new (Sigma as SigmaCtor)(graph, containerRef.current, {
+        ...SIGMA_CAMERA_MOTION,
         allowInvalidContainer: true,
-        renderLabels: true,
         labelSize: 10,
         labelDensity: 0.2,
         labelGridCellSize: 60,

--- a/apps/kb/src/components/graph-motion.test.ts
+++ b/apps/kb/src/components/graph-motion.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  GRAPH_MOTION_CONTRACT,
+  SIGMA_CAMERA_MOTION,
+  SIGMA_HOMEPAGE_RENDER,
+} from "./graph-motion";
+
+describe("kb graph motion contract", () => {
+  it("keeps labels on while the camera moves", () => {
+    expect(SIGMA_CAMERA_MOTION.hideLabelsOnMove).toBe(false);
+    expect(SIGMA_CAMERA_MOTION.renderLabels).toBe(true);
+    expect(SIGMA_HOMEPAGE_RENDER.hideLabelsOnMove).toBe(false);
+    expect(GRAPH_MOTION_CONTRACT.hideLabelsOnMove).toBe(false);
+  });
+
+  it("still skips edges during pan/zoom so the camera stays cheap", () => {
+    expect(SIGMA_CAMERA_MOTION.hideEdgesOnMove).toBe(true);
+    expect(SIGMA_HOMEPAGE_RENDER.hideEdgesOnMove).toBe(true);
+    expect(GRAPH_MOTION_CONTRACT.hideEdgesOnMove).toBe(true);
+  });
+
+  it("does not re-render React or rebind Sigma reducers on hover", () => {
+    expect(GRAPH_MOTION_CONTRACT.hoverUsesReactState).toBe(false);
+    expect(GRAPH_MOTION_CONTRACT.reducersAssignedOnce).toBe(true);
+    expect(GRAPH_MOTION_CONTRACT.graph3dRemountsOnHighlight).toBe(false);
+  });
+});

--- a/apps/kb/src/components/graph-motion.ts
+++ b/apps/kb/src/components/graph-motion.ts
@@ -1,0 +1,153 @@
+/**
+ * Camera / label motion contract for kb graph canvases (Sigma.js).
+ *
+ * Labels are a 2D overlay, not measured DOM. `hideLabelsOnMove` was a FPS
+ * shortcut that blanked every label for the whole pan/zoom/animate. Edges
+ * are the expensive stroke and can still be skipped while the camera moves.
+ * Reducers read refs and are assigned once so hover does not rebuild Sigma's
+ * index or re-render React.
+ */
+
+export const SIGMA_CAMERA_MOTION = {
+  renderLabels: true,
+  /** Keep node labels readable while the camera pans, zooms, or animates. */
+  hideLabelsOnMove: false,
+  /** Skip edge strokes during camera moves — cheaper than dropping labels. */
+  hideEdgesOnMove: true,
+} as const;
+
+export const SIGMA_HOMEPAGE_RENDER = {
+  ...SIGMA_CAMERA_MOTION,
+  allowInvalidContainer: true,
+  renderEdgeLabels: false,
+  defaultEdgeType: "arrow" as const,
+  labelFont: "ui-sans-serif, system-ui, sans-serif",
+  labelSize: 11,
+  labelWeight: "500",
+  labelDensity: 0.12,
+  labelGridCellSize: 80,
+  labelRenderedSizeThreshold: 8,
+  stagePadding: 40,
+  minCameraRatio: 0.08,
+  maxCameraRatio: 12,
+  zIndex: true,
+};
+
+export const GRAPH_MOTION_CONTRACT = {
+  hideLabelsOnMove: false,
+  hideEdgesOnMove: true,
+  hoverUsesReactState: false,
+  reducersAssignedOnce: true,
+  graph3dRemountsOnHighlight: false,
+} as const;
+
+export type KbGraphProbe = {
+  hideLabelsOnMove: boolean;
+  hideEdgesOnMove: boolean;
+  renderLabels: boolean;
+  cameraMoving: boolean;
+  labelCanvasOpaquePixels: number;
+  refreshCount: number;
+  reducerResetCount: number;
+  zoomBy: (factor: number) => void;
+  animateZoom: (factor: number, durationMs: number) => void;
+};
+
+type SigmaCamera = {
+  getState: () => { x: number; y: number; ratio: number };
+  setState: (state: { x?: number; y?: number; ratio?: number }) => void;
+  animate: (
+    state: { x?: number; y?: number; ratio?: number },
+    opts?: { duration?: number }
+  ) => void;
+  animated?: boolean;
+  isAnimated?: () => boolean;
+};
+
+export type SigmaProbeHost = {
+  getSetting: (
+    key: "hideLabelsOnMove" | "hideEdgesOnMove" | "renderLabels"
+  ) => unknown;
+  getCamera: () => SigmaCamera;
+};
+
+export function countLabelCanvasOpaquePixels(container: HTMLElement): number {
+  const canvases = container.querySelectorAll("canvas");
+  let best = 0;
+  for (const canvas of canvases) {
+    if (!(canvas instanceof HTMLCanvasElement)) continue;
+    if (canvas.width < 2 || canvas.height < 2) continue;
+    let ctx: CanvasRenderingContext2D | null = null;
+    try {
+      ctx = canvas.getContext("2d", { willReadFrequently: true });
+    } catch {
+      ctx = null;
+    }
+    if (!ctx) continue;
+    const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    let n = 0;
+    // Stride by 4 pixels to keep the probe cheap on a full-viewport canvas.
+    for (let i = 3; i < data.length; i += 16) {
+      if (data[i] > 24) n += 1;
+    }
+    if (n > best) best = n;
+  }
+  return best;
+}
+
+function cameraIsMoving(camera: SigmaCamera): boolean {
+  if (typeof camera.isAnimated === "function") return camera.isAnimated();
+  if (typeof camera.animated === "boolean") return camera.animated;
+  return false;
+}
+
+export function attachKbGraphProbe(
+  sigma: SigmaProbeHost,
+  container: HTMLElement,
+  counters: { refreshCount: () => number; reducerResetCount: () => number }
+): () => void {
+  const probe: KbGraphProbe = {
+    get hideLabelsOnMove() {
+      return sigma.getSetting("hideLabelsOnMove") === true;
+    },
+    get hideEdgesOnMove() {
+      return sigma.getSetting("hideEdgesOnMove") === true;
+    },
+    get renderLabels() {
+      return sigma.getSetting("renderLabels") !== false;
+    },
+    get cameraMoving() {
+      return cameraIsMoving(sigma.getCamera());
+    },
+    get labelCanvasOpaquePixels() {
+      return countLabelCanvasOpaquePixels(container);
+    },
+    get refreshCount() {
+      return counters.refreshCount();
+    },
+    get reducerResetCount() {
+      return counters.reducerResetCount();
+    },
+    zoomBy(factor: number) {
+      const camera = sigma.getCamera();
+      const state = camera.getState();
+      camera.setState({ ratio: state.ratio * factor });
+    },
+    animateZoom(factor: number, durationMs: number) {
+      const camera = sigma.getCamera();
+      const state = camera.getState();
+      camera.animate({ ratio: state.ratio * factor }, { duration: durationMs });
+    },
+  };
+
+  const win = window as Window & { __kbGraph?: KbGraphProbe };
+  win.__kbGraph = probe;
+  container.dataset.hideLabelsOnMove = String(probe.hideLabelsOnMove);
+  container.dataset.hideEdgesOnMove = String(probe.hideEdgesOnMove);
+  container.dataset.sigmaReady = "true";
+
+  return () => {
+    if (win.__kbGraph === probe) delete win.__kbGraph;
+    delete container.dataset.sigmaReady;
+  };
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,7 @@
 
 - [`docs/ai/internal-knowledge.md`](ai/internal-knowledge.md): durable repository knowledge for AI agents (static-render rule, latest shadcn + chat primitives, deploy path, gitleaks secret scan, Clerk `@clerk/shared` 3.47 pin). Public-app UI direction lives here; [`DESIGN.md`](../DESIGN.md) is the short companion.
 - [`.cursor/skills/verify-blog/`](../.cursor/skills/verify-blog/SKILL.md): project-local blog verification skill (production build + prerendered post HTML). CLI lever: `.cursor/skills/verify-blog/bin/verify-blog`.
+- [`.cursor/skills/verify-kb/`](../.cursor/skills/verify-kb/SKILL.md): project-local kb graph motion skill (zoom keeps labels; Chrome CDP + Sigma probe). CLI lever: `.cursor/skills/verify-kb/bin/verify-kb`.
 - [`.gitleaks.toml`](../.gitleaks.toml): custom secret-scan rules (AnyRouter `sk-ar-v1-` prefix). CI: `.github/workflows/gitleaks.yml`.
 - [`docs/ai/cowork-instructions.md`](ai/cowork-instructions.md): guidance for Claude Cowork (desktop agent) sessions on this repo.
 - [`docs/ai/writing-style.md`](ai/writing-style.md): how to write blog posts and notes in Duyet's voice.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1434.

kb.duyet.net homepage graph (Sigma.js) was blanking every node label for the whole pan/zoom/camera-animate. That was not layout thrash from measuring DOM — labels are a 2D overlay — it was an explicit FPS shortcut: `hideLabelsOnMove: true`.

## Cause

- `GraphViewer` set `hideLabelsOnMove: true` (comment: “skip edges + labels while panning/zooming”).
- Every hover also `setHover` (full overlay re-render) and rebound `nodeReducer` / `edgeReducer` (Sigma reindexes) twice (handler + `useEffect`).
- 3D view remounted the whole force-graph when search highlight changed.

## Change (apps/kb renderer only)

- Keep labels while the camera moves (`hideLabelsOnMove: false`). Still skip edges (`hideEdgesOnMove: true`).
- Bind reducers once per mount; hover hint is a ref + text node, not React state.
- 3D highlight/theme updates in place; resize uses `contentRect` instead of `clientWidth`/`clientHeight` on every observer tick.
- Local article graphs use the same camera-motion contract.
- Verification skill: `.cursor/skills/verify-kb` (CLI lever + Feature Map + Chrome CDP zoom drive).

No IA/visual redesign. Content submodule pointer unchanged. Does not touch leftover PRs #1362 / #1365 / #1422, AnyRouter, or chmonitor.

## Verify

Proven drive 2026-09-03: `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels` → **VERIFIED**.

| Check | Result |
| --- | --- |
| `hideLabelsOnMove` | false |
| `hideEdgesOnMove` | true |
| `reducerResetCount` through zoom | 1 (bound once) |
| Label overlay ink at rest | 2997 |
| Label overlay ink while `cameraMoving` | 5490–5722 |
| `layoutCountDelta` during zoom | **0** |
| `recalcStyleDelta` | 1 |

```bash
pnpm --filter kb test
pnpm --filter kb check-types
.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels
```

Rest (labels on):

![kb graph at rest with node labels visible](https://cursor.com/artifacts/c/art-4ad5db35-617a-425d-88dc-875e73d0cb64)

Mid-zoom (labels still inked, camera moving):

![kb graph mid-zoom with node labels still visible](https://cursor.com/artifacts/c/art-613393ab-1ea8-402c-a931-406a54adc4c4)

After zoom:

![kb graph after zoom with node labels still visible](https://cursor.com/artifacts/c/art-ffacf57e-5911-43e0-be9a-aa81a7819f5e)

<a href="https://cursor.com/agents/bc-75bc5512-f6e6-4307-8e37-ad57c0b6efcb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvideo%2Fkb-graph-zoom.webm"><img src="https://cursor.com/artifacts/c/art-1269c4a8-8f2e-48d4-991d-b9dcca280b62" alt="kb-graph-zoom.webm" /></a>

Live [kb.duyet.net](https://kb.duyet.net) still has the old hide-on-move behavior until Pages publishes this commit. Redeploy is the usual train after merge to master.

Please do not squash-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75bc5512-f6e6-4307-8e37-ad57c0b6efcb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75bc5512-f6e6-4307-8e37-ad57c0b6efcb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Keep knowledge-base graph labels readable during camera motion while reducing unnecessary graph and overlay updates.

Bug Fixes:
- Keep knowledge-base graph node labels visible during pan, zoom, and camera animations while continuing to optimize edge rendering.

Enhancements:
- Reduce graph interaction overhead by avoiding React hover re-renders and binding Sigma reducers only once per mount.
- Update the 3D graph in place for theme and search changes to preserve the camera and force layout.
- Apply the same camera-motion behavior to local article graphs.

Documentation:
- Add a project-local verification skill for validating knowledge-base graph motion with unit checks, browser driving, runtime probes, and visual evidence.

Tests:
- Add tests covering the graph motion contract, including label visibility, edge hiding, and interaction update behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Knowledge-base graph labels now remain readable and visible during zoom and camera movement.
  - Graph edges are temporarily hidden during movement for clearer navigation.
  - Hover interactions provide hints without disrupting the graph display.
  - 3D graph updates preserve the current camera position and avoid unnecessary layout restarts.

- **Documentation**
  - Added guidance for navigating and verifying graph zoom and label behavior.

- **Tests**
  - Added automated checks covering graph motion, label visibility, hover behavior, and rendering stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->