### PR TITLE
fix(blog): restyle old-post warning with column background

### DIFF
--- a/apps/blog/src/routes/$year/$month/-content.tsx
+++ b/apps/blog/src/routes/$year/$month/-content.tsx
@@ -213,7 +213,7 @@ export default function Content({ post }: { post: ContentPost }) {
 
   return (
     <>
-      <OldPostWarning post={post} className="mb-6" year={5} />
+      <OldPostWarning post={post} year={5} />
 
       <div ref={copyRef} className="contents">
         {post.isMDX && post.mdxSource ? (

--- a/apps/blog/src/routes/$year/$month/-old-post-warning.test.tsx
+++ b/apps/blog/src/routes/$year/$month/-old-post-warning.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { OldPostWarning } from "./-old-post-warning";
+import type { Post } from "@duyet/interfaces";
+
+const post = (date: string): Post =>
+  ({
+    slug: "2013/07/hadoop-la-gi",
+    title: "Hadoop là gì",
+    date: new Date(date),
+    category: "Data",
+    category_slug: "data",
+    tags: [],
+    tags_slug: [],
+    featured: false,
+  }) as Post;
+
+describe("OldPostWarning", () => {
+  it("hides posts younger than the threshold", () => {
+    const { container } = render(
+      <OldPostWarning post={post("2026-01-01")} year={5} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("fills the 68ch text column with a muted background", () => {
+    const { container } = render(
+      <OldPostWarning post={post("2013-07-01")} year={5} />,
+    );
+    const aside = container.querySelector("aside");
+    expect(aside).not.toBeNull();
+    expect(aside?.textContent).toMatch(/This post is over \d+ years old/);
+    expect(aside?.className).toContain("w-full");
+    expect(aside?.className).toContain("max-w-[68ch]");
+    expect(aside?.className).toContain("bg-muted");
+  });
+});

--- a/apps/blog/src/routes/$year/$month/-old-post-warning.tsx
+++ b/apps/blog/src/routes/$year/$month/-old-post-warning.tsx
@@ -21,13 +21,14 @@ export function OldPostWarning({
   }
 
   return (
-    <p
+    <aside
+      role="note"
       className={cn(
-        "mx-auto max-w-[68ch] text-sm leading-relaxed text-muted-foreground",
+        "mx-auto mb-8 box-border w-full max-w-[68ch] rounded-md bg-muted px-4 py-3 text-sm leading-relaxed text-muted-foreground",
         className,
       )}
     >
       This post is over {postYear} years old. The information may be outdated.
-    </p>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary
The old-post notice is now an `aside` that fills the 68ch text column with `bg-muted` padding, matching the main article measure.

## Test plan
- [x] `pnpm --filter blog exec vitest run src/routes/\$year/\$month/-old-post-warning.test.tsx`
- [ ] After preview/prod: open a post older than 5 years and confirm the banner spans the text column

## Summary by Sourcery

Restyle the old-post warning to fill the article text column with a muted note background.

Bug Fixes:
- Restyle the old-post warning as a full-width, muted-background note within the 68ch article column.

Enhancements:
- Use semantic aside markup for the old-post warning and preserve spacing at the content level.

Tests:
- Add coverage for hiding recent posts and rendering the styled warning for posts older than the threshold.