### PR TITLE
fix(blog): quiet old-post warning to match prose width

### DIFF
--- a/apps/blog/src/routes/$year/$month/-old-post-warning.tsx
+++ b/apps/blog/src/routes/$year/$month/-old-post-warning.tsx
@@ -1,6 +1,5 @@
 import type { Post } from "@duyet/interfaces";
 import { cn } from "@duyet/libs/utils";
-import { AlertTriangle } from "lucide-react";
 
 export function OldPostWarning({
   post,
@@ -21,21 +20,14 @@ export function OldPostWarning({
     return null;
   }
 
-  const warningText = `This post is over ${postYear} years old. The information may be outdated.`;
-
   return (
-    <div
-      className={cn("border-l-4 border-yellow-400 bg-yellow-50 p-4", className)}
+    <p
+      className={cn(
+        "mx-auto max-w-[68ch] text-sm leading-relaxed text-muted-foreground",
+        className,
+      )}
     >
-      <div className="flex items-center">
-        <AlertTriangle
-          className="mr-3 h-5 w-5 text-yellow-400"
-          aria-hidden="true"
-        />
-        <p className="text-sm text-yellow-700">
-          <span className="font-medium">Note:</span> {warningText}
-        </p>
-      </div>
-    </div>
+      This post is over {postYear} years old. The information may be outdated.
+    </p>
   );
 }


### PR DESCRIPTION
Fixes #1479.

The old-post warning was a full-bleed yellow bar with a thick left border and a triangle icon — wider than the article prose because it sat outside the 68ch typeset grid.

This change:
- Drops the left border, yellow fill, and AlertTriangle icon
- Renders a muted `text-sm` note constrained to `max-w-[68ch]` (same measure as `.post-reader .typeset`)
- Keeps the existing age copy and 5-year threshold logic

Dark mode uses `text-muted-foreground`.

## Summary by Sourcery

Match the old-post warning presentation to the article prose width and reduce its visual emphasis.

Bug Fixes:
- Align the old-post warning with the article’s prose width for a quieter, more consistent reading experience.

Enhancements:
- Replace the full-bleed alert styling and warning icon with a muted, small-text note constrained to the 68ch prose measure while preserving the existing age message and threshold behavior.