### PR TITLE
fix(api): omit nameless D1 from production wrangler deploy

### DIFF
--- a/.cursor/skills/verify-api/SKILL.md
+++ b/.cursor/skills/verify-api/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: verify-api
+description: Drive and prove apps/api (api.duyet.net) over HTTP and the production Wrangler D1 deploy plan. Use when verifying duyet-api health, OpenAPI, submissions, or that CI wrangler deploy will not auto-provision D1 by name.
+---
+
+# Verify api (apps/api)
+
+Agent-facing skill for the Hono Cloudflare Worker at `apps/api` (live: `https://api.duyet.net`). Public callers use HTTP. Production publish is `pnpm --filter api deploy` (`scripts/deploy.ts` after `esbuild`). Do not treat unit tests as proof that Wrangler will publish, and do not treat `https://duyet.net/openapi.json` as proof that `api.duyet.net` is on the same SHA.
+
+Harness binary (the lever): `.cursor/skills/verify-api/bin/verify-api`. Always invoke it by that path from the repo root. It prints JSON. Evidence survives cleanup under `$VERIFY_API_EVIDENCE` (default `/tmp/verify-api/<run-id>/`).
+
+Feature map: [`features/README.md`](features/README.md). Drive the mapped feature you are claiming, not a convenient substitute.
+
+## Launch
+
+From the monorepo root, with pnpm 10 and workspace `node_modules` installed.
+
+Local Worker HTTP uses the Hono module in-process (`app.request` via `.cursor/skills/verify-api/scripts/drive-http.ts`). That is the same worker source Wrangler bundles. `wrangler dev` is optional and often spins in a reload loop on overlay filesystems; do not treat a hung `dev-start` as a failed health claim when `drive health` already passed.
+
+```bash
+.cursor/skills/verify-api/bin/verify-api drive health
+```
+
+Production D1 plan does not need a server:
+
+```bash
+.cursor/skills/verify-api/bin/verify-api prove --feature production-d1
+```
+
+## Doctor
+
+Read-only. Run first whenever anything looks off:
+
+```bash
+.cursor/skills/verify-api/bin/verify-api doctor
+```
+
+Pass requires:
+
+- `apps/api/wrangler.toml` `name = "duyet-api"`.
+- `apps/api/package.json` `deploy` runs `tsx scripts/deploy.ts`.
+- `apps/api/src/lib/d1-deploy-plan.ts` and `apps/api/scripts/plan-production-deploy.ts` exist.
+- Production plan (`pnpm --filter api deploy:plan`) has `ok: true` and `productionHasD1: false` until a real `database_id` UUID is committed.
+
+Do not drive an instance whose doctor reports `deployUsesHelper: false` or `productionD1Safe: false`.
+
+## Drive
+
+Prefer the lever over ad-hoc grep. Recipes live in `features/`. Stable handles:
+
+- Health: `GET /` and `GET /health`.
+- OpenAPI: `GET /openapi.json` paths `/api/contact`, `/api/jd`, `/api/comments`.
+- Contact: `POST /api/contact` with `Content-Type: application/json`.
+- Production D1: `deploy:plan` JSON; production toml must not contain nameless `[[d1_databases]]`.
+
+```bash
+.cursor/skills/verify-api/bin/verify-api prove --feature production-d1
+```
+
+That is the proven-drive command for the CI deploy contract. For HTTP after `dev-start`:
+
+```bash
+.cursor/skills/verify-api/bin/verify-api drive health
+.cursor/skills/verify-api/bin/verify-api drive openapi
+.cursor/skills/verify-api/bin/verify-api drive submissions-contact
+```
+
+Live `https://api.duyet.net` is a separate check (`drive live-worker`). CF HIT on an old body without `contact` in `endpoints` means the Worker did not publish.
+
+## Evidence
+
+Named location: `/tmp/verify-api/<run-id>/` (printed as `evidenceDir` in every command's JSON). Capture:
+
+- `report.json` — lever output.
+- `doctor.json` / `plan.json` — doctor and `deploy:plan`.
+- `health.json` / `openapi.json` — HTTP bodies when those features ran.
+- `dev.log` when this lever started `wrangler dev`.
+
+Proof standards:
+
+- Exercise the Worker HTTP (local wrangler or live `api.duyet.net`), not only Vitest.
+- For the D1 deploy contract, exercise `planProductionDeploy` / `deploy:plan`, not a comment in `wrangler.toml`.
+- `https://duyet.net/openapi.json` can list new paths while `api.duyet.net` still 404s them. Always fetch the Worker origin you claim.
+- Cleanup must not delete this directory.
+
+## Cleanup
+
+```bash
+.cursor/skills/verify-api/bin/verify-api cleanup
+```
+
+Stops only the `wrangler dev` PID this lever started (recorded in `/tmp/verify-api/state.json`). Never `pkill wrangler` / `pkill workerd`. Never delete `evidenceDir`.
+
+## Proven drive
+
+2026-09-03 — `.cursor/skills/verify-api/bin/verify-api prove --feature production-d1`
+
+Verdict: **VERIFIED**. `deployUsesHelper: true`, `productionD1Safe: true`, `stripD1: true`, `productionHasD1: false`, `applyMigrations: false`. Planned production toml has `[[send_email]]` and no `[[d1_databases]]`. Evidence: `/tmp/verify-api/20260903T180812Z/`.
+
+HTTP via Hono `app.request`: `drive health` 200 with `listsContact: true`; `drive openapi` has the three submission paths; `drive submissions-contact` is 503 (no D1) and honeypot 202.
+
+```bash
+pnpm --filter api test
+pnpm --filter api check-types
+.cursor/skills/verify-api/bin/verify-api prove --feature production-d1
+.cursor/skills/verify-api/bin/verify-api drive health
+```
+
+```bash
+.cursor/skills/verify-api/bin/verify-api doctor
+.cursor/skills/verify-api/bin/verify-api deploy-plan
+.cursor/skills/verify-api/bin/verify-api drive production-d1
+.cursor/skills/verify-api/bin/verify-api drive health
+.cursor/skills/verify-api/bin/verify-api drive openapi
+.cursor/skills/verify-api/bin/verify-api drive submissions-contact
+.cursor/skills/verify-api/bin/verify-api drive live-worker
+.cursor/skills/verify-api/bin/verify-api prove --feature production-d1
+.cursor/skills/verify-api/bin/verify-api dev-start
+.cursor/skills/verify-api/bin/verify-api dev-stop
+.cursor/skills/verify-api/bin/verify-api cleanup
+```
+
+`--help` or an empty invocation prints the same list instead of JSON. All other commands emit one JSON object on stdout. Non-zero exit means the claim is not verified.

--- a/.cursor/skills/verify-api/bin/verify-api
+++ b/.cursor/skills/verify-api/bin/verify-api
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+# CLI lever for .cursor/skills/verify-api — run from the monorepo root.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+DRIVE_HTTP="${ROOT}/.cursor/skills/verify-api/scripts/drive-http.ts"
+STATE_DIR="${VERIFY_API_STATE_DIR:-/tmp/verify-api}"
+STATE_FILE="${STATE_DIR}/state.json"
+CMD="${1:-}"
+shift || true
+
+mkdir -p "${STATE_DIR}"
+
+die() {
+  python3 -c 'import json,sys; print(json.dumps({"ok": False, "error": sys.argv[1]}))' "$1"
+  exit 1
+}
+
+usage() {
+  cat <<'EOF'
+verify-api — drive apps/api HTTP and the production D1 deploy plan
+
+Commands:
+  doctor                         Wrangler name, deploy helper, production D1 plan
+  deploy-plan                    pnpm --filter api deploy:plan
+  drive <feature>                production-d1|health|openapi|submissions-contact|live-worker
+  prove [--feature <id>]         doctor + drive (default production-d1)
+  dev-start                      wrangler dev on port 8787
+  dev-stop                       Stop the wrangler this lever started
+  cleanup                        dev-stop; keep evidence
+  --help                         This text
+
+Evidence: $VERIFY_API_EVIDENCE or /tmp/verify-api/<run-id>/
+EOF
+}
+
+ensure_root() {
+  [[ -f "${ROOT}/package.json" && -d "${ROOT}/apps/api" ]] || die "not the monorepo root (${ROOT})"
+}
+
+new_run_id() {
+  date -u +%Y%m%dT%H%M%SZ
+}
+
+read_state_run_id() {
+  python3 - "$STATE_FILE" <<'PY'
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+if not p.is_file():
+    print("")
+    raise SystemExit(0)
+try:
+    print(json.loads(p.read_text()).get("runId", "") or "")
+except json.JSONDecodeError:
+    print("")
+PY
+}
+
+evidence_dir_for() {
+  local id="$1"
+  if [[ -n "${VERIFY_API_EVIDENCE:-}" ]]; then
+    printf '%s' "${VERIFY_API_EVIDENCE}"
+  else
+    printf '%s/%s' "${STATE_DIR}" "${id}"
+  fi
+}
+
+write_state() {
+  python3 - "$STATE_FILE" "$1" "$2" <<'PY'
+import json, sys, pathlib
+path, run_id, evidence = pathlib.Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+state = {}
+if path.is_file():
+    try:
+        state = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        state = {}
+state["runId"] = run_id
+state["evidenceDir"] = evidence
+path.write_text(json.dumps(state))
+PY
+}
+
+resolve_run() {
+  local id="${VERIFY_API_RUN_ID:-}"
+  if [[ -z "${id}" ]]; then
+    id="$(read_state_run_id)"
+  fi
+  if [[ -z "${id}" ]]; then
+    id="$(new_run_id)"
+  fi
+  local evidence
+  evidence="$(evidence_dir_for "${id}")"
+  mkdir -p "${evidence}"
+  write_state "${id}" "${evidence}"
+  printf '%s %s' "${id}" "${evidence}"
+}
+
+dev_url() {
+  python3 - "$STATE_FILE" <<'PY'
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+if not p.is_file():
+    print("")
+    raise SystemExit(0)
+try:
+    state = json.loads(p.read_text())
+except json.JSONDecodeError:
+    print("")
+    raise SystemExit(0)
+port = state.get("devPort") or 8787
+print(f"http://127.0.0.1:{port}")
+PY
+}
+
+cmd_deploy_plan() {
+  ensure_root
+  local pair id evidence
+  pair="$(resolve_run)"
+  id="${pair%% *}"
+  evidence="${pair#* }"
+  local out="${evidence}/plan.json"
+  set +e
+  (
+    cd "${ROOT}"
+    pnpm --filter api deploy:plan
+  ) >"${out}.raw" 2>"${evidence}/plan.err"
+  local status=$?
+  set -e
+  python3 - "$out" "${out}.raw" "$status" "$id" "$evidence" <<'PY'
+import json, sys, pathlib, re
+out, raw_path, status, run_id, evidence = sys.argv[1:6]
+raw = pathlib.Path(raw_path).read_text(encoding="utf-8", errors="replace")
+plan = None
+for match in re.finditer(r"\{.*\}", raw, re.S):
+    try:
+        plan = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        continue
+ok = int(status) == 0 and isinstance(plan, dict) and plan.get("ok") is True
+report = {
+    "ok": ok,
+    "exitCode": int(status),
+    "plan": plan,
+    "stripD1": None if not plan else plan.get("stripD1"),
+    "productionHasD1": None if not plan else plan.get("productionHasD1"),
+    "applyMigrations": None if not plan else plan.get("applyMigrations"),
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "planPath": out,
+}
+pathlib.Path(out).write_text(json.dumps(report, indent=2) + "\n")
+print(json.dumps(report))
+raise SystemExit(0 if ok else 1)
+PY
+}
+
+cmd_doctor() {
+  ensure_root
+  local pair id evidence
+  pair="$(resolve_run)"
+  id="${pair%% *}"
+  evidence="${pair#* }"
+  local doctor_partial="${evidence}/doctor.partial.json"
+  python3 - "$ROOT" "$id" "$evidence" <<'PY' >"${doctor_partial}"
+import json, pathlib, re, sys
+root = pathlib.Path(sys.argv[1])
+run_id, evidence = sys.argv[2:4]
+toml = (root / "apps/api/wrangler.toml").read_text(encoding="utf-8")
+pkg = json.loads((root / "apps/api/package.json").read_text())
+deploy = pkg.get("scripts", {}).get("deploy", "")
+base = {
+    "nameDuyetApi": bool(re.search(r'(?m)^name\s*=\s*"duyet-api"\s*$', toml)),
+    "deployUsesHelper": "tsx scripts/deploy.ts" in deploy,
+    "helperExists": (root / "apps/api/src/lib/d1-deploy-plan.ts").is_file(),
+    "planScriptExists": (root / "apps/api/scripts/plan-production-deploy.ts").is_file(),
+    "deployScriptExists": (root / "apps/api/scripts/deploy.ts").is_file(),
+    "runId": run_id,
+    "evidenceDir": evidence,
+}
+print(json.dumps(base))
+PY
+  set +e
+  cmd_deploy_plan >"${evidence}/doctor-plan.json"
+  local plan_st=$?
+  set -e
+  python3 - "${doctor_partial}" "${evidence}/doctor-plan.json" "$plan_st" "${evidence}" <<'PY'
+import json, sys, pathlib
+base = json.loads(pathlib.Path(sys.argv[1]).read_text())
+plan_wrap = json.loads(pathlib.Path(sys.argv[2]).read_text())
+plan_st = int(sys.argv[3])
+evidence = sys.argv[4]
+plan = plan_wrap.get("plan") or {}
+safe = (
+    plan_st == 0
+    and plan.get("ok") is True
+    and (
+        (plan.get("stripD1") is True and plan.get("productionHasD1") is False)
+        or (plan.get("stripD1") is False and plan.get("applyMigrations") is True)
+    )
+)
+ok = (
+    base["nameDuyetApi"]
+    and base["deployUsesHelper"]
+    and base["helperExists"]
+    and base["planScriptExists"]
+    and base["deployScriptExists"]
+    and safe
+)
+out = {
+    **base,
+    "ok": ok,
+    "productionD1Safe": safe,
+    "plan": plan,
+}
+pathlib.Path(evidence, "doctor.json").write_text(json.dumps(out, indent=2) + "\n")
+print(json.dumps(out))
+raise SystemExit(0 if ok else 1)
+PY
+}
+
+http_get() {
+  local url="$1"
+  local dest="$2"
+  python3 - "$url" "$dest" <<'PY'
+import json, sys, urllib.request, urllib.error, pathlib
+url, dest = sys.argv[1:3]
+req = urllib.request.Request(url, method="GET")
+try:
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        body = resp.read()
+        status = resp.status
+        headers = {k.lower(): v for k, v in resp.headers.items()}
+except urllib.error.HTTPError as e:
+    body = e.read()
+    status = e.code
+    headers = {k.lower(): v for k, v in e.headers.items()}
+except Exception as e:
+    pathlib.Path(dest).write_text(json.dumps({"ok": False, "error": str(e), "url": url}) + "\n")
+    print(json.dumps({"ok": False, "error": str(e), "url": url, "status": 0}))
+    raise SystemExit(1)
+text = body.decode("utf-8", errors="replace")
+pathlib.Path(dest).write_text(text)
+parsed = None
+try:
+    parsed = json.loads(text)
+except json.JSONDecodeError:
+    parsed = None
+print(json.dumps({
+    "ok": 200 <= status < 300,
+    "status": status,
+    "url": url,
+    "cfCacheStatus": headers.get("cf-cache-status"),
+    "body": parsed if parsed is not None else text[:500],
+    "bodyPath": dest,
+}))
+PY
+}
+
+http_post_json() {
+  local url="$1"
+  local payload="$2"
+  local dest="$3"
+  python3 - "$url" "$payload" "$dest" <<'PY'
+import json, sys, urllib.request, urllib.error, pathlib
+url, payload, dest = sys.argv[1:4]
+data = payload.encode("utf-8")
+req = urllib.request.Request(
+    url,
+    data=data,
+    method="POST",
+    headers={"Content-Type": "application/json"},
+)
+try:
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        body = resp.read()
+        status = resp.status
+except urllib.error.HTTPError as e:
+    body = e.read()
+    status = e.code
+except Exception as e:
+    pathlib.Path(dest).write_text(json.dumps({"ok": False, "error": str(e)}) + "\n")
+    print(json.dumps({"ok": False, "error": str(e), "status": 0, "url": url}))
+    raise SystemExit(1)
+text = body.decode("utf-8", errors="replace")
+pathlib.Path(dest).write_text(text)
+parsed = None
+try:
+    parsed = json.loads(text)
+except json.JSONDecodeError:
+    parsed = None
+print(json.dumps({
+    "status": status,
+    "url": url,
+    "body": parsed if parsed is not None else text[:500],
+    "bodyPath": dest,
+}))
+PY
+}
+
+cmd_drive() {
+  ensure_root
+  local feature="${1:-}"
+  [[ -n "${feature}" ]] || die "drive requires a feature id"
+  local pair id evidence
+  pair="$(resolve_run)"
+  id="${pair%% *}"
+  evidence="${pair#* }"
+
+  case "${feature}" in
+    production-d1)
+      cmd_deploy_plan
+      ;;
+    health|openapi|submissions-contact)
+      local dest="${evidence}/drive-${feature}.json"
+      set +e
+      (
+        cd "${ROOT}"
+        pnpm exec tsx "${DRIVE_HTTP}" "${feature}"
+      ) >"${dest}" 2>"${evidence}/drive-${feature}.err"
+      local st=$?
+      set -e
+      python3 - "$dest" "$evidence" "$id" "$feature" "$st" <<'PY'
+import json, sys, pathlib, re
+dest, evidence, run_id, feature, st = sys.argv[1:6]
+raw = pathlib.Path(dest).read_text(encoding="utf-8", errors="replace")
+report = None
+for match in re.finditer(r"\{.*\}", raw, re.S):
+    try:
+        candidate = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        continue
+    if isinstance(candidate, dict) and "feature" in candidate:
+        report = candidate
+if report is None:
+    err = pathlib.Path(evidence, f"drive-{feature}.err").read_text(encoding="utf-8", errors="replace")
+    print(json.dumps({"ok": False, "error": "drive-http did not print JSON", "stderr": err[-2000:], "stdout": raw[-2000:]}))
+    raise SystemExit(1)
+report["runId"] = run_id
+report["evidenceDir"] = evidence
+report["exitCode"] = int(st)
+pathlib.Path(evidence, "report.json").write_text(json.dumps(report, indent=2) + "\n")
+print(json.dumps(report))
+raise SystemExit(0 if report.get("ok") and int(st) == 0 else 1)
+PY
+      ;;
+    live-worker)
+      local health_meta root_meta contact
+      health_meta="$(http_get "https://api.duyet.net/health" "${evidence}/live-health.json")"
+      root_meta="$(http_get "https://api.duyet.net/" "${evidence}/live-root.json")"
+      contact="$(http_post_json "https://api.duyet.net/api/contact" '{"name":"Ada","email":"ada@example.test","message":"hello"}' "${evidence}/live-contact.json")"
+      python3 - "$health_meta" "$root_meta" "$contact" "$evidence" "$id" <<'PY'
+import json, sys, pathlib
+health, root, contact, evidence, run_id = (
+    json.loads(sys.argv[1]),
+    json.loads(sys.argv[2]),
+    json.loads(sys.argv[3]),
+    sys.argv[4],
+    sys.argv[5],
+)
+rbody = root.get("body") or {}
+endpoints = rbody.get("endpoints") if isinstance(rbody, dict) else {}
+lists = isinstance(endpoints, dict) and "contact" in endpoints
+cstat = contact.get("status")
+ok = health.get("status") == 200 and lists and cstat != 404
+report = {
+    "ok": ok,
+    "feature": "live-worker",
+    "healthStatus": health.get("status"),
+    "rootStatus": root.get("status"),
+    "listsContact": lists,
+    "contactStatus": cstat,
+    "cfCacheStatus": root.get("cfCacheStatus"),
+    "runId": run_id,
+    "evidenceDir": evidence,
+}
+pathlib.Path(evidence, "report.json").write_text(json.dumps(report, indent=2) + "\n")
+print(json.dumps(report))
+raise SystemExit(0 if ok else 1)
+PY
+      ;;
+    *)
+      die "unknown feature: ${feature}"
+      ;;
+  esac
+}
+
+cmd_prove() {
+  local feature="production-d1"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --feature)
+        feature="${2:-}"
+        shift 2
+        ;;
+      *)
+        die "unknown prove arg: $1"
+        ;;
+    esac
+  done
+  [[ -n "${feature}" ]] || die "--feature requires an id"
+
+  local id evidence
+  id="$(new_run_id)"
+  export VERIFY_API_RUN_ID="${id}"
+  evidence="$(evidence_dir_for "${id}")"
+  export VERIFY_API_EVIDENCE="${evidence}"
+  mkdir -p "${evidence}"
+  write_state "${id}" "${evidence}"
+
+  set +e
+  cmd_doctor >"${evidence}/prove-doctor.json"
+  local doctor_st=$?
+  set -e
+  if [[ ${doctor_st} -ne 0 ]]; then
+    python3 - "$evidence" "$id" "$feature" <<'PY'
+import json, sys, pathlib
+evidence, run_id, feature = sys.argv[1:4]
+out = {
+    "ok": False,
+    "stage": "doctor",
+    "feature": feature,
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "prove-doctor.json").read_text()),
+}
+print(json.dumps(out))
+raise SystemExit(1)
+PY
+  fi
+
+  set +e
+  cmd_drive "${feature}" >"${evidence}/prove-drive.json"
+  local drive_st=$?
+  set -e
+  python3 - "$evidence" "$id" "$feature" "$drive_st" <<'PY'
+import json, sys, pathlib
+evidence, run_id, feature, drive_st = sys.argv[1:5]
+out = {
+    "ok": int(drive_st) == 0,
+    "feature": feature,
+    "runId": run_id,
+    "evidenceDir": evidence,
+    "doctor": json.loads(pathlib.Path(evidence, "prove-doctor.json").read_text()),
+    "drive": json.loads(pathlib.Path(evidence, "prove-drive.json").read_text()),
+}
+print(json.dumps(out))
+raise SystemExit(0 if out["ok"] else 1)
+PY
+}
+
+cmd_dev_start() {
+  ensure_root
+  local port="${VERIFY_API_DEV_PORT:-8787}"
+  if curl -sf -o /dev/null "http://127.0.0.1:${port}/health"; then
+    python3 - "$STATE_FILE" <<'PY'
+import json, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+state = {}
+if path.is_file():
+    try:
+        state = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        state = {}
+if state.get("devPid"):
+    print(json.dumps({"ok": True, "reused": True, "url": f"http://127.0.0.1:{state.get('devPort', 8787)}/health", "devPid": state.get("devPid")}))
+    raise SystemExit(0)
+print(json.dumps({"ok": False, "error": "port 8787 already in use by a process this lever did not start"}))
+raise SystemExit(1)
+PY
+  fi
+  local pair id evidence
+  pair="$(resolve_run)"
+  id="${pair%% *}"
+  evidence="${pair#* }"
+  local log="${evidence}/dev.log"
+  (
+    cd "${ROOT}/apps/api"
+    pnpm run dev
+  ) >"${log}" 2>&1 &
+  local pid=$!
+  python3 - "$STATE_FILE" "$pid" "$port" "$log" "$id" "$evidence" <<'PY'
+import json, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+state = {}
+if path.is_file():
+    try:
+        state = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        state = {}
+state["devPid"] = int(sys.argv[2])
+state["devPort"] = int(sys.argv[3])
+state["devLog"] = sys.argv[4]
+state["runId"] = sys.argv[5]
+state["evidenceDir"] = sys.argv[6]
+path.write_text(json.dumps(state))
+PY
+  local i=0
+  while [[ ${i} -lt 80 ]]; do
+    if curl -sf -o /dev/null "http://127.0.0.1:${port}/health"; then
+      python3 -c 'import json,sys; print(json.dumps({"ok": True, "devPid": int(sys.argv[1]), "url": sys.argv[2], "health": sys.argv[3], "log": sys.argv[4], "runId": sys.argv[5], "evidenceDir": sys.argv[6]}))' \
+        "${pid}" "http://127.0.0.1:${port}" "http://127.0.0.1:${port}/health" "${log}" "${id}" "${evidence}"
+      return 0
+    fi
+    if ! kill -0 "${pid}" 2>/dev/null; then
+      die "wrangler dev exited; see ${log}"
+    fi
+    sleep 0.25
+    i=$((i + 1))
+  done
+  die "wrangler dev did not become ready on port ${port}; see ${log}"
+}
+
+cmd_dev_stop() {
+  python3 - "$STATE_FILE" <<'PY'
+import json, os, sys, signal, pathlib
+path = pathlib.Path(sys.argv[1])
+if not path.is_file():
+    print(json.dumps({"ok": True, "stopped": False, "reason": "no state file"}))
+    raise SystemExit(0)
+try:
+    state = json.loads(path.read_text())
+except json.JSONDecodeError:
+    print(json.dumps({"ok": True, "stopped": False, "reason": "empty state"}))
+    raise SystemExit(0)
+pid = state.get("devPid")
+if not pid:
+    print(json.dumps({"ok": True, "stopped": False, "reason": "no devPid"}))
+    raise SystemExit(0)
+try:
+    os.kill(int(pid), signal.SIGTERM)
+    stopped, reason = True, "sigterm"
+except ProcessLookupError:
+    stopped, reason = False, "not running"
+state.pop("devPid", None)
+path.write_text(json.dumps(state))
+print(json.dumps({"ok": True, "stopped": stopped, "pid": pid, "reason": reason}))
+PY
+}
+
+case "${CMD}" in
+  doctor) cmd_doctor ;;
+  deploy-plan) cmd_deploy_plan ;;
+  drive) cmd_drive "${1:-}" ;;
+  prove) cmd_prove "$@" ;;
+  dev-start) cmd_dev_start ;;
+  dev-stop) cmd_dev_stop ;;
+  cleanup) cmd_dev_stop ;;
+  -h|--help|help|"") usage ;;
+  *) die "unknown command: ${CMD}" ;;
+esac

