### PR TITLE
fix(blog): react #300 crash on series slug pages

### DIFF
--- a/apps/blog/src/routes/category.tsx
+++ b/apps/blog/src/routes/category.tsx
@@ -28,11 +28,10 @@ function Categories() {
   const hasChild = useMatches().some(
     (match) => match.routeId === "/category/$category"
   );
-  if (hasChild) return <Outlet />;
-
   const { categories } = Route.useLoaderData() as {
     categories: CategoryCount;
   };
+  if (hasChild) return <Outlet />;
 
   const sorted = Object.entries(categories).sort(
     ([, a], [, b]) => b - a

--- a/apps/blog/src/routes/series.tsx
+++ b/apps/blog/src/routes/series.tsx
@@ -47,9 +47,8 @@ function SeriesPage(): ReactElement {
   const hasChild = useMatches().some(
     (match) => match.routeId === "/series/$slug"
   );
-  if (hasChild) return <Outlet />;
-
   const { seriesList } = Route.useLoaderData() as { seriesList: Series[] };
+  if (hasChild) return <Outlet />;
 
   return (
     <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
Closes #1467

## Root cause
`SeriesPage` (`apps/blog/src/routes/series.tsx`) called `useMatches()`, then **returned `<Outlet />` for `/series/$slug` before `Route.useLoaderData()`**.

On a series slug page that parent still mounts. The early return skipped a hook, so React threw minified **#300** (rendered fewer hooks than expected) while HTTP stayed 200. Same pattern existed in `apps/blog/src/routes/category.tsx`.

`$slug.tsx` itself was fine: its `!series` return is after the only hook.

## Fix
Call `useLoaderData` unconditionally, then early-return `<Outlet />`.

## Out of scope
Does not touch #1455, #1362, #1365. Does not merge #1466.

Do not squash-merge; merge when CI is green.

## Summary by Sourcery

Bug Fixes:
- Prevent React hook-order crashes on nested series and category pages by loading route data before rendering child outlets.