### PR TITLE
perf(kb): keep graph edges visible while zooming

### DIFF
--- a/.cursor/skills/verify-kb/SKILL.md
+++ b/.cursor/skills/verify-kb/SKILL.md
@@ -93,7 +93,9 @@ Stops only the preview PID this lever started (recorded in `/tmp/verify-kb/state
 
 ## Proven drive
 
-Pending this PR — run `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges` after the motion contract change.
+2026-09-03 — `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges`
+
+Verdict: **VERIFIED**. Homepage Sigma probe: `hideLabelsOnMove: false`, `hideEdgesOnMove: false`, `reducerResetCount: 1` through zoom. Label overlay ink at rest (1680) and while `cameraMoving` (5510–5740). Edge canvas ink at rest (6942) and while `cameraMoving` (20848–22786, min 20848). `layoutCountDelta: 0`. Screenshots `rest.png` / `zoom-mid.png` / `zoom-end.png` plus `zoom.webm`. Evidence: `/tmp/verify-kb/20260903T083111Z/`.
 
 ```bash
 pnpm --filter kb test

--- a/.cursor/skills/verify-kb/SKILL.md
+++ b/.cursor/skills/verify-kb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-kb
-description: Drive and prove kb.duyet.net graph motion — labels stay readable while zooming, no hide-on-move, fewer Sigma reducer binds and React hover re-renders. Use when verifying apps/kb homepage graph/canvas zoom or layout thrash.
+description: Drive and prove kb.duyet.net graph motion — labels and connection lines stay readable while zooming, no hide-on-move, fewer Sigma reducer binds and React hover re-renders. Use when verifying apps/kb homepage graph/canvas zoom or layout thrash.
 ---
 
 # Verify kb graph motion (apps/kb)
@@ -19,7 +19,7 @@ From the monorepo root, with pnpm 10 and workspace `node_modules` installed. Sub
 pnpm --filter kb test
 ```
 
-Ready when the command exits 0. That covers the motion contract (`hideLabelsOnMove: false`). The graph itself is client-only; a production Pages build is optional for this feature.
+Ready when the command exits 0. That covers the motion contract (`hideLabelsOnMove: false`, `hideEdgesOnMove: false`). The graph itself is client-only; a production Pages build is optional for this feature.
 
 Optional preview (production `dist/client` if present, otherwise `vite dev` on port 3009):
 
@@ -39,30 +39,32 @@ Read-only. Run first whenever anything looks off:
 
 Pass requires:
 
-- `SIGMA_CAMERA_MOTION.hideLabelsOnMove` is `false` and `hideEdgesOnMove` is `true`.
-- `GraphViewer.tsx` does not contain `hideLabelsOnMove: true`.
+- `SIGMA_CAMERA_MOTION.hideLabelsOnMove` is `false` and `hideEdgesOnMove` is `false`.
+- `GraphViewer.tsx` does not contain `hideLabelsOnMove: true` or `hideEdgesOnMove: true` / `data-hide-edges-on-move="true"`.
 - `GraphViewer.tsx` does not call `setHover` (hover is a ref + text node).
 - `apps/kb/kb` is a git submodule (pointer churn is out of scope).
 
-Do not drive an instance whose doctor reports `labelsStayOnMove: false`.
+Do not drive an instance whose doctor reports `labelsStayOnMove: false` or `edgesStayOnMove: false`.
 
 ## Drive
 
 Prefer the lever over ad-hoc grep. Recipes live in `features/`. Stable handles:
 
 - Homepage graph canvas: `[data-kb-graph="2d"]` / `aria-label="Knowledge graph"`.
-- Runtime probe: `window.__kbGraph` (`hideLabelsOnMove`, `labelCanvasOpaquePixels`, `reducerResetCount`, `animateZoom`).
-- Dataset: `data-hide-labels-on-move="false"`, `data-sigma-ready="true"` after Sigma mounts.
+- Runtime probe: `window.__kbGraph` (`hideLabelsOnMove`, `hideEdgesOnMove`, `labelCanvasOpaquePixels`, `edgeCanvasOpaquePixels`, `reducerResetCount`, `animateZoom`).
+- Dataset: `data-hide-labels-on-move="false"`, `data-hide-edges-on-move="false"`, `data-sigma-ready="true"` after Sigma mounts.
 
 ```bash
-.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels
+.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges
 ```
 
-That is the proven-drive command: doctor, unit tests, preview, Chrome CDP zoom with labels sampled mid-animation, JSON + screenshots. For Chrome-only after preview is up:
+That is the proven-drive command: doctor, unit tests, preview, Chrome CDP zoom with label and edge pixels sampled mid-animation, JSON + screenshots. For Chrome-only after preview is up:
 
 ```bash
-.cursor/skills/verify-kb/bin/verify-kb drive zoom-labels
+.cursor/skills/verify-kb/bin/verify-kb drive zoom-edges
 ```
+
+`zoom-labels` uses the same driver and the same fail-if-edges-disappear checks.
 
 ## Evidence
 
@@ -77,6 +79,7 @@ Proof standards:
 
 - Exercise the live canvas (`__kbGraph` + screenshots), not only the TypeScript source.
 - Mid-zoom `labelCanvasOpaquePixels` must be > 0 and `hideLabelsOnMove` must be false.
+- Every `cameraMoving` sample must have `edgeCanvasOpaquePixels` > 0 and `hideEdgesOnMove` must be false. A moving sample with zero edge ink fails prove.
 - `reducerResetCount` must stay `1` after hover-less zoom (reducers bound once per mount).
 - Cleanup must not delete this directory.
 
@@ -90,21 +93,19 @@ Stops only the preview PID this lever started (recorded in `/tmp/verify-kb/state
 
 ## Proven drive
 
-2026-09-03 — `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels`
-
-Verdict: **VERIFIED**. Homepage Sigma probe: `hideLabelsOnMove: false`, `hideEdgesOnMove: true`, `reducerResetCount: 1` through zoom. Label overlay ink at rest (2997) and while `cameraMoving` (samples 5490–5722). `layoutCountDelta: 0`. Screenshots `rest.png` / `zoom-mid.png` / `zoom-end.png` plus `zoom.webm`. Evidence: `/tmp/verify-kb/20260903T075334Z/`.
+Pending this PR — run `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges` after the motion contract change.
 
 ```bash
 pnpm --filter kb test
 pnpm --filter kb check-types
-.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels
+.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges
 ```
 
 ```bash
 .cursor/skills/verify-kb/bin/verify-kb doctor
 .cursor/skills/verify-kb/bin/verify-kb test
-.cursor/skills/verify-kb/bin/verify-kb drive zoom-labels
-.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels
+.cursor/skills/verify-kb/bin/verify-kb drive zoom-edges
+.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges
 .cursor/skills/verify-kb/bin/verify-kb preview-start
 .cursor/skills/verify-kb/bin/verify-kb preview-stop
 .cursor/skills/verify-kb/bin/verify-kb cleanup

--- a/.cursor/skills/verify-kb/bin/verify-kb
+++ b/.cursor/skills/verify-kb/bin/verify-kb
@@ -220,17 +220,25 @@ cmd_preview_start() {
   ensure_root
   local port="${VERIFY_KB_PREVIEW_PORT:-3009}"
   local log="${STATE_DIR}/preview.log"
+  local vite_bin="${ROOT}/node_modules/.bin/vite"
+  [[ -x "${vite_bin}" ]] || die "vite not found at ${vite_bin}; run pnpm install"
+  # Drop a previous lever-owned preview so we do not curl a leftover
+  # grandchild (pnpm exec leaves vite behind after SIGTERM of the wrapper).
+  cmd_preview_stop >/dev/null || true
+  if curl -sf -o /dev/null "http://127.0.0.1:${port}/"; then
+    die "port ${port} already answers; stop that process or set VERIFY_KB_PREVIEW_PORT"
+  fi
   local pid
   if [[ -f "${ROOT}/apps/kb/dist/client/index.html" ]]; then
     (
       cd "${ROOT}/apps/kb"
-      exec pnpm exec vite preview --host 127.0.0.1 --port "${port}" --strictPort
+      exec "${vite_bin}" preview --host 127.0.0.1 --port "${port}" --strictPort
     ) >"${log}" 2>&1 &
     pid=$!
   else
     (
       cd "${ROOT}/apps/kb"
-      exec pnpm exec vite dev --host 127.0.0.1 --port "${port}" --strictPort
+      exec "${vite_bin}" dev --host 127.0.0.1 --port "${port}" --strictPort
     ) >"${log}" 2>&1 &
     pid=$!
   fi
@@ -250,13 +258,13 @@ path.write_text(json.dumps(state))
 PY
   local i=0
   while [[ ${i} -lt 80 ]]; do
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      die "preview process exited; see ${log}"
+    fi
     if curl -sf -o /dev/null "http://127.0.0.1:${port}/"; then
       python3 -c 'import json,sys; print(json.dumps({"ok": True, "previewPid": int(sys.argv[1]), "url": sys.argv[2], "log": sys.argv[3]}))' \
         "${pid}" "http://127.0.0.1:${port}/" "${log}"
       return 0
-    fi
-    if ! kill -0 "${pid}" 2>/dev/null; then
-      die "preview process exited; see ${log}"
     fi
     sleep 0.25
     i=$((i + 1))
@@ -280,18 +288,48 @@ pid = state.get("previewPid")
 if not pid:
     print(json.dumps({"ok": True, "stopped": False, "reason": "no previewPid"}))
     raise SystemExit(0)
-try:
-    os.kill(int(pid), signal.SIGTERM)
-    stopped, reason = True, "sigterm"
+
+def children_of(root):
+    kids = {}
+    proc = pathlib.Path("/proc")
+    if not proc.is_dir():
+        return [int(root)]
+    for entry in proc.iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            status = (entry / "status").read_text()
+        except OSError:
+            continue
+        ppid = None
+        for line in status.splitlines():
+            if line.startswith("PPid:"):
+                ppid = int(line.split()[1])
+                break
+        if ppid is None:
+            continue
+        kids.setdefault(ppid, []).append(int(entry.name))
+    ordered = []
+    stack = [int(root)]
+    while stack:
+        cur = stack.pop()
+        ordered.append(cur)
+        stack.extend(kids.get(cur, []))
+    return ordered
+
+tree = children_of(pid)
+stopped, reason = False, "not running"
+for child in reversed(tree):
     try:
-        os.killpg(int(pid), signal.SIGTERM)
-    except (ProcessLookupError, PermissionError, OSError):
+        os.kill(child, signal.SIGTERM)
+        stopped, reason = True, "sigterm"
+    except ProcessLookupError:
         pass
-except ProcessLookupError:
-    stopped, reason = False, "not running"
+    except PermissionError:
+        reason = "permission"
 state.pop("previewPid", None)
 path.write_text(json.dumps(state))
-print(json.dumps({"ok": True, "stopped": stopped, "pid": pid, "reason": reason}))
+print(json.dumps({"ok": True, "stopped": stopped, "pid": pid, "reason": reason, "killed": tree}))
 PY
 }
 

--- a/.cursor/skills/verify-kb/bin/verify-kb
+++ b/.cursor/skills/verify-kb/bin/verify-kb
@@ -21,10 +21,10 @@ usage() {
 verify-kb — drive apps/kb homepage graph zoom/labels
 
 Commands:
-  doctor                         Source contract (labels stay on move)
+  doctor                         Source contract (labels + edges stay on move)
   test                           pnpm --filter kb test
-  drive <feature>                Chrome CDP zoom-labels (requires preview)
-  prove [--feature <id>]         doctor + test + preview + drive (default zoom-labels)
+  drive <feature>                Chrome CDP zoom (zoom-labels | zoom-edges)
+  prove [--feature <id>]         doctor + test + preview + drive (default zoom-edges)
   preview-start                  vite preview of dist/client, else vite dev
   preview-stop                   Stop the preview this lever started
   cleanup                        preview-stop; keep evidence
@@ -127,23 +127,34 @@ local_graph = (root / "apps/kb/src/components/LocalGraph.tsx").read_text()
 graph3d = (root / "apps/kb/src/components/Graph3D.tsx").read_text()
 gitmodules = (root / ".gitmodules").read_text() if (root / ".gitmodules").is_file() else ""
 
-hide_true = "hideLabelsOnMove: true" in viewer
-hide_false_setting = "hideLabelsOnMove: false" in motion
+hide_labels_true = "hideLabelsOnMove: true" in viewer
+hide_labels_false = "hideLabelsOnMove: false" in motion
+hide_edges_true_viewer = (
+    "hideEdgesOnMove: true" in viewer
+    or 'data-hide-edges-on-move="true"' in viewer
+)
+hide_edges_true_motion = "hideEdgesOnMove: true" in motion
+hide_edges_false = "hideEdgesOnMove: false" in motion
 uses_set_hover = "setHover(" in viewer or "setHover =" in viewer
 imports_motion = "SIGMA_HOMEPAGE_RENDER" in viewer
 local_uses_motion = "SIGMA_CAMERA_MOTION" in local_graph
 graph3d_key = "graphKey" in graph3d and "highlightIds" in graph3d
 submodule = "apps/kb/kb" in gitmodules
 
-labels_ok = hide_false_setting and not hide_true and imports_motion
+labels_ok = hide_labels_false and not hide_labels_true and imports_motion
+edges_ok = hide_edges_false and not hide_edges_true_viewer and not hide_edges_true_motion
 hover_ok = not uses_set_hover
-ok = labels_ok and hover_ok and local_uses_motion and submodule
+ok = labels_ok and edges_ok and hover_ok and local_uses_motion and submodule
 
 out = {
     "ok": ok,
     "labelsStayOnMove": labels_ok,
-    "hideLabelsOnMoveTrueInViewer": hide_true,
-    "hideLabelsOnMoveFalseInMotion": hide_false_setting,
+    "edgesStayOnMove": edges_ok,
+    "hideLabelsOnMoveTrueInViewer": hide_labels_true,
+    "hideLabelsOnMoveFalseInMotion": hide_labels_false,
+    "hideEdgesOnMoveTrueInViewer": hide_edges_true_viewer,
+    "hideEdgesOnMoveTrueInMotion": hide_edges_true_motion,
+    "hideEdgesOnMoveFalseInMotion": hide_edges_false,
     "hoverUsesReactState": uses_set_hover,
     "viewerImportsMotion": imports_motion,
     "localGraphUsesMotion": local_uses_motion,
@@ -192,7 +203,7 @@ cmd_drive() {
   ensure_root
   local feature="${1:-}"
   [[ -n "${feature}" ]] || die "drive requires a feature id"
-  [[ "${feature}" == "zoom-labels" ]] || die "unknown feature: ${feature}"
+  [[ "${feature}" == "zoom-labels" || "${feature}" == "zoom-edges" ]] || die "unknown feature: ${feature}"
   local pair id evidence
   pair="$(resolve_run)"
   id="${pair%% *}"
@@ -285,7 +296,7 @@ PY
 }
 
 cmd_prove() {
-  local feature="zoom-labels"
+  local feature="zoom-edges"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --feature)

--- a/.cursor/skills/verify-kb/features/README.md
+++ b/.cursor/skills/verify-kb/features/README.md
@@ -8,7 +8,7 @@ This directory is the maintained source for verifying user-facing graph motion o
 - `apps/kb/kb` submodule is checked out. Do not commit a new submodule pointer for this feature.
 - Launch means the homepage graph canvas is answering (dev or preview). `pnpm --filter kb test` is required for the motion contract; a full Pages prerender is not.
 - Put `.cursor/skills/verify-kb/bin` on `PATH` or invoke the binary by repo-relative path.
-- Run `verify-kb doctor` and require `labelsStayOnMove: true`.
+- Run `verify-kb doctor` and require `labelsStayOnMove: true` and `edgesStayOnMove: true`.
 - Never drive a preview that this run did not start, unless `--url` is passed explicitly.
 
 ## Driving conventions
@@ -19,8 +19,8 @@ This directory is the maintained source for verifying user-facing graph motion o
 
 ## Proof and skip reporting
 
-- Capture the user action (zoom) and the resulting state (labels still inked on the 2D overlay).
-- Pixel proof is `labelCanvasOpaquePixels` at rest, mid-zoom, and end. Source grep alone is not enough for a zoom-labels claim.
+- Capture the user action (zoom) and the resulting state (labels still inked on the 2D overlay; edges still inked on `canvas.sigma-edges`).
+- Pixel proof is `labelCanvasOpaquePixels` and `edgeCanvasOpaquePixels` at rest, mid-zoom, and while `cameraMoving`. Source grep alone is not enough for a zoom-labels or zoom-edges claim. A `cameraMoving` sample with `edgePixels === 0` fails prove.
 - Record LayoutCount / RecalcStyleCount deltas when Chrome Performance metrics are available. Do not claim "no jank" without a number.
 - Report an unreachable path with the attempted command and the unmet precondition.
 
@@ -35,4 +35,5 @@ Each feature file starts with an H1 title and one paragraph describing the user-
 
 ## Features
 
-- [Zoom labels](./zoom-labels.md) covers homepage graph zoom keeping labels readable, with cheaper hover/refresh.
+- [Zoom labels](./zoom-labels.md) covers homepage graph zoom keeping labels readable, with cheaper hover/refresh. Edges stay inked too.
+- [Zoom edges](./zoom-edges.md) covers homepage graph zoom/pan keeping connection lines inked (`hideEdgesOnMove: false`). Labels stay; do not re-enable `hideLabelsOnMove`.

--- a/.cursor/skills/verify-kb/features/zoom-edges.md
+++ b/.cursor/skills/verify-kb/features/zoom-edges.md
@@ -1,0 +1,37 @@
+# Zoom keeps graph connection lines inked
+
+On the kb homepage graph, connection lines stay on the edges WebGL canvas while the user zooms or pans. Motion must not blank edges. Labels stay on too — do not re-enable `hideLabelsOnMove`.
+
+## Sub-features
+
+- `edges-on-move` keeps `hideEdgesOnMove` false so Sigma does not skip the edges layer during pan/zoom/animate.
+- `labels-on-move` keeps `hideLabelsOnMove` false (labels stay; do not trade them for edges).
+- `pixels-mid-zoom-edges` has opaque pixels on `canvas.sigma-edges` while `cameraMoving` is true.
+- `hover-no-rerender` updates the hover hint through a ref, not `setHover`.
+- `reducers-once` binds node/edge reducers once per mount (`reducerResetCount === 1`).
+
+## How to get to it (user POV)
+
+- Open `https://kb.duyet.net/` and scroll-zoom or pan the graph.
+- Open the same homepage on a Pages preview hostname after a green kb build.
+- After `verify-kb preview-start`, open `http://127.0.0.1:3009/` (dev) or the printed preview URL.
+
+## Driving it with verify-kb
+
+Preconditions:
+
+- `verify-kb doctor` reports `edgesStayOnMove: true` and `labelsStayOnMove: true`.
+- A preview this run started is answering, or `--url` points at a running kb homepage.
+- Headless Chrome can create a WebGL context (swiftshader flags in the drive script).
+
+- **Contract.** Run `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges`. Combined JSON `"ok": true`.
+- **Canvas.** After Sigma ready, rest `edgeCanvasOpaquePixels` > 0 and `labelCanvasOpaquePixels` > 0. Call `__kbGraph.animateZoom(0.5, 800)`. Every sample with `cameraMoving` has `edgePixels` > 0. `hideEdgesOnMove` and `hideLabelsOnMove` are false. `reducerResetCount` is 1.
+- **Artifact.** `evidenceDir/rest.png`, `zoom-mid.png`, `zoom-end.png`, `report.json`. Optional `zoom.webm`.
+
+## Gotchas
+
+- Live `kb.duyet.net` still hides edges until this change is deployed. Recert local preview (or a new Pages preview), not stale production, for the fix claim. Production is the before-state.
+- Sigma draws edges on a dedicated WebGL canvas (`canvas.sigma-edges`). Sampling the 2D label overlay cannot prove edges stayed.
+- `hideEdgesOnMove: true` clears that layer every frame while the camera is animated. Source grep of the setting is not enough; mid-zoom `edgeCanvasOpaquePixels` must stay above zero.
+- The first 1.4s staged reveal hides some nodes. Wait until rest edge ink exists before zooming.
+- Do not bump `apps/kb/kb` or mix leftover PRs #1362 / #1365 / #1422.

--- a/.cursor/skills/verify-kb/features/zoom-labels.md
+++ b/.cursor/skills/verify-kb/features/zoom-labels.md
@@ -1,14 +1,15 @@
 # Zoom keeps graph labels readable
 
-On the kb homepage graph, node labels stay on the canvas while the user zooms. Motion should not blank labels or rebuild Sigma reducers / re-render React on hover.
+On the kb homepage graph, node labels stay on the canvas while the user zooms. Motion should not blank labels or rebuild Sigma reducers / re-render React on hover. Connection lines stay inked too.
 
 ## Sub-features
 
 - `labels-on-move` keeps `hideLabelsOnMove` false so Sigma does not skip the label overlay during pan/zoom/animate.
-- `edges-on-move` still skips edges while the camera moves (`hideEdgesOnMove: true`).
+- `edges-on-move` keeps `hideEdgesOnMove` false so connection lines stay inked during pan/zoom/animate.
 - `hover-no-rerender` updates the hover hint through a ref, not `setHover`.
 - `reducers-once` binds node/edge reducers once per mount (`reducerResetCount === 1`).
 - `pixels-mid-zoom` has opaque label-canvas pixels while a zoom animation is in flight.
+- `pixels-mid-zoom-edges` has opaque `sigma-edges` pixels while `cameraMoving` is true.
 
 ## How to get to it (user POV)
 
@@ -20,17 +21,18 @@ On the kb homepage graph, node labels stay on the canvas while the user zooms. M
 
 Preconditions:
 
-- `verify-kb doctor` reports `labelsStayOnMove: true`.
+- `verify-kb doctor` reports `labelsStayOnMove: true` and `edgesStayOnMove: true`.
 - A preview this run started is answering, or `--url` points at a running kb homepage.
 - Headless Chrome can create a WebGL context (swiftshader flags in the drive script).
 
 - **Contract.** Run `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-labels`. Combined JSON `"ok": true`.
-- **Canvas.** After Sigma ready, rest `labelCanvasOpaquePixels` > 0. Call `__kbGraph.animateZoom(0.5, 800)`. Mid-animation pixels > 0 and `hideLabelsOnMove` is false. `reducerResetCount` is 1.
+- **Canvas.** After Sigma ready, rest `labelCanvasOpaquePixels` > 0 and `edgeCanvasOpaquePixels` > 0. Call `__kbGraph.animateZoom(0.5, 800)`. Mid-animation label pixels > 0, every `cameraMoving` sample has `edgePixels` > 0, and both hide-on-move flags are false. `reducerResetCount` is 1.
 - **Artifact.** `evidenceDir/rest.png`, `zoom-mid.png`, `zoom-end.png`, `report.json`. Optional `zoom.webm`.
 
 ## Gotchas
 
-- Live `kb.duyet.net` still hides labels until this change is deployed. Recert local preview (or a new Pages preview), not stale production, for the fix claim. Production is the before-state.
+- Live `kb.duyet.net` still hides edges until this change is deployed. Recert local preview (or a new Pages preview), not stale production, for the fix claim. Production is the before-state.
 - The first 1.4s staged reveal clears labels on purpose. Sampling before reveal finishes looks like a zoom-label failure.
 - WebGL-less Chrome yields no Sigma probe. That is an environment miss, not proof that labels hide.
+- A `cameraMoving` sample with `edgePixels === 0` fails prove — that is the hide-edges-on-move leak.
 - Do not bump `apps/kb/kb` or mix leftover PRs #1362 / #1365 / #1422.

--- a/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs
+++ b/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs
@@ -220,7 +220,7 @@ async function main() {
           const el = document.querySelector('[data-kb-graph="2d"]');
           const ready = el && el.getAttribute('data-sigma-ready') === 'true';
           const probe = window.__kbGraph;
-          if (ready && probe && probe.hideLabelsOnMove === false) {
+          if (ready && probe && probe.hideLabelsOnMove === false && probe.hideEdgesOnMove === false) {
             resolve({ ok: true, elapsedMs: Date.now() - start });
             return;
           }
@@ -248,8 +248,9 @@ async function main() {
           const start = Date.now();
           const tick = () => {
             const n = window.__kbGraph?.labelCanvasOpaquePixels ?? 0;
-            if (n > 0 || Date.now() - start > 3000) {
-              resolve(n);
+            const e = window.__kbGraph?.edgeCanvasOpaquePixels ?? 0;
+            if ((n > 0 && e > 0) || Date.now() - start > 3000) {
+              resolve({ labels: n, edges: e });
               return;
             }
             requestAnimationFrame(tick);
@@ -268,6 +269,7 @@ async function main() {
             renderLabels: window.__kbGraph.renderLabels,
             cameraMoving: window.__kbGraph.cameraMoving,
             labelCanvasOpaquePixels: window.__kbGraph.labelCanvasOpaquePixels,
+            edgeCanvasOpaquePixels: window.__kbGraph.edgeCanvasOpaquePixels,
             refreshCount: window.__kbGraph.refreshCount,
             reducerResetCount: window.__kbGraph.reducerResetCount,
           })`
@@ -318,7 +320,9 @@ async function main() {
           `new Promise((resolve) => {
             const before = {
               hideLabelsOnMove: window.__kbGraph.hideLabelsOnMove,
+              hideEdgesOnMove: window.__kbGraph.hideEdgesOnMove,
               pixels: window.__kbGraph.labelCanvasOpaquePixels,
+              edgePixels: window.__kbGraph.edgeCanvasOpaquePixels,
               moving: window.__kbGraph.cameraMoving,
               reducerResetCount: window.__kbGraph.reducerResetCount,
               refreshCount: window.__kbGraph.refreshCount,
@@ -331,7 +335,9 @@ async function main() {
                 t: Date.now() - start,
                 moving: window.__kbGraph.cameraMoving,
                 pixels: window.__kbGraph.labelCanvasOpaquePixels,
+                edgePixels: window.__kbGraph.edgeCanvasOpaquePixels,
                 hideLabelsOnMove: window.__kbGraph.hideLabelsOnMove,
+                hideEdgesOnMove: window.__kbGraph.hideEdgesOnMove,
               });
               if (Date.now() - start < 700) {
                 requestAnimationFrame(tick);
@@ -342,7 +348,9 @@ async function main() {
                 samples,
                 after: {
                   hideLabelsOnMove: window.__kbGraph.hideLabelsOnMove,
+                  hideEdgesOnMove: window.__kbGraph.hideEdgesOnMove,
                   pixels: window.__kbGraph.labelCanvasOpaquePixels,
+                  edgePixels: window.__kbGraph.edgeCanvasOpaquePixels,
                   moving: window.__kbGraph.cameraMoving,
                   reducerResetCount: window.__kbGraph.reducerResetCount,
                   refreshCount: window.__kbGraph.refreshCount,
@@ -390,21 +398,39 @@ async function main() {
     const midPixels = Array.isArray(mid?.samples)
       ? Math.max(...mid.samples.map((s) => s.pixels || 0), 0)
       : 0;
-    const movingSample = Array.isArray(mid?.samples)
-      ? mid.samples.find((s) => s.moving) || mid.samples[Math.floor(mid.samples.length / 2)]
-      : null;
+    const midEdgePixels = Array.isArray(mid?.samples)
+      ? Math.max(...mid.samples.map((s) => s.edgePixels || 0), 0)
+      : 0;
+    const movingSamples = Array.isArray(mid?.samples)
+      ? mid.samples.filter((s) => s.moving)
+      : [];
+    const movingSample = movingSamples[0] || (Array.isArray(mid?.samples)
+      ? mid.samples[Math.floor(mid.samples.length / 2)]
+      : null);
+    const movingEdgeMin = movingSamples.length
+      ? Math.min(...movingSamples.map((s) => s.edgePixels || 0))
+      : 0;
+    const edgesDisappearedWhileMoving =
+      movingSamples.length > 0 && movingEdgeMin === 0;
 
     const checks = {
       probeReady: Boolean(ready?.ok),
       hideLabelsOnMoveFalse: restProbe?.hideLabelsOnMove === false,
-      hideEdgesOnMoveTrue: restProbe?.hideEdgesOnMove === true,
+      hideEdgesOnMoveFalse: restProbe?.hideEdgesOnMove === false,
       renderLabels: restProbe?.renderLabels === true,
       reducersOnce: restProbe?.reducerResetCount === 1,
       restPixels: (restProbe?.labelCanvasOpaquePixels ?? 0) > 0,
+      restEdgePixels: (restProbe?.edgeCanvasOpaquePixels ?? 0) > 0,
       midPixels: midPixels > 0,
+      midEdgePixels: midEdgePixels > 0,
       midHideLabelsFalse:
         movingSample?.hideLabelsOnMove === false ||
         mid?.after?.hideLabelsOnMove === false,
+      midHideEdgesFalse:
+        movingSample?.hideEdgesOnMove === false ||
+        mid?.after?.hideEdgesOnMove === false,
+      edgesStayWhileMoving:
+        movingSamples.length > 0 && !edgesDisappearedWhileMoving,
       reducersUnchanged:
         restProbe?.reducerResetCount === 1 &&
         mid?.after?.reducerResetCount === 1,
@@ -429,6 +455,9 @@ async function main() {
       restProbe,
       zoom: mid,
       midPixels,
+      midEdgePixels,
+      movingEdgeMin,
+      edgesDisappearedWhileMoving,
       layoutCountDelta,
       recalcStyleDelta,
       screenshots: {

--- a/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs
+++ b/.cursor/skills/verify-kb/scripts/drive-zoom-labels.mjs
@@ -284,7 +284,7 @@ async function main() {
     }
 
     const restPng = join(outDir, "rest.png");
-    if (ready?.ok) await screenshot(session, restPng);
+    await screenshot(session, restPng);
 
     const frameDir = join(outDir, "frames");
     mkdirSync(frameDir, { recursive: true });
@@ -461,7 +461,7 @@ async function main() {
       layoutCountDelta,
       recalcStyleDelta,
       screenshots: {
-        rest: ready?.ok ? restPng : null,
+        rest: restPng,
         zoomMid: ready?.ok ? midPng : null,
         zoomEnd: ready?.ok ? endPng : null,
       },

--- a/apps/kb/src/components/GraphViewer.tsx
+++ b/apps/kb/src/components/GraphViewer.tsx
@@ -27,7 +27,7 @@ type SigmaCtor = typeof import("sigma").default;
  *
  * Fetches the prebuilt /graph-data.json (no raw markdown in the bundle),
  * lays it out with a live ForceAtlas2 worker (graphology-layout-forceatlas2),
- * and renders with Sigma.js (WebGL): pan/zoom (labels stay readable), node
+ * and renders with Sigma.js (WebGL): pan/zoom (labels and edges stay readable), node
  * drag (reheats layout), hover neighbor highlight, click-to-read detail
  * panel (markdown fetched on demand), kind/tag filters, force sliders, and
  * search. Hover highlight is ref-only so the overlay tree does not re-render.
@@ -856,7 +856,7 @@ export function GraphViewer() {
             className="absolute inset-0"
             data-kb-graph="2d"
             data-hide-labels-on-move="false"
-            data-hide-edges-on-move="true"
+            data-hide-edges-on-move="false"
             data-sigma-ready={ready ? "true" : "false"}
             aria-label="Knowledge graph"
           />

--- a/apps/kb/src/components/graph-motion.test.ts
+++ b/apps/kb/src/components/graph-motion.test.ts
@@ -13,10 +13,17 @@ describe("kb graph motion contract", () => {
     expect(GRAPH_MOTION_CONTRACT.hideLabelsOnMove).toBe(false);
   });
 
-  it("still skips edges during pan/zoom so the camera stays cheap", () => {
-    expect(SIGMA_CAMERA_MOTION.hideEdgesOnMove).toBe(true);
-    expect(SIGMA_HOMEPAGE_RENDER.hideEdgesOnMove).toBe(true);
-    expect(GRAPH_MOTION_CONTRACT.hideEdgesOnMove).toBe(true);
+  it("keeps connection lines on while the camera moves", () => {
+    expect(SIGMA_CAMERA_MOTION.hideEdgesOnMove).toBe(false);
+    expect(SIGMA_HOMEPAGE_RENDER.hideEdgesOnMove).toBe(false);
+    expect(GRAPH_MOTION_CONTRACT.hideEdgesOnMove).toBe(false);
+  });
+
+  it("does not re-enable hideLabelsOnMove when keeping edges", () => {
+    expect(SIGMA_CAMERA_MOTION.hideLabelsOnMove).toBe(false);
+    expect(SIGMA_CAMERA_MOTION.hideEdgesOnMove).toBe(false);
+    expect(GRAPH_MOTION_CONTRACT.hideLabelsOnMove).toBe(false);
+    expect(GRAPH_MOTION_CONTRACT.hideEdgesOnMove).toBe(false);
   });
 
   it("does not re-render React or rebind Sigma reducers on hover", () => {

--- a/apps/kb/src/components/graph-motion.ts
+++ b/apps/kb/src/components/graph-motion.ts
@@ -1,19 +1,20 @@
 /**
- * Camera / label motion contract for kb graph canvases (Sigma.js).
+ * Camera / label / edge motion contract for kb graph canvases (Sigma.js).
  *
  * Labels are a 2D overlay, not measured DOM. `hideLabelsOnMove` was a FPS
- * shortcut that blanked every label for the whole pan/zoom/animate. Edges
- * are the expensive stroke and can still be skipped while the camera moves.
- * Reducers read refs and are assigned once so hover does not rebuild Sigma's
- * index or re-render React.
+ * shortcut that blanked every label for the whole pan/zoom/animate.
+ * `hideEdgesOnMove` skipped the dedicated edges WebGL layer the same way —
+ * connection lines vanished and the graph felt leaky. Keep both inked while
+ * the camera moves. Reducers read refs and are assigned once so hover does
+ * not rebuild Sigma's index or re-render React.
  */
 
 export const SIGMA_CAMERA_MOTION = {
   renderLabels: true,
   /** Keep node labels readable while the camera pans, zooms, or animates. */
   hideLabelsOnMove: false,
-  /** Skip edge strokes during camera moves — cheaper than dropping labels. */
-  hideEdgesOnMove: true,
+  /** Keep connection lines inked while the camera pans, zooms, or animates. */
+  hideEdgesOnMove: false,
 } as const;
 
 export const SIGMA_HOMEPAGE_RENDER = {
@@ -35,7 +36,7 @@ export const SIGMA_HOMEPAGE_RENDER = {
 
 export const GRAPH_MOTION_CONTRACT = {
   hideLabelsOnMove: false,
-  hideEdgesOnMove: true,
+  hideEdgesOnMove: false,
   hoverUsesReactState: false,
   reducersAssignedOnce: true,
   graph3dRemountsOnHighlight: false,
@@ -47,6 +48,7 @@ export type KbGraphProbe = {
   renderLabels: boolean;
   cameraMoving: boolean;
   labelCanvasOpaquePixels: number;
+  edgeCanvasOpaquePixels: number;
   refreshCount: number;
   reducerResetCount: number;
   zoomBy: (factor: number) => void;
@@ -69,6 +71,9 @@ export type SigmaProbeHost = {
     key: "hideLabelsOnMove" | "hideEdgesOnMove" | "renderLabels"
   ) => unknown;
   getCamera: () => SigmaCamera;
+  getCanvases: () => Record<string, HTMLCanvasElement>;
+  on: (event: "afterRender", handler: () => void) => void;
+  off: (event: "afterRender", handler: () => void) => void;
 };
 
 export function countLabelCanvasOpaquePixels(container: HTMLElement): number {
@@ -95,6 +100,47 @@ export function countLabelCanvasOpaquePixels(container: HTMLElement): number {
   return best;
 }
 
+function webglContext(canvas: HTMLCanvasElement): WebGLRenderingContext | null {
+  for (const name of ["webgl2", "webgl"] as const) {
+    let ctx: RenderingContext | null = null;
+    try {
+      ctx = canvas.getContext(name);
+    } catch {
+      ctx = null;
+    }
+    if (ctx && "readPixels" in ctx) {
+      return ctx as WebGLRenderingContext;
+    }
+  }
+  return null;
+}
+
+export function countEdgeCanvasOpaquePixels(
+  sigma: SigmaProbeHost,
+  container: HTMLElement
+): number {
+  const canvases = sigma.getCanvases?.() ?? {};
+  const edges =
+    canvases.edges ??
+    container.querySelector("canvas.sigma-edges") ??
+    null;
+  if (!(edges instanceof HTMLCanvasElement)) return 0;
+  const gl = webglContext(edges);
+  if (!gl) return 0;
+  const width = gl.drawingBufferWidth;
+  const height = gl.drawingBufferHeight;
+  if (width < 2 || height < 2) return 0;
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  const pixels = new Uint8Array(width * height * 4);
+  gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+  let n = 0;
+  // Same stride as the label overlay probe.
+  for (let i = 3; i < pixels.length; i += 16) {
+    if (pixels[i] > 24) n += 1;
+  }
+  return n;
+}
+
 function cameraIsMoving(camera: SigmaCamera): boolean {
   if (typeof camera.isAnimated === "function") return camera.isAnimated();
   if (typeof camera.animated === "boolean") return camera.animated;
@@ -106,6 +152,15 @@ export function attachKbGraphProbe(
   container: HTMLElement,
   counters: { refreshCount: () => number; reducerResetCount: () => number }
 ): () => void {
+  // Sample the edges WebGL layer in afterRender so readPixels still sees
+  // the buffer (Sigma creates it with preserveDrawingBuffer: false).
+  let edgeInk = 0;
+  const sampleEdges = () => {
+    edgeInk = countEdgeCanvasOpaquePixels(sigma, container);
+  };
+  sigma.on("afterRender", sampleEdges);
+  sampleEdges();
+
   const probe: KbGraphProbe = {
     get hideLabelsOnMove() {
       return sigma.getSetting("hideLabelsOnMove") === true;
@@ -121,6 +176,9 @@ export function attachKbGraphProbe(
     },
     get labelCanvasOpaquePixels() {
       return countLabelCanvasOpaquePixels(container);
+    },
+    get edgeCanvasOpaquePixels() {
+      return edgeInk;
     },
     get refreshCount() {
       return counters.refreshCount();
@@ -147,6 +205,7 @@ export function attachKbGraphProbe(
   container.dataset.sigmaReady = "true";
 
   return () => {
+    sigma.off("afterRender", sampleEdges);
     if (win.__kbGraph === probe) delete win.__kbGraph;
     delete container.dataset.sigmaReady;
   };

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 - [`docs/ai/internal-knowledge.md`](ai/internal-knowledge.md): durable repository knowledge for AI agents (static-render rule, latest shadcn + chat primitives, deploy path, gitleaks secret scan, Clerk `@clerk/shared` 3.47 pin). Public-app UI direction lives here; [`DESIGN.md`](../DESIGN.md) is the short companion.
 - [`.cursor/skills/verify-blog/`](../.cursor/skills/verify-blog/SKILL.md): project-local blog verification skill (production build + prerendered post HTML). CLI lever: `.cursor/skills/verify-blog/bin/verify-blog`.
-- [`.cursor/skills/verify-kb/`](../.cursor/skills/verify-kb/SKILL.md): project-local kb graph motion skill (zoom keeps labels; Chrome CDP + Sigma probe). CLI lever: `.cursor/skills/verify-kb/bin/verify-kb`.
+- [`.cursor/skills/verify-kb/`](../.cursor/skills/verify-kb/SKILL.md): project-local kb graph motion skill (zoom keeps labels and edges; Chrome CDP + Sigma probe). CLI lever: `.cursor/skills/verify-kb/bin/verify-kb`.
 - [`.gitleaks.toml`](../.gitleaks.toml): custom secret-scan rules (AnyRouter `sk-ar-v1-` prefix). CI: `.github/workflows/gitleaks.yml`.
 - [`docs/ai/cowork-instructions.md`](ai/cowork-instructions.md): guidance for Claude Cowork (desktop agent) sessions on this repo.
 - [`docs/ai/writing-style.md`](ai/writing-style.md): how to write blog posts and notes in Duyet's voice.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1436.

Follow-up to #1435 (`b19e9f73`). Live kb.duyet.net still ships `hideEdgesOnMove:!0`, so Sigma clears the dedicated edges WebGL layer for the whole pan/zoom/animate. That is the leaky/janky feel.

## Change

- `SIGMA_CAMERA_MOTION.hideEdgesOnMove` is `false` (homepage + local article graphs).
- Labels stay on. `hideLabelsOnMove` remains `false`. Do not re-enable it.
- `__kbGraph.edgeCanvasOpaquePixels` samples `canvas.sigma-edges` on `afterRender`.
- `verify-kb prove --feature zoom-edges` fails if any `cameraMoving` sample has zero edge ink.

No IA redesign. Content submodule pointer unchanged. Does not touch leftover PRs #1362 / #1365 / #1422.

## Verify

Proven drive 2026-09-03: `.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges` → **VERIFIED**.

| Check | Result |
| --- | --- |
| `hideLabelsOnMove` | false |
| `hideEdgesOnMove` | false |
| `reducerResetCount` through zoom | 1 (bound once) |
| Label overlay ink at rest | 1680 |
| Label overlay ink while `cameraMoving` | 5510–5740 |
| Edge canvas ink at rest | 6942 |
| Edge canvas ink while `cameraMoving` | 20848–22786 (min 20848) |
| `layoutCountDelta` during zoom | **0** |
| `recalcStyleDelta` | 1 |

```bash
pnpm --filter kb test
pnpm --filter kb check-types
.cursor/skills/verify-kb/bin/verify-kb prove --feature zoom-edges
```

Rest (edges and labels on):

![kb graph at rest with connection lines and node labels visible](https://cursor.com/artifacts/c/art-e1a54db9-7aa8-4f9b-a550-bc4e8cc47557)

Mid-zoom (edges still inked, camera moving):

![kb graph mid-zoom with connection lines still visible](https://cursor.com/artifacts/c/art-0617af9d-fab1-42ab-841c-1801c73812f1)

After zoom:

![kb graph after zoom with connection lines still visible](https://cursor.com/artifacts/c/art-1cfa8b8c-348e-4f48-9a1e-abd1fb1b5dc4)

<a href="https://cursor.com/agents/bc-66ac22bc-87d7-4f63-8850-4e39753a420d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvideo%2Fkb_graph_zoom_edges.webm"><img src="https://cursor.com/artifacts/c/art-dea9fc03-b390-4d07-a38b-18f77dfffc33" alt="kb_graph_zoom_edges.webm" /></a>

Live [kb.duyet.net](https://kb.duyet.net) still hides edges until Pages publishes this commit.

Please do not squash-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66ac22bc-87d7-4f63-8850-4e39753a420d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66ac22bc-87d7-4f63-8850-4e39753a420d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Keep knowledge graph edges rendered during camera motion while preserving label visibility and strengthen automated pixel-level verification of the motion contract.

New Features:
- Keep knowledge graph connection edges visible during pan, zoom, and camera animations alongside labels.

Bug Fixes:
- Prevent Sigma's edges layer from being cleared while the graph camera is moving, eliminating disappearing connection lines and improving perceived motion continuity.

Enhancements:
- Expose sampled edge-canvas pixel data through the graph probe for runtime verification.
- Extend graph-motion verification to validate edge visibility during camera movement and capture edge-rendering evidence.

Documentation:
- Update the knowledge-graph verification guidance and feature documentation to cover edge visibility and zoom-edge proofs.

Tests:
- Update the graph motion contract tests to require labels and edges to remain visible during camera movement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Graph connection lines now remain visible during pan, zoom, and animation.
  - Added edge-rendering verification alongside label verification, including mid-motion pixel checks.
  - Added a dedicated “Zoom edges” verification workflow.

- **Bug Fixes**
  - Improved validation to detect missing connection lines while the camera is moving.

- **Documentation**
  - Updated graph behavior and verification guidance to cover persistent labels and edges.
  - Updated the verification index to reflect the expanded zoom behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->