--- a/.cursor/skills/verify-api/features/README.md
+++ b/.cursor/skills/verify-api/features/README.md
@@ -1,0 +1,46 @@
+# duyet-api verification map
+
+This directory is the maintained source for verifying user-facing behavior of `apps/api` (`https://api.duyet.net`). Read the index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Work from the monorepo root with pnpm 10.
+- Put `.cursor/skills/verify-api/bin` on `PATH` or invoke the binary by repo-relative path.
+- Run `verify-api doctor` and require `deployUsesHelper: true` and `productionD1Safe: true`.
+- For HTTP features, run `verify-api drive health` (Hono `app.request`). `dev-start` is optional `wrangler dev` and can spin a reload loop in this environment.
+- `production-d1` and `live-worker` do not use the local server.
+
+## Driving conventions
+
+- Start every local HTTP recipe from a healthy `dev-start` unless the feature is config-only.
+- Treat paths as literal (`/health`, `/openapi.json`, `/api/contact`).
+- Run HTTP through `verify-api drive`.
+- Cleanup stops only the wrangler PID in `/tmp/verify-api/state.json`. Do not remove proof artifacts.
+
+## Proof and skip reporting
+
+- Capture the request (method, path, status) and the response body, not only that the port is open.
+- Config proof includes `deploy:plan` JSON (`stripD1`, `productionHasD1`, `applyMigrations`).
+- Live proof includes `cf-cache-status` and whether `GET /` lists `contact`.
+- Record the feature ID and entry point used with every artifact.
+- Report an unreachable path with the attempted command and the unmet precondition.
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with verify-api` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable handles, required state, commands, and observable proof.
+
+## Features
+
+- [Production D1 deploy](./production-d1.md) covers CI `wrangler deploy` without nameless D1 auto-provision.
+- [Health](./health.md) covers `GET /` and `GET /health`.
+- [OpenAPI](./openapi.md) covers `GET /openapi.json` listing submission paths.
+- [Contact submission](./submissions-contact.md) covers `POST /api/contact`.
+- [Live worker](./live-worker.md) covers `https://api.duyet.net` versus the Pages OpenAPI mirror.

--- a/.cursor/skills/verify-api/features/health.md
+++ b/.cursor/skills/verify-api/features/health.md
@@ -1,0 +1,31 @@
+# Health
+
+Callers can ask whether the Worker is up. `GET /health` returns `{status:"ok"}`. `GET /` returns `{name, version, status:"healthy", endpoints}`.
+
+## Sub-features
+
+- `health-ok` answers `GET /health` with HTTP 200 and `"status":"ok"`.
+- `health-root` answers `GET /` with HTTP 200 and `"status":"healthy"`.
+- `health-submissions-listed` includes `contact`, `jd`, and `comments` in `endpoints` on a current build.
+
+## How to get to it (user POV)
+
+- Open `https://api.duyet.net/health`.
+- Open `https://api.duyet.net/`.
+- Hit the same paths on local `wrangler dev` (`http://127.0.0.1:8787`).
+
+## Driving it with verify-api
+
+Preconditions:
+
+- `verify-api doctor` reports `productionD1Safe: true`.
+
+- **Health.** Run `.cursor/skills/verify-api/bin/verify-api drive health`. `"healthStatus": 200` and `"healthOk": true`. Harness is `hono-app.request`.
+- **Root.** Same command. `"rootStatus": 200` and `"rootHealthy": true`.
+- **Endpoints.** `"listsContact": true`. A current bundle lists `contact` under `endpoints`.
+- **Proof.** `evidenceDir/health.json` and `evidenceDir/root.json` hold the bodies.
+
+## Gotchas
+
+- Live `api.duyet.net` can be CF HIT on the previous Worker. A 200 without `contact` is the old deploy, not a pass for submissions.
+- Global rate limit is 600/minute. Health checks are cheap; do not loop.

--- a/.cursor/skills/verify-api/features/live-worker.md
+++ b/.cursor/skills/verify-api/features/live-worker.md
@@ -1,0 +1,31 @@
+# Live worker
+
+`https://api.duyet.net` is the published Worker. A Pages 200 on `https://duyet.net` or `https://duyet.net/openapi.json` does not mean this origin updated.
+
+## Sub-features
+
+- `live-health` `GET https://api.duyet.net/health` is HTTP 200.
+- `live-root` `GET https://api.duyet.net/` lists current `endpoints`.
+- `live-contact` `POST /api/contact` is not 404 on a current SHA.
+- `live-vs-pages` Pages OpenAPI is not used as Worker proof.
+
+## How to get to it (user POV)
+
+- Open `https://api.duyet.net/`.
+- Compare `https://api.duyet.net/openapi.json` with `https://duyet.net/openapi.json`.
+
+## Driving it with verify-api
+
+Preconditions:
+
+- Network egress to `api.duyet.net` is allowed.
+- No local wrangler is required.
+
+- **Live.** Run `.cursor/skills/verify-api/bin/verify-api drive live-worker`. `"healthStatus": 200`.
+- **Current script.** `"listsContact": true` on `GET /`. `"contactStatus"` is not `404`.
+- **Proof.** `evidenceDir/live-root.json`. Record `cf-cache-status` when present. HIT plus a body without `contact` is the previous Worker.
+
+## Gotchas
+
+- CF cache can keep the old `GET /` body. Check `endpoints.contact`, not only HTTP 200.
+- After a failed `wrangler deploy`, Total Upload in the log does not mean the new script is live.

--- a/.cursor/skills/verify-api/features/openapi.md
+++ b/.cursor/skills/verify-api/features/openapi.md
@@ -1,0 +1,30 @@
+# OpenAPI
+
+`GET /openapi.json` is the Worker document. It lists `/api/contact`, `/api/jd`, and `/api/comments` on a current build.
+
+## Sub-features
+
+- `openapi-200` answers HTTP 200 with `openapi` and `paths`.
+- `openapi-submissions` includes the three submission paths.
+- `openapi-worker-origin` is fetched from the Worker under test, not from `duyet.net`.
+
+## How to get to it (user POV)
+
+- Open `https://api.duyet.net/openapi.json`.
+- Open `http://127.0.0.1:8787/openapi.json` under `wrangler dev`.
+- Open `https://duyet.net/openapi.json` as the Pages mirror (not Worker proof).
+
+## Driving it with verify-api
+
+Preconditions:
+
+- Workspace `node_modules` is installed.
+
+- **Fetch.** Run `.cursor/skills/verify-api/bin/verify-api drive openapi`. `"status": 200`. Harness is `hono-app.request`.
+- **Paths.** `"paths"` contains `/api/contact`, `/api/jd`, `/api/comments`.
+- **Proof.** `evidenceDir/openapi.json` is the body from the Worker URL, not `https://duyet.net/openapi.json`.
+
+## Gotchas
+
+- After #1449, Pages mirrored OpenAPI while `api.duyet.net/openapi.json` still lacked the paths. Always compare origins.
+- A 200 OpenAPI document without those three paths is the previous Worker.

--- a/.cursor/skills/verify-api/features/production-d1.md
+++ b/.cursor/skills/verify-api/features/production-d1.md
@@ -1,0 +1,34 @@
+# Production D1 deploy
+
+Production `pnpm --filter api deploy` publishes `duyet-api` without calling Cloudflare `GET /accounts/.../d1/database/duyet-api-submissions` when `wrangler.toml` has no D1 `database_id` UUID. Remote migrations run only after that UUID is committed.
+
+## Sub-features
+
+- `d1-plan` prints `deploy:plan` JSON from the committed `wrangler.toml`.
+- `d1-strip` omits `[[d1_databases]]` from the production config when `database_id` is missing or not a UUID.
+- `d1-keep` keeps the binding and sets `applyMigrations` when `database_id` is a UUID.
+- `d1-script` uses `tsx scripts/deploy.ts` as the `deploy` script, not a raw `wrangler deploy`.
+
+## How to get to it (user POV)
+
+- Push to `master` so `.github/workflows/cf-worker-deploy.yml` runs `pnpm run deploy` in `apps/api`.
+- Run `pnpm --filter api deploy` locally with `CLOUDFLARE_API_TOKEN`.
+- After creating D1 `duyet-api-submissions`, add `database_id` in `apps/api/wrangler.toml` and redeploy.
+
+## Driving it with verify-api
+
+Preconditions:
+
+- `verify-api doctor` reports `deployUsesHelper: true`.
+- Workspace dependencies are installed (`pnpm install`).
+
+- **Doctor contract.** Run `.cursor/skills/verify-api/bin/verify-api doctor`. JSON has `"deployUsesHelper": true` and `"productionD1Safe": true`.
+- **Plan.** Run `.cursor/skills/verify-api/bin/verify-api deploy-plan` (or `drive production-d1`). Exit `0`. `"ok": true`. While no UUID is committed, `"stripD1": true`, `"productionHasD1": false`, `"applyMigrations": false`, and the printed `toml` has no `[[d1_databases]]`.
+- **Proof.** `evidenceDir/plan.json` contains that object. `apps/api/package.json` `scripts.deploy` contains `tsx scripts/deploy.ts`.
+
+## Gotchas
+
+- `wrangler.toml` still lists `[[d1_databases]]` without an id for local `wrangler dev`. Proof is the *planned* production toml, not the source file.
+- `wrangler deploy --dry-run` on the *source* `wrangler.toml` still models the name lookup. Drive `deploy:plan`, not dry-run of the unstripped file.
+- Pages `https://duyet.net/openapi.json` can list `/api/contact` while this Worker deploy is still red.
+- After a UUID is committed, `"productionHasD1": true` and `"applyMigrations": true` is the passing shape. Do not expect strip forever.

--- a/.cursor/skills/verify-api/features/submissions-contact.md
+++ b/.cursor/skills/verify-api/features/submissions-contact.md
@@ -1,0 +1,33 @@
+# Contact submission
+
+`POST /api/contact` accepts `{name, email, message}` as JSON. A valid body is 202 `{id, status:"pending"}` when D1 is bound, 503 when `SUBMISSIONS_DB` is missing, and 404 on a Worker that never shipped the route.
+
+## Sub-features
+
+- `contact-json` requires `Content-Type: application/json`.
+- `contact-accept` returns 202 with `status: pending` when D1 is bound.
+- `contact-unavailable` returns 503 `{error:"Service Unavailable"}` when the production deploy omitted D1.
+- `contact-honeypot` returns 202 and stores nothing when `website` is non-empty.
+
+## How to get to it (user POV)
+
+- `POST https://api.duyet.net/api/contact` with JSON.
+- `POST https://duyet.net/api/contact` through the home Pages proxy.
+- `POST http://127.0.0.1:8787/api/contact` under `wrangler dev`.
+
+## Driving it with verify-api
+
+Preconditions:
+
+- Workspace `node_modules` is installed.
+- Body is `{name, email, message}` JSON.
+
+- **Post.** Run `.cursor/skills/verify-api/bin/verify-api drive submissions-contact`. Status is `202` (D1 bound) or `503` (no binding). Never `404`. Harness is `hono-app.request`.
+- **Honeypot.** Same command posts `website: "http://spam.example"` and expects `202`.
+- **Proof.** `evidenceDir/contact.json` has the status and a body that is not `{"error":"Not Found"}`.
+
+## Gotchas
+
+- Live `api.duyet.net` returned 404 for this path while Pages OpenAPI already listed it. 404 means the Worker SHA is old, not that the parser rejected the body.
+- Rate limit is 5 per IP per 10 minutes on this route, plus the global 600/minute limiter.
+- Do not log the submitted fields. The route tests fail if a field or client IP appears on stdout.

--- a/.cursor/skills/verify-api/scripts/drive-http.ts
+++ b/.cursor/skills/verify-api/scripts/drive-http.ts
@@ -1,0 +1,134 @@
+import app from "../../../../apps/api/src/index.js";
+
+type Feature = "health" | "openapi" | "submissions-contact";
+
+async function readJson(res: Response): Promise<unknown> {
+  return res.json();
+}
+
+async function driveHealth(): Promise<object> {
+  const health = await app.request("/health");
+  const root = await app.request("/");
+  const healthBody = (await readJson(health)) as { status?: string };
+  const rootBody = (await readJson(root)) as {
+    status?: string;
+    endpoints?: Record<string, string>;
+  };
+  const listsContact = Boolean(rootBody.endpoints?.contact);
+  const ok =
+    health.status === 200 &&
+    healthBody.status === "ok" &&
+    root.status === 200 &&
+    rootBody.status === "healthy" &&
+    listsContact;
+  return {
+    ok,
+    feature: "health",
+    healthStatus: health.status,
+    healthOk: healthBody.status === "ok",
+    rootStatus: root.status,
+    rootHealthy: rootBody.status === "healthy",
+    listsContact,
+    harness: "hono-app.request",
+  };
+}
+
+async function driveOpenapi(): Promise<object> {
+  const res = await app.request("/openapi.json");
+  const body = (await readJson(res)) as { paths?: Record<string, unknown> };
+  const paths = body.paths ?? {};
+  const present = {
+    "/api/contact": "/api/contact" in paths,
+    "/api/jd": "/api/jd" in paths,
+    "/api/comments": "/api/comments" in paths,
+  };
+  const ok = res.status === 200 && Object.values(present).every(Boolean);
+  return {
+    ok,
+    feature: "openapi",
+    status: res.status,
+    paths: present,
+    harness: "hono-app.request",
+  };
+}
+
+async function driveContact(): Promise<object> {
+  const headers = { "Content-Type": "application/json" };
+  const env = {};
+  const contact = await app.request(
+    "/api/contact",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        name: "Ada",
+        email: "ada@example.test",
+        message: "hello",
+      }),
+    },
+    env
+  );
+  const honeypot = await app.request(
+    "/api/contact",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        name: "Ada",
+        email: "ada@example.test",
+        message: "hello",
+        website: "http://spam.example",
+      }),
+    },
+    env
+  );
+  const contactBody = (await readJson(contact)) as { error?: string };
+  const notFound =
+    contact.status === 404 || contactBody.error === "Not Found";
+  const ok =
+    (contact.status === 202 || contact.status === 503) &&
+    honeypot.status === 202 &&
+    !notFound;
+  return {
+    ok,
+    feature: "submissions-contact",
+    contactStatus: contact.status,
+    honeypotStatus: honeypot.status,
+    notFound,
+    harness: "hono-app.request",
+  };
+}
+
+function isFeature(id: string): id is Feature {
+  return id === "health" || id === "openapi" || id === "submissions-contact";
+}
+
+async function drive(id: Feature): Promise<object> {
+  switch (id) {
+    case "health":
+      return driveHealth();
+    case "openapi":
+      return driveOpenapi();
+    case "submissions-contact":
+      return driveContact();
+    default: {
+      const _exhaustive: never = id;
+      throw new Error(`unhandled feature: ${_exhaustive}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const feature = process.argv[2] ?? "";
+  if (!isFeature(feature)) {
+    process.stderr.write(
+      "usage: tsx drive-http.ts health|openapi|submissions-contact\n"
+    );
+    process.exit(2);
+  }
+  const report = await drive(feature);
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+  process.exit((report as { ok?: boolean }).ok ? 0 : 1);
+}
+
+void main();

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # Build output
 dist
 .wrangler
+.wrangler-deploy.toml
 
 # Environment variables
 .env

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -83,6 +83,17 @@ npx wrangler secret put OPENROUTER_API_KEY
 pnpm run deploy
 ```
 
+`pnpm run deploy` runs `scripts/deploy.ts`. That helper omits `[[d1_databases]]` from the production Wrangler config when `database_id` is not a UUID. Wrangler 4.45+ otherwise looks up `/d1/database/duyet-api-submissions` and auto-provisions; the GitHub Actions token returns authentication error 10000 on that route.
+
+To bind production D1 and apply migrations:
+
+1. In the same Cloudflare account as `duyet-api` (Duyet Personal), create D1 database `duyet-api-submissions` (`npx wrangler d1 create duyet-api-submissions`, or the dashboard). The Actions token needs D1 Edit for create and for `wrangler d1 migrations apply`.
+2. Copy the printed `database_id` UUID into `apps/api/wrangler.toml` under `[[d1_databases]]`. Do not invent a UUID.
+3. Confirm Email Routing allows `me@duyet.net` as a destination for `[[send_email]]`.
+4. Redeploy. `scripts/deploy.ts` then keeps the binding and runs `wrangler d1 migrations apply SUBMISSIONS_DB --remote`.
+
+Until step 2, production `POST /api/contact`, `/api/jd`, and `/api/comments` return 503 (`SUBMISSIONS_DB` missing). Local `pnpm run dev` still uses `database_name` for a local D1.
+
 ## Project Structure
 
 ```

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "config": "tsx ../../scripts/sync-app-secrets.ts duyet-api",
     "dev": "pnpm dlx wrangler dev src/index.ts --port 8787",
-    "deploy": "pnpm run build && pnpm dlx wrangler deploy && pnpm dlx wrangler d1 migrations apply SUBMISSIONS_DB --remote",
+    "deploy": "pnpm run build && tsx scripts/deploy.ts",
+    "deploy:plan": "tsx scripts/plan-production-deploy.ts",
     "build": "esbuild src/index.ts --bundle --outdir=dist --platform=browser --format=esm",
     "openapi:mirror": "tsx scripts/openapi-mirror.ts",
     "start": "node dist/index.js",

--- a/apps/api/scripts/deploy.ts
+++ b/apps/api/scripts/deploy.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { planProductionDeploy } from "../src/lib/d1-deploy-plan.js";
+
+const root = resolve(import.meta.dirname, "..");
+const srcPath = resolve(root, "wrangler.toml");
+const tmpPath = resolve(root, ".wrangler-deploy.toml");
+const src = readFileSync(srcPath, "utf8");
+const plan = planProductionDeploy(src);
+const usesTmp = plan.toml !== src;
+
+if (usesTmp) {
+  writeFileSync(tmpPath, plan.toml);
+}
+
+const wrangler = (args: string[]) =>
+  spawnSync("pnpm", ["dlx", "wrangler", ...args], {
+    cwd: root,
+    stdio: "inherit",
+  });
+
+try {
+  const deploy = wrangler(
+    usesTmp ? ["deploy", "--config", tmpPath] : ["deploy"]
+  );
+  if (deploy.status !== 0) {
+    process.exit(deploy.status ?? 1);
+  }
+  if (plan.applyMigrations) {
+    const migrations = wrangler([
+      "d1",
+      "migrations",
+      "apply",
+      "SUBMISSIONS_DB",
+      "--remote",
+    ]);
+    if (migrations.status !== 0) {
+      process.exit(migrations.status ?? 1);
+    }
+  } else {
+    console.info(plan.reason);
+  }
+} finally {
+  if (usesTmp && existsSync(tmpPath)) {
+    unlinkSync(tmpPath);
+  }
+}

--- a/apps/api/scripts/plan-production-deploy.ts
+++ b/apps/api/scripts/plan-production-deploy.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { planProductionDeploy } from "../src/lib/d1-deploy-plan.js";
+
+const src = readFileSync(resolve(import.meta.dirname, "../wrangler.toml"), "utf8");
+const plan = planProductionDeploy(src);
+const productionHasD1 = /^\s*\[\[d1_databases\]\]/m.test(plan.toml);
+const ok =
+  (!productionHasD1 && !plan.applyMigrations) ||
+  (productionHasD1 && !plan.stripD1 && plan.applyMigrations);
+
+process.stdout.write(
+  `${JSON.stringify({ ...plan, productionHasD1, ok }, null, 2)}\n`
+);
+process.exit(ok ? 0 : 1);

--- a/apps/api/src/lib/d1-deploy-plan.test.ts
+++ b/apps/api/src/lib/d1-deploy-plan.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  isD1DatabaseId,
+  planProductionDeploy,
+  SKIP_D1_REASON,
+} from "./d1-deploy-plan.js";
+
+const FIXTURE_UUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+const NAMELESS_D1 = `name = "duyet-api"
+main = "dist/index.js"
+
+[[d1_databases]]
+binding = "SUBMISSIONS_DB"
+database_name = "duyet-api-submissions"
+migrations_dir = "migrations"
+
+[[send_email]]
+name = "NOTIFY_EMAIL"
+destination_address = "me@duyet.net"
+`;
+
+describe("isD1DatabaseId", () => {
+  it("accepts a D1 UUID", () => {
+    expect(isD1DatabaseId(FIXTURE_UUID)).toBe(true);
+  });
+
+  it("rejects placeholders and empty values", () => {
+    expect(isD1DatabaseId("")).toBe(false);
+    expect(isD1DatabaseId("duyet-api-submissions")).toBe(false);
+    expect(isD1DatabaseId("<unique-ID-for-your-database>")).toBe(false);
+  });
+});
+
+describe("planProductionDeploy", () => {
+  it("omits nameless D1 so wrangler deploy does not hit /d1/database/<name>", () => {
+    const plan = planProductionDeploy(NAMELESS_D1);
+    expect(plan.stripD1).toBe(true);
+    expect(plan.applyMigrations).toBe(false);
+    expect(plan.reason).toBe(SKIP_D1_REASON);
+    expect(plan.toml).not.toMatch(/\[\[d1_databases\]\]/);
+    expect(plan.toml).not.toContain("duyet-api-submissions");
+    expect(plan.toml).toContain('name = "duyet-api"');
+    expect(plan.toml).toContain("[[send_email]]");
+    expect(plan.toml).toContain('destination_address = "me@duyet.net"');
+  });
+
+  it("keeps a UUID D1 binding and applies remote migrations", () => {
+    const source = `name = "duyet-api"
+
+[[d1_databases]]
+binding = "SUBMISSIONS_DB"
+database_name = "duyet-api-submissions"
+database_id = "${FIXTURE_UUID}"
+migrations_dir = "migrations"
+`;
+    const plan = planProductionDeploy(source);
+    expect(plan.stripD1).toBe(false);
+    expect(plan.applyMigrations).toBe(true);
+    expect(plan.toml).toContain("[[d1_databases]]");
+    expect(plan.toml).toContain(`database_id = "${FIXTURE_UUID}"`);
+  });
+
+  it("strips a placeholder database_id the same as a missing one", () => {
+    const source = `name = "duyet-api"
+
+[[d1_databases]]
+binding = "SUBMISSIONS_DB"
+database_name = "duyet-api-submissions"
+database_id = "REPLACE_ME"
+`;
+    const plan = planProductionDeploy(source);
+    expect(plan.stripD1).toBe(true);
+    expect(plan.applyMigrations).toBe(false);
+    expect(plan.toml).not.toMatch(/\[\[d1_databases\]\]/);
+  });
+
+  it("never leaves nameless D1 in the production plan for committed wrangler.toml", () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, "../../wrangler.toml"),
+      "utf8"
+    );
+    const plan = planProductionDeploy(source);
+    if (plan.applyMigrations) {
+      expect(plan.stripD1).toBe(false);
+      expect(plan.toml).toMatch(/database_id = "[0-9a-f-]{36}"/i);
+    } else {
+      expect(source).toContain("[[d1_databases]]");
+      expect(plan.stripD1).toBe(true);
+      expect(plan.toml).not.toMatch(/\[\[d1_databases\]\]/);
+    }
+    expect(plan.toml).toContain('name = "duyet-api"');
+    expect(plan.toml).toContain("[[send_email]]");
+  });
+});

--- a/apps/api/src/lib/d1-deploy-plan.ts
+++ b/apps/api/src/lib/d1-deploy-plan.ts
@@ -1,0 +1,92 @@
+const D1_DATABASE_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const SKIP_D1_REASON =
+  "skip D1 bind and remote migrations: wrangler.toml has no database_id UUID";
+
+export interface ProductionDeployPlan {
+  toml: string;
+  stripD1: boolean;
+  applyMigrations: boolean;
+  reason: string;
+}
+
+interface TomlSection {
+  header: string | null;
+  raw: string;
+}
+
+export function isD1DatabaseId(value: string): boolean {
+  return D1_DATABASE_ID.test(value.trim());
+}
+
+function quotedValue(body: string, key: string): string | undefined {
+  const match = body.match(
+    new RegExp(`^\\s*${key}\\s*=\\s*"([^"]*)"\\s*$`, "m")
+  );
+  return match?.[1];
+}
+
+function parseTomlSections(toml: string): TomlSection[] {
+  const lines = toml.split("\n");
+  const sections: TomlSection[] = [];
+  let header: string | null = null;
+  let buf: string[] = [];
+
+  const flush = () => {
+    if (header === null && buf.length === 0) {
+      return;
+    }
+    sections.push({ header, raw: buf.join("\n") });
+    buf = [];
+  };
+
+  for (const line of lines) {
+    if (/^\s*\[/.test(line)) {
+      flush();
+      header = line.trim();
+      buf = [line];
+      continue;
+    }
+    buf.push(line);
+  }
+  flush();
+  return sections;
+}
+
+function joinSections(sections: TomlSection[]): string {
+  const joined = sections
+    .map((section) => section.raw.replace(/\n+$/u, ""))
+    .filter((raw) => raw.length > 0)
+    .join("\n\n");
+  return `${joined.trimEnd()}\n`;
+}
+
+export function planProductionDeploy(toml: string): ProductionDeployPlan {
+  const sections = parseTomlSections(toml);
+  let stripD1 = false;
+  const kept: TomlSection[] = [];
+
+  for (const section of sections) {
+    if (section.header === "[[d1_databases]]") {
+      const id = quotedValue(section.raw, "database_id");
+      if (!id || !isD1DatabaseId(id)) {
+        stripD1 = true;
+        continue;
+      }
+    }
+    kept.push(section);
+  }
+
+  const applyMigrations = kept.some(
+    (section) => section.header === "[[d1_databases]]"
+  );
+  return {
+    toml: joinSections(kept),
+    stripD1,
+    applyMigrations,
+    reason: stripD1
+      ? SKIP_D1_REASON
+      : "bind SUBMISSIONS_DB and apply remote migrations",
+  };
+}

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -13,8 +13,6 @@ routes = [
   { pattern = "api.duyet.net/*", zone_name = "duyet.net" }
 ]
 
-# No database_id: wrangler provisions the database on first deploy and locally
-# under `wrangler dev`.
 [[d1_databases]]
 binding = "SUBMISSIONS_DB"
 database_name = "duyet-api-submissions"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -3,6 +3,7 @@
 - [`docs/ai/internal-knowledge.md`](ai/internal-knowledge.md): durable repository knowledge for AI agents (static-render rule, latest shadcn + chat primitives, deploy path, gitleaks secret scan, Clerk `@clerk/shared` 3.47 pin). Public-app UI direction lives here; [`DESIGN.md`](../DESIGN.md) is the short companion.
 - [`.cursor/skills/verify-blog/`](../.cursor/skills/verify-blog/SKILL.md): project-local blog verification skill (production build + prerendered post HTML). CLI lever: `.cursor/skills/verify-blog/bin/verify-blog`.
 - [`.cursor/skills/verify-kb/`](../.cursor/skills/verify-kb/SKILL.md): project-local kb graph motion skill (zoom keeps labels and edges; Chrome CDP + Sigma probe). CLI lever: `.cursor/skills/verify-kb/bin/verify-kb`.
+- [`.cursor/skills/verify-api/`](../.cursor/skills/verify-api/SKILL.md): project-local duyet-api skill (wrangler.dev HTTP + production D1 deploy plan). CLI lever: `.cursor/skills/verify-api/bin/verify-api`.
 - [`.gitleaks.toml`](../.gitleaks.toml): custom secret-scan rules (AnyRouter `sk-ar-v1-` prefix). CI: `.github/workflows/gitleaks.yml`.
 - [`docs/ai/cowork-instructions.md`](ai/cowork-instructions.md): guidance for Claude Cowork (desktop agent) sessions on this repo.
 - [`docs/ai/writing-style.md`](ai/writing-style.md): how to write blog posts and notes in Duyet's voice.

--- a/docs/ai/internal-knowledge.md
+++ b/docs/ai/internal-knowledge.md
@@ -116,7 +116,7 @@ herdr agent prompt feat-<short> "<full task spec>" --wait --timeout 600000
 
 - `apps/agent-ui`: `pnpm run dev` uses Vite on port 3008; local chat expects `apps/agent-api` on port 8788 unless `VITE_DUYET_AGENTS_API_URL` or `VITE_AGENT_API_URL` is set. Production chat uses the same-origin `/api/v1/chat` Pages Function proxy so browsers do not need to resolve `agents-api.duyet.net`.
 - `apps/agent-api`: `pnpm run dev` uses Wrangler on port 8788; `pnpm run deploy` type-checks then deploys the Worker; `pnpm run cf:deploy:prod` loads production env files before deploy; `pnpm run config` syncs `AGENT_API_TOKEN` plus Clerk verification secrets.
-- `apps/api`: `pnpm run dev` uses Wrangler; `pnpm run deploy` builds then deploys the Worker.
+- `apps/api`: `pnpm run dev` uses Wrangler; `pnpm run deploy` builds then runs `scripts/deploy.ts`. That helper omits `[[d1_databases]]` from the production config when `database_id` is not a UUID, so CI does not auto-provision D1 by name. After `wrangler d1 create duyet-api-submissions`, put the printed UUID in `apps/api/wrangler.toml` and the same deploy applies `SUBMISSIONS_DB` migrations remotely.
 - `apps/cv`: `pnpm run preview` validates production output locally.
 - `apps/data-sync`: use `pnpm run sync <name>`, `pnpm run sync:all`, `pnpm run migrate:*`, and `pnpm run cleanup:dry-run`.
 - `apps/kb`: `pnpm run build` runs the content prebuild and must preserve article `links` frontmatter in `public/k/*.md` for knowledge-graph and LLM consumers.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`d605d104` shipped `apps/api` with `[[d1_databases]]` and no `database_id`. Wrangler 4.45+ then calls `GET /accounts/.../d1/database/duyet-api-submissions` to auto-provision. GitHub Actions `CLOUDFLARE_API_TOKEN` returns authentication error 10000 on that route, so `pnpm run deploy` exits 1 after the script upload. Live `https://api.duyet.net` stays on the previous Worker. `POST /api/contact` is still 404. Pages `https://duyet.net/openapi.json` already lists the new paths.

## Scope

- `apps/api/src/lib/d1-deploy-plan.ts` plans production Wrangler config. A D1 block without a UUID `database_id` is omitted. A UUID block is kept and remote migrations run.
- `apps/api/scripts/deploy.ts` is the new `pnpm --filter api deploy` path. It writes `.wrangler-deploy.toml` only when the plan differs, then `wrangler deploy`. It skips `wrangler d1 migrations apply SUBMISSIONS_DB --remote` until a UUID is committed.
- `apps/api/wrangler.toml` still has nameless `[[d1_databases]]` for local `wrangler dev`. `[[send_email]]` stays.
- `.cursor/skills/verify-api/` drives health, OpenAPI, contact, live `api.duyet.net`, and the production D1 plan.

Out of scope: inventing a D1 UUID, changing the Actions token, Email Routing, release-please, kb, AnyRouter, chmonitor.

## Tradeoffs

The Worker config in git is not bit-identical to the config Wrangler publishes until `database_id` exists. That is the point. A nameless D1 in the file Wrangler reads is the 10000. A `[env.dev]` split would be a second Worker name and more Wrangler surface. `apps/news` already deploys with a UUID D1 binding on this token, so the durable fix after this PR is create-then-id, same as news.

## Blast Radius

Master Worker CI is red on every `apps/api` push until this lands. Existing GET routes on `api.duyet.net` keep serving the old script until a green deploy. After merge, submissions return 503 (`SUBMISSIONS_DB` missing) until D1 exists. Email notify still depends on `[[send_email]]` and is untested in production.

## Verification

- `pnpm --filter api test`: 8 files, 132 tests (6 new in `d1-deploy-plan.test.ts`).
- `pnpm --filter api check-types`
- `pnpm exec biome lint` on the new TypeScript files
- `.cursor/skills/verify-api/bin/verify-api prove --feature production-d1`: `stripD1: true`, `productionHasD1: false`, planned toml has no `[[d1_databases]]`
- `.cursor/skills/verify-api/bin/verify-api drive health` and `drive submissions-contact` via Hono `app.request`: health 200 with `contact` listed, contact 503, honeypot 202

Live `api.duyet.net` is still the previous Worker until this merge deploys.

## Dashboard leftovers (Duyet)

No UUID is in this PR. After merge, `duyet-api` can publish without D1. Submissions stay 503 until you:

1. In Cloudflare account **Duyet Personal** (the account `wrangler` printed in the failed job), create D1 database `duyet-api-submissions` (`npx wrangler d1 create duyet-api-submissions`, or the dashboard).
2. Give the GitHub Actions `CLOUDFLARE_API_TOKEN` **D1 Edit**. User Super Administrator does not grant that to a custom token. Create and `migrations apply` both need it.
3. Commit the printed `database_id` UUID under `[[d1_databases]]` in `apps/api/wrangler.toml`. Do not invent one.
4. Confirm Email Routing allows destination `me@duyet.net` for `[[send_email]]`. News already deploys a send_email binding. This one sets `destination_address` and has not been exercised.

Then the next `pnpm run deploy` binds `SUBMISSIONS_DB` and runs remote migrations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4805cc2e-2222-40b9-a45e-695fa1827fef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4805cc2e-2222-40b9-a45e-695fa1827fef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Make API deployments safe before a production D1 database ID is available while retaining automatic migrations once the database is configured.

Bug Fixes:
- Prevent production Wrangler deploys from attempting to auto-provision nameless D1 databases, avoiding authentication failures during API releases.

Enhancements:
- Add a production deployment planner and helper that strips unassigned D1 bindings, preserves valid UUID bindings, and applies remote migrations only when production D1 is configured.
- Add an API verification skill covering deployment plans, health, OpenAPI, contact submissions, and live Worker checks.

Documentation:
- Document the API deployment behavior, D1 setup requirements, and verification workflow.

Tests:
- Add coverage for D1 UUID validation and production deployment planning scenarios.