### PR TITLE
fix(blog): align /notes heading padding with content width

### DIFF
--- a/apps/blog/src/routes/notes.tsx
+++ b/apps/blog/src/routes/notes.tsx
@@ -23,7 +23,7 @@ function NotesPage(): ReactElement {
 
   return (
     <div className="min-h-screen bg-[var(--rd-bg)]">
-      <header className="mx-auto max-w-6xl px-6 pt-16 pb-10 md:pt-24 md:pb-12">
+      <header className="mx-auto max-w-3xl px-6 pt-16 pb-10 md:pt-24 md:pb-12">
         <p className="text-[11px] font-mono uppercase tracking-[0.18em] text-[var(--rd-text-3)]">
           Logbook
         </p>


### PR DESCRIPTION
Closes #1465

On `/notes`, the logbook heading (`LOGBOOK` / Quick Notes / description) used `max-w-6xl` while the notes list and divider used `max-w-3xl px-6`. The heading sat closer to the left edge than the date column.

This change reuses the list container width (`max-w-3xl px-6`) on the heading block only. Typography and cards are unchanged.

## Files
- `apps/blog/src/routes/notes.tsx`

## Summary by Sourcery

Bug Fixes:
- Align the `/notes` logbook heading with the notes list and divider by matching their content width and horizontal padding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Notes page header width to better align with the narrower content column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->