### PR TITLE
fix(blog): register mdx prompt highlight as a factory

### DIFF
--- a/apps/blog/lib/__tests__/mdx-prompt-highlight.test.ts
+++ b/apps/blog/lib/__tests__/mdx-prompt-highlight.test.ts
@@ -1,0 +1,53 @@
+import { compile } from "@mdx-js/mdx";
+import { common } from "lowlight";
+import rehypeHighlight from "rehype-highlight";
+import { describe, expect, it } from "vitest";
+
+function promptLanguage() {
+  return {
+    name: "prompt",
+    disableAutodetect: true,
+    case_insensitive: false,
+    contains: [{ scope: "built_in", begin: /^\/[A-Za-z][\w:-]*/ }],
+  };
+}
+
+const source = `
+# Goal
+
+\`\`\`prompt
+/goal ship it
+\`\`\`
+`;
+
+describe("MDX prompt highlight registration", () => {
+  it("compiles when prompt is a highlight.js factory", async () => {
+    await expect(
+      compile(source, {
+        outputFormat: "function-body",
+        rehypePlugins: [
+          [rehypeHighlight, { detect: false, languages: { ...common, prompt: promptLanguage } }],
+        ],
+      })
+    ).resolves.toBeTruthy();
+  });
+
+  it("throws r.bind / is not a function when prompt is a bare object", async () => {
+    await expect(
+      Promise.resolve().then(() =>
+        compile(source, {
+          outputFormat: "function-body",
+          rehypePlugins: [
+            [
+              rehypeHighlight,
+              {
+                detect: false,
+                languages: { ...common, prompt: promptLanguage() },
+              },
+            ],
+          ],
+        })
+      )
+    ).rejects.toThrow(/bind is not a function/);
+  });
+});

--- a/apps/blog/src/routes/$year/$month/-content.test.ts
+++ b/apps/blog/src/routes/$year/$month/-content.test.ts
@@ -14,4 +14,9 @@ describe("post content static HTML", () => {
     expect(source).toContain("fallback={staticArticle}");
     expect(source).toContain("dangerouslySetInnerHTML");
   });
+
+  it("registers prompt as a highlight.js language factory", () => {
+    expect(source).toContain("prompt: promptLanguage");
+    expect(source).not.toContain("prompt: promptLanguage()");
+  });
 });

--- a/apps/blog/src/routes/$year/$month/-content.tsx
+++ b/apps/blog/src/routes/$year/$month/-content.tsx
@@ -29,30 +29,27 @@ const mdxCache = new Map<
 >();
 
 // Minimal hljs grammar for ```prompt blocks: highlights /slash-commands only.
-// Factory: lowlight/highlight.js register a language by calling it as
-// `(hljs) => definition`, so a bare object throws at registration
-// ("languageDefinition is not a function") and crashes every .mdx post.
-const promptLanguage = (): {
-  name: string;
-  disableAutodetect: boolean;
-  case_insensitive: boolean;
-  contains: { scope: string; begin: RegExp }[];
-} => ({
-  name: "prompt",
-  disableAutodetect: true,
-  case_insensitive: false,
-  contains: [{ scope: "built_in", begin: /^\/[A-Za-z][\w:-]*/ }],
-});
+// Register as a factory `(hljs) => definition`. Passing the returned object
+// throws `languageDefinition.bind is not a function` (minified: `r.bind is
+// not a function`) and crashes every .mdx post that uses ```prompt.
+function promptLanguage() {
+  return {
+    name: "prompt",
+    disableAutodetect: true,
+    case_insensitive: false,
+    contains: [{ scope: "built_in", begin: /^\/[A-Za-z][\w:-]*/ }],
+  };
+}
 
 let highlightLanguagesPromise:
-  | Promise<Record<string, ReturnType<typeof promptLanguage>>>
+  | Promise<Record<string, typeof promptLanguage>>
   | undefined;
 
 async function getHighlightLanguages() {
   if (!highlightLanguagesPromise) {
     highlightLanguagesPromise = import("lowlight").then(({ common }) => ({
       ...common,
-      prompt: promptLanguage(),
+      prompt: promptLanguage,
     }));
   }
   return highlightLanguagesPromise;


### PR DESCRIPTION
## Summary
Client MDX compile registered the `prompt` highlight grammar as a bare object. highlight.js expects a factory, so production threw `r.bind is not a function` and posts like https://blog.duyet.net/2026/06/goal-and-loop/ never hydrated (Mermaid stayed as raw `{ flowchart ... }`).

Pass `promptLanguage` the same way `markdownToHtml` already does.

## Test plan
- [x] `pnpm --filter blog exec vitest run lib/__tests__/mdx-prompt-highlight.test.ts src/routes/\$year/\$month/-content.test.ts`
- [ ] After deploy, open `/2026/06/goal-and-loop/` and confirm both flowcharts render and no `r.bind` console error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the home and About pages with a dark, editorial visual style, responsive layouts, updated typography, and new interactive sections.
  - Added searchable app and project directories with category filters and empty states.
  - Added project showcases, skills, capabilities, platform resources, process steps, and closing calls to action.
  - Added richer project media, including screenshots, generated artwork, and video previews.
  - Added a new marketing-style site header with navigation variants and optional calls to action.

- **Bug Fixes**
  - Fixed rendering of custom `prompt` code blocks in blog content compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